### PR TITLE
Ignore bitbucket's automatic merge commit in PR builds

### DIFF
--- a/@commitlint/is-ignored/src/index.js
+++ b/@commitlint/is-ignored/src/index.js
@@ -17,7 +17,7 @@ const WILDCARDS = [
 		),
 	c => c.match(/^Merged (.*?)(in|into) (.*)/),
 	c => c.match(/^Merge remote-tracking branch (.*)/),
-	c => c.match(/^Automatic merge from (.*)/),
+	c => c.match(/^Automatic merge(.*)/),
 	c => c.match(/^Auto-merged (.*?) into (.*)/)
 ];
 

--- a/@commitlint/is-ignored/src/index.test.js
+++ b/@commitlint/is-ignored/src/index.test.js
@@ -107,6 +107,7 @@ test('should return true for bitbucket merge commits', t => {
 		isIgnored('Merged in feature/facebook-friends-sync (pull request #8)')
 	);
 	t.true(isIgnored('Merged develop into feature/component-form-select-card'));
+	t.true(isIgnored('Automatic merge'));
 });
 
 test('should return true for automatic merge commits', t => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I updated one of the regular expressions in `is-ignored`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On bitbucket server's PR builds a commit is created with only the message "Automatic merge". This would cause commit linting to fail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Updated the unit tests and ran locally with a commit of that message ("Automatic merge")

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
