### PR TITLE
docs: add new example section #237

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,3 +13,4 @@
   * [Configuration](reference-configuration.md)
   * [Rules](reference-rules.md)
   * [API](reference-api.md)
+  * [Examples](reference-examples.md)

--- a/docs/reference-examples.md
+++ b/docs/reference-examples.md
@@ -1,0 +1,23 @@
+# Examples
+
+These examples show common usages of how commitlint can be configured.
+
+
+## Validate for issue/ticket numbers
+
+In your `package.json` add:
+
+```js
+  commitlint: {
+    'rules': { 
+      'references-empty': [2, 'never'],
+    },
+    parserPreset: {
+      parserOpts: {
+        issuePrefixes: ['PROJ-']
+      }
+    },
+  }
+```
+
+


### PR DESCRIPTION
Adding to a general example section to the docs to provide examples to typical usecases of commitlint configs.

This is just a draft. Happy to add more exmaples for the start.