### PR TITLE
feat: config based is-ignored overrides

### DIFF
--- a/@commitlint/is-ignored/src/index.js
+++ b/@commitlint/is-ignored/src/index.js
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-const WILDCARDS = [
+export const WILDCARDS = [
 	c =>
 		c.match(
 			/^((Merge pull request)|(Merge (.*?) into (.*?)|(Merge branch (.*?)))(?:\r?\n)*$)/m
@@ -21,6 +21,32 @@ const WILDCARDS = [
 	c => c.match(/^Auto-merged (.*?) into (.*)/)
 ];
 
-export default function isIgnored(commit = '') {
-	return WILDCARDS.some(w => w(commit));
+export default function isIgnored(commit = '', opts = {}) {
+	let wildcards = [];
+	if (opts.ignoredMessages) {
+		if (opts.disableDefaultIgnoredMessages) {
+			wildcards = wildcards.concat(WILDCARDS);
+		}
+		if (!Array.isArray(opts.ignoredMessages)) {
+			throw new Error('ignoredMessages must be an Array');
+		}
+		opts.ignoredMessages.forEach(ignoreConfig => {
+			if (typeof ignoreConfig === 'function') {
+				wildcards.push(ignoreConfig);
+			} else if (ignoreConfig instanceof RegExp) {
+				wildcards.push(c => c.match(ignoreConfig));
+			} else if (typeof ignoreConfig === 'string') {
+				wildcards.push(c => c.match(new RegExp(ignoreConfig)));
+			} else {
+				throw new Error(
+					'ignoredMessage element must be a function, string or RegExp'
+				);
+			}
+		});
+	} else if (opts.disableDefaultIgnoredMessages) {
+		return false;
+	} else {
+		wildcards = WILDCARDS;
+	}
+	return wildcards.some(w => w(commit));
 }

--- a/@commitlint/is-ignored/src/index.test.js
+++ b/@commitlint/is-ignored/src/index.test.js
@@ -118,61 +118,36 @@ test('should return false for commits containing, but not starting, with merge b
 	t.false(isIgnored('foo bar Merge branch xxx'));
 });
 
-test('should return false for ignored message if disableDefaultIgnoredMessages is true', t => {
+test('should return false for ignored message if defaults is false', t => {
 	t.false(
 		isIgnored('Auto-merged develop into master', {
-			disableDefaultIgnoredMessages: true
+			defaults: false
 		})
 	);
 });
 
-test('should return false for ignored message if custom ignoredMessages and disableDefaultIgnoredMessages is true', t => {
+test('should return false for ignored message if custom ignores and defaults is false', t => {
 	t.false(
 		isIgnored('Auto-merged develop into master', {
-			disableDefaultIgnoredMessages: true,
-			ignoredMessages: []
+			defaults: false
 		})
 	);
 });
 
-test('should throw error if ignoredMessages is not an array', t => {
+test('should throw error if ignores is not an array', t => {
 	const ignoredString = 'this should be ignored';
-	t.throws(
+	t.throws(() => {
 		isIgnored(ignoredString, {
-			ignoredMessages: 'throws error'
-		})
-	);
+			ignores: 'throws error'
+		});
+	});
 });
 
-test('should return true for custom ignoredMessages as function', t => {
+test('should return true for custom ignores as function', t => {
 	const ignoredString = 'this should be ignored';
 	t.true(
 		isIgnored(ignoredString, {
-			ignoredMessages: [c => c === ignoredString]
-		})
-	);
-});
-
-test('should return true for custom ignoredMessages as RegExp', t => {
-	t.true(
-		isIgnored('Should Ignore', {
-			ignoredMessages: [/^should ignore$/i]
-		})
-	);
-});
-
-test('should return true for custom ignoredMessages as string', t => {
-	t.true(
-		isIgnored('Should Ignore', {
-			ignoredMessages: ['[sS]hould [iI]gnore']
-		})
-	);
-});
-
-test('should throw error if ignoredMessage value is not an RegExp, string or function', t => {
-	t.throws(
-		isIgnored('some commit message', {
-			ignoredMessages: [true]
+			ignores: [c => c === ignoredString]
 		})
 	);
 });

--- a/@commitlint/is-ignored/src/index.test.js
+++ b/@commitlint/is-ignored/src/index.test.js
@@ -117,3 +117,62 @@ test('should return true for automatic merge commits', t => {
 test('should return false for commits containing, but not starting, with merge branch', t => {
 	t.false(isIgnored('foo bar Merge branch xxx'));
 });
+
+test('should return false for ignored message if disableDefaultIgnoredMessages is true', t => {
+	t.false(
+		isIgnored('Auto-merged develop into master', {
+			disableDefaultIgnoredMessages: true
+		})
+	);
+});
+
+test('should return false for ignored message if custom ignoredMessages and disableDefaultIgnoredMessages is true', t => {
+	t.false(
+		isIgnored('Auto-merged develop into master', {
+			disableDefaultIgnoredMessages: true,
+			ignoredMessages: []
+		})
+	);
+});
+
+test('should throw error if ignoredMessages is not an array', t => {
+	const ignoredString = 'this should be ignored';
+	t.throws(
+		isIgnored(ignoredString, {
+			ignoredMessages: 'throws error'
+		})
+	);
+});
+
+test('should return true for custom ignoredMessages as function', t => {
+	const ignoredString = 'this should be ignored';
+	t.true(
+		isIgnored(ignoredString, {
+			ignoredMessages: [c => c === ignoredString]
+		})
+	);
+});
+
+test('should return true for custom ignoredMessages as RegExp', t => {
+	t.true(
+		isIgnored('Should Ignore', {
+			ignoredMessages: [/^should ignore$/i]
+		})
+	);
+});
+
+test('should return true for custom ignoredMessages as string', t => {
+	t.true(
+		isIgnored('Should Ignore', {
+			ignoredMessages: ['[sS]hould [iI]gnore']
+		})
+	);
+});
+
+test('should throw error if ignoredMessage value is not an RegExp, string or function', t => {
+	t.throws(
+		isIgnored('some commit message', {
+			ignoredMessages: [true]
+		})
+	);
+});

--- a/@commitlint/lint/src/index.js
+++ b/@commitlint/lint/src/index.js
@@ -15,7 +15,7 @@ const buildCommitMesage = ({header, body, footer}) => {
 
 export default async (message, rules = {}, opts = {}) => {
 	// Found a wildcard match, skip
-	if (isIgnored(message)) {
+	if (isIgnored(message, opts)) {
 		return {
 			valid: true,
 			errors: [],

--- a/@commitlint/lint/src/index.js
+++ b/@commitlint/lint/src/index.js
@@ -15,7 +15,9 @@ const buildCommitMesage = ({header, body, footer}) => {
 
 export default async (message, rules = {}, opts = {}) => {
 	// Found a wildcard match, skip
-	if (isIgnored(message, opts)) {
+	if (
+		isIgnored(message, {defaults: opts.defaultIgnores, ignores: opts.ignores})
+	) {
 		return {
 			valid: true,
 			errors: [],

--- a/@commitlint/lint/src/index.test.js
+++ b/@commitlint/lint/src/index.test.js
@@ -45,7 +45,7 @@ test('negative on ignored message, disabled ignored messages and broken rule', a
 			'type-empty': [2, 'never']
 		},
 		{
-			disableDefaultIgnoredMessages: true
+			defaultIgnores: false
 		}
 	);
 	t.false(actual.valid);
@@ -59,7 +59,7 @@ test('positive on custom ignored message and broken rule', async t => {
 			'type-empty': [2, 'never']
 		},
 		{
-			ignoredMessages: [c => c === ignoredMessage]
+			ignores: [c => c === ignoredMessage]
 		}
 	);
 	t.true(actual.valid);

--- a/@commitlint/lint/src/index.test.js
+++ b/@commitlint/lint/src/index.test.js
@@ -38,6 +38,34 @@ test('positive on ignored message and broken rule', async t => {
 	t.is(actual.input, 'Revert "some bogus commit"');
 });
 
+test('negative on ignored message, disabled ignored messages and broken rule', async t => {
+	const actual = await lint(
+		'Revert "some bogus commit"',
+		{
+			'type-empty': [2, 'never']
+		},
+		{
+			disableDefaultIgnoredMessages: true
+		}
+	);
+	t.false(actual.valid);
+});
+
+test('positive on custom ignored message and broken rule', async t => {
+	const ignoredMessage = 'some ignored custom message';
+	const actual = await lint(
+		ignoredMessage,
+		{
+			'type-empty': [2, 'never']
+		},
+		{
+			ignoredMessages: [c => c === ignoredMessage]
+		}
+	);
+	t.true(actual.valid);
+	t.is(actual.input, ignoredMessage);
+});
+
 test('positive on stub message and opts', async t => {
 	const actual = await lint(
 		'foo-bar',

--- a/@commitlint/load/src/index.js
+++ b/@commitlint/load/src/index.js
@@ -7,7 +7,15 @@ import resolveFrom from 'resolve-from';
 
 const w = (a, b) => (Array.isArray(b) ? b : undefined);
 const valid = input =>
-	pick(input, 'extends', 'rules', 'parserPreset', 'formatter');
+	pick(
+		input,
+		'extends',
+		'rules',
+		'parserPreset',
+		'formatter',
+		'ignoredMessages',
+		'disableDefaultIgnoredMessages'
+	);
 
 export default async (seed = {}, options = {cwd: process.cwd()}) => {
 	const loaded = await loadConfig(options.cwd, options.file);
@@ -17,7 +25,7 @@ export default async (seed = {}, options = {cwd: process.cwd()}) => {
 	const config = valid(merge(loaded.config, seed));
 	const opts = merge(
 		{extends: [], rules: {}, formatter: '@commitlint/format'},
-		pick(config, 'extends')
+		pick(config, 'extends', 'ignoredMessages', 'disableDefaultIgnoredMessages')
 	);
 
 	// Resolve parserPreset key

--- a/@commitlint/load/src/index.js
+++ b/@commitlint/load/src/index.js
@@ -15,8 +15,8 @@ const valid = input =>
 		'plugins',
 		'parserPreset',
 		'formatter',
-		'ignoredMessages',
-		'disableDefaultIgnoredMessages'
+		'ignores',
+		'defaultIgnores'
 	);
 
 export default async (seed = {}, options = {cwd: process.cwd()}) => {
@@ -27,13 +27,7 @@ export default async (seed = {}, options = {cwd: process.cwd()}) => {
 	const config = valid(merge(loaded.config, seed));
 	const opts = merge(
 		{extends: [], rules: {}, formatter: '@commitlint/format'},
-		pick(
-			config,
-			'extends',
-			'plugins',
-			'ignoredMessages',
-			'disableDefaultIgnoredMessages'
-		)
+		pick(config, 'extends', 'plugins', 'ignores', 'defaultIgnores')
 	);
 
 	// Resolve parserPreset key

--- a/@commitlint/load/src/index.js
+++ b/@commitlint/load/src/index.js
@@ -12,7 +12,7 @@ const valid = input =>
 		input,
 		'extends',
 		'rules',
-    'plugins',
+		'plugins',
 		'parserPreset',
 		'formatter',
 		'ignoredMessages',
@@ -27,7 +27,13 @@ export default async (seed = {}, options = {cwd: process.cwd()}) => {
 	const config = valid(merge(loaded.config, seed));
 	const opts = merge(
 		{extends: [], rules: {}, formatter: '@commitlint/format'},
-		pick(config, 'extends', 'plugins', 'ignoredMessages', 'disableDefaultIgnoredMessages')
+		pick(
+			config,
+			'extends',
+			'plugins',
+			'ignoredMessages',
+			'disableDefaultIgnoredMessages'
+		)
 	);
 
 	// Resolve parserPreset key

--- a/docs/reference-configuration.md
+++ b/docs/reference-configuration.md
@@ -26,6 +26,14 @@ type Config = {
      * Rules to check against
      */
     rules?: {[name: string]: Rule};
+    /*
+     * Custom list of Messages to Ignore, string values will be compiled as RegExp
+     */
+    ignoredMessages?: Array<string | RegExp | string => boolean>;
+    /*
+     * If this is true we will not use any of the default is-ignored rules
+     */
+    disableDefaultIgnoredMessages?: boolean;
 }
 
 const Configuration: Config = {
@@ -49,7 +57,20 @@ const Configuration: Config = {
      */
     rules: {
         'type-enum': [2, 'always', ['foo']]
-    }
+    },
+    /*
+     * These RegExp and functions are used to ignore messages that shouldn't be linted
+     */
+    ignoredMessages: [
+        '^Entire Message to Ignore$',
+        /^(ci|github):/,
+        (commit) => commit === ''
+    ],
+    /*
+     * If this is true then the default ignores like `Merge commit` are not ignored
+     * and will cause commitlint to fail
+     */
+    disableDefaultIgnoredMessages: true
 };
 
 module.exports = Configuration;


### PR DESCRIPTION
## Description
Adding in options to customise which messages can be ignored by commitlint.

## Motivation and Context
For example, using this you could cause commitlint to fail for automated commit messages like ‘Merge upstream into branch’ or similar. It would also allow users to add their own custom ignores for automated systems.
In my company I have quite a few issues with these causing weird CI errors due to us only allowing fast-forward commits and it would be nice if Husky could tell us earlier.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
