### PR TITLE
feat(resolve-extends): accept short scoped package names in extends

### DIFF
--- a/@commitlint/resolve-extends/src/index.js
+++ b/@commitlint/resolve-extends/src/index.js
@@ -72,7 +72,12 @@ function getId(raw = '', prefix = '') {
 	const first = raw.charAt(0);
 	const scoped = first === '@';
 	const relative = first === '.';
-	return scoped || relative ? raw : [prefix, raw].filter(String).join('-');
+
+	if (scoped) {
+		return raw.includes('/') ? raw : [raw, prefix].filter(String).join('/');
+	}
+
+	return relative ? raw : [prefix, raw].filter(String).join('-');
 }
 
 function resolveConfig(raw, context = {}) {

--- a/@commitlint/resolve-extends/src/index.test.js
+++ b/@commitlint/resolve-extends/src/index.test.js
@@ -96,6 +96,18 @@ test('ignores prefix for scoped extends', t => {
 	});
 });
 
+test('adds prefix as suffix for scopes only', t => {
+	const input = {extends: ['@scope']};
+
+	resolveExtends(input, {
+		prefix: 'prefix',
+		resolve: id,
+		require(id) {
+			t.is(id, '@scope/prefix');
+		}
+	});
+});
+
 test('ignores prefix for relative extends', t => {
 	const input = {extends: ['./extender']};
 

--- a/docs/concepts-shareable-config.md
+++ b/docs/concepts-shareable-config.md
@@ -20,9 +20,24 @@ The rules found in `commitlint-config-example` are merged with the rules in `com
 
 This works recursively, enabling shareable configuration to extend on an indefinite chain of other shareable configurations.
 
-## Special cases
+## Relative config
 
-Scoped npm packages are not prefixed.
+You can also load local configuration by using a relative path to the file.
+
+> This must always start with a `.` (dot).
+
+```js
+// commitlint.config.js
+module.exports = {
+  extends: ['./example'] // => ./example.js
+}
+```
+
+## Scoped packages
+
+When using scoped packages you have two options.
+
+You can provide the full path of the package like:
 
 ```js
 // commitlint.config.js
@@ -31,11 +46,15 @@ module.exports = {
 };
 ```
 
-The same is true for relative imports
+Or just the scope/owner of the package.
+
+> Just like "normal" extends listed above, this will add `<scope>/commitlint-config`.
 
 ```js
 // commitlint.config.js
 module.exports = {
-  extends: ['./example'] // => ./example.js
-}
+  extends: ['@coolcompany'] // => coolcompany/commitlint-config
+};
 ```
+
+If you don't use the exact `<scope>/commitlint-config` pattern, you have to provide the full name of the package.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a feature for question #596, and thus fixes #596. 

## Motivation and Context
This change is based on [ESLint's method of scoped config packages](https://eslint.org/docs/developer-guide/shareable-configs#npm-scoped-modules).

## Usage examples

```js
// commitlint.config.js
module.exports = {
	extends: ['@mycompany'] // @mycompany/commitlint-config
};
```

> See the documentation changes for more examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
