### PR TITLE
feat: lint references-empty when commit is the specified type

### DIFF
--- a/@commitlint/rules/src/references-empty.js
+++ b/@commitlint/rules/src/references-empty.js
@@ -1,10 +1,19 @@
 import message from '@commitlint/message';
 
-export default (parsed, when = 'never') => {
+export default (parsed, when = 'never', value = []) => {
+	const notEmptyType = value.indexOf(parsed.type) !== -1;
+	if (value.length > 0 && !notEmptyType) {
+		return [true];
+	}
 	const negated = when === 'always';
 	const notEmpty = parsed.references.length > 0;
 	return [
 		negated ? !notEmpty : notEmpty,
-		message(['references', negated ? 'must' : 'may not', 'be empty'])
+		message([
+			'references',
+			negated ? 'must' : 'may not',
+			'be empty',
+			notEmptyType ? `when type of [${value.join(', ')}]` : ''
+		])
 	];
 };

--- a/@commitlint/rules/src/references-empty.test.js
+++ b/@commitlint/rules/src/references-empty.test.js
@@ -8,8 +8,7 @@ const messages = {
 	comment: 'foo: baz\n#1 Comment',
 	reference: '#comment\nfoo: baz \nCloses #1',
 	references: '#comment\nfoo: bar \nCloses #1, #2, #3',
-	prefix: 'bar REF-1234',
-	foo: 'foo: bar'
+	prefix: 'bar REF-1234'
 };
 
 const opts = (async () => {
@@ -29,8 +28,7 @@ const parsed = {
 		parse(messages.references, undefined, (await opts).parserOpts))(),
 	prefix: parse(messages.prefix, undefined, {
 		issuePrefixes: ['REF-']
-	}),
-	foo: (async () => parse(messages.foo, undefined, (await opts).parserOpts))()
+	})
 };
 
 test('defaults to never and fails for plain', async t => {
@@ -87,14 +85,14 @@ test('succeeds for custom references with always', async t => {
 	t.is(actual, expected);
 });
 
-test('with foo type should fail for "never [foo]"', async t => {
-	const [actual] = referencesEmpty(await parsed.foo, 'never', ['foo']);
+test('plain with foo type should fail for "never [foo]"', async t => {
+	const [actual] = referencesEmpty(await parsed.plain, 'never', ['foo']);
 	const expected = false;
 	t.is(actual, expected);
 });
 
-test('with foo type should succeed for "never [bar]"', async t => {
-	const [actual] = referencesEmpty(await parsed.foo, 'never', ['bar']);
+test('plain with foo type should succeed for "never [bar]"', async t => {
+	const [actual] = referencesEmpty(await parsed.plain, 'never', ['bar']);
 	const expected = true;
 	t.is(actual, expected);
 });

--- a/@commitlint/rules/src/references-empty.test.js
+++ b/@commitlint/rules/src/references-empty.test.js
@@ -8,7 +8,8 @@ const messages = {
 	comment: 'foo: baz\n#1 Comment',
 	reference: '#comment\nfoo: baz \nCloses #1',
 	references: '#comment\nfoo: bar \nCloses #1, #2, #3',
-	prefix: 'bar REF-1234'
+	prefix: 'bar REF-1234',
+	foo: 'foo: bar'
 };
 
 const opts = (async () => {
@@ -28,7 +29,8 @@ const parsed = {
 		parse(messages.references, undefined, (await opts).parserOpts))(),
 	prefix: parse(messages.prefix, undefined, {
 		issuePrefixes: ['REF-']
-	})
+	}),
+	foo: (async () => parse(messages.foo, undefined, (await opts).parserOpts))()
 };
 
 test('defaults to never and fails for plain', async t => {
@@ -81,6 +83,18 @@ test('fails for references with always', async t => {
 
 test('succeeds for custom references with always', async t => {
 	const [actual] = referencesEmpty(await parsed.prefix, 'never');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with foo type should fail for "never [foo]"', async t => {
+	const [actual] = referencesEmpty(await parsed.foo, 'never', ['foo']);
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('with foo type should succeed for "never [bar]"', async t => {
+	const [actual] = referencesEmpty(await parsed.foo, 'never', ['bar']);
 	const expected = true;
 	t.is(actual, expected);
 });

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -137,6 +137,16 @@ Rule configurations are either of type `array` residing on a key with the rule's
 #### references-empty
 * **condition**: `references` has at least one entry
 * **rule**: `never`
+* **value**
+```js
+  []
+```
+* **possible values**
+```js
+  [
+    'fix' // when type-enum is fix
+  ]
+```
 
 #### scope-enum
 * **condition**: `scope` is found in value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Verify references-empty when commit is the specified type

## Motivation and Context
References is required when it's a **fix** or **feat** commit, because other types in the actual scene rarely need to include references.

## Usage examples
<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
 "parserPreset": {
    "parserOpts": {
      "issuePrefixes": ["JIRA-"]
    }
  },
  "rules": {
    "references-empty": [2, "never", ["fix", "feat"]]
  }
}
```

```sh
echo "fix: foobar" | commitlint # fails
echo "feat: foobar" | commitlint # fails
echo "fix: foobar (JIRA-1)" | commitlint # passes
echo "test: foobar" | commitlint # passes
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
test script:
https://github.com/EthianWong/commitlint/blob/51e9a1b122502109b72ec58964007427569a106f/%40commitlint/rules/src/references-empty.test.js#L90

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
