### PR TITLE
docs: add missing character

### DIFF
--- a/docs/concepts-commit-conventions.md
+++ b/docs/concepts-commit-conventions.md
@@ -6,7 +6,7 @@ With this additional information tools can derive useful human-readable informat
 
 * Automated, rich changelogs
 * Automatic version bumps
-* Filter fo test harnesses to run
+* Filter for test harnesses to run
 
 The most common commit conventions follow this pattern:
 


### PR DESCRIPTION
Fixes spelling of the word "for" in the docs:
https://conventional-changelog.github.io/commitlint/#/concepts-commit-conventions

This is a documentation-only change.

Thanks!
