### PR TITLE
fix: don't merge array properties with custom opts

### DIFF
--- a/@commitlint/parse/src/index.js
+++ b/@commitlint/parse/src/index.js
@@ -1,12 +1,17 @@
 import {sync} from 'conventional-commits-parser';
 import defaultChangelogOpts from 'conventional-changelog-angular';
-import {merge} from 'lodash';
+import {isArray, mergeWith} from 'lodash';
 
 export default parse;
 
 async function parse(message, parser = sync, parserOpts = undefined) {
 	const defaultOpts = (await defaultChangelogOpts).parserOpts;
-	const parsed = parser(message, merge({}, defaultOpts, parserOpts));
+	const parsed = parser(
+		message,
+		mergeWith({}, defaultOpts, parserOpts, (objValue, srcValue) => {
+			if (isArray(objValue)) return srcValue;
+		})
+	);
 	parsed.raw = message;
 	return parsed;
 }

--- a/@commitlint/parse/src/index.test.js
+++ b/@commitlint/parse/src/index.test.js
@@ -98,6 +98,28 @@ test('uses custom opts parser', async t => {
 	t.deepEqual(actual, expected);
 });
 
+test('does not merge array properties with custom opts', async t => {
+	const message = 'type: subject';
+	const actual = await parse(message, undefined, {
+		headerPattern: /^(.*):\s(.*)$/,
+		headerCorrespondence: ['type', 'subject']
+	});
+	const expected = {
+		body: null,
+		footer: null,
+		header: 'type: subject',
+		mentions: [],
+		merge: null,
+		notes: [],
+		raw: 'type: subject',
+		references: [],
+		revert: null,
+		subject: 'subject',
+		type: 'type'
+	};
+	t.deepEqual(actual, expected);
+});
+
 test('supports scopes with /', async t => {
 	const message = 'type(some/scope): subject';
 	const actual = await parse(message);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

With a custom "headerCorrespondence" of two entries, commit message
subjects couldn't be parsed due to merge with the default (Angular).

For example, the following custom parser opts (ESLint style) wouldn't
work because "headerCorrespondence" is `['type', 'subject', 'subject']`
after the merge.

```js
{
  headerPattern: /^(.*):\s(.*)$/,
  headerCorrespondence: ['type', 'subject'],
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See #594.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

A corresponding test has been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.