### PR TITLE
chore: update lock file before upcoming release

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -182,16 +182,6 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@commitlint/test@7.5.0":
-  version "7.5.0"
-  resolved "https://registry.npmjs.org/@commitlint/test/-/test-7.5.0.tgz#2c68ba0b49096978cf6e82fa2f6208a7f3f9bbc9"
-  integrity sha512-LIFXGS2h7VGpNNouJ2ymmqPyF3KjAfIBqJfb6VBEGLAnMgiQeX7Qx3BYMFkZlDFrxSY2GpNKqB3LCITYYMsbDA==
-  dependencies:
-    "@commitlint/utils" "^7.5.0"
-    "@marionebl/sander" "0.6.1"
-    execa "0.9.0"
-    pkg-dir "2.0.0"
-
 "@concordance/react@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz#fcf3cad020e5121bfd1c61d05bc3516aac25f734"


### PR DESCRIPTION
update the `yarn.lock` file to be able to release