### PR TITLE
fix: update lerna and resolve audit issues

### DIFF
--- a/@commitlint/config-lerna-scopes/fixtures/basic/lerna.json
+++ b/@commitlint/config-lerna-scopes/fixtures/basic/lerna.json
@@ -1,5 +1,5 @@
 {
-    "lerna": "3.2.1",
+    "lerna": "3.13.3",
 	"version": "1.0.0",
 	"packages": [
 		"packages/*"

--- a/@commitlint/config-lerna-scopes/fixtures/basic/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/basic/package.json
@@ -2,6 +2,6 @@
     "name": "basic",
     "version": "1.0.0",
     "devDependencies": {
-        "lerna": "3.10.8"
+        "lerna": "3.13.3"
     }
 }

--- a/@commitlint/config-lerna-scopes/fixtures/empty/lerna.json
+++ b/@commitlint/config-lerna-scopes/fixtures/empty/lerna.json
@@ -1,5 +1,5 @@
 {
-    "lerna": "3.2.1",
+    "lerna": "3.13.3",
 	"version": "1.0.0",
 	"packages": [
 		"packages/*"

--- a/@commitlint/config-lerna-scopes/fixtures/empty/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/empty/package.json
@@ -2,6 +2,6 @@
     "name": "empty",
     "version": "1.0.0",
     "devDependencies": {
-        "lerna": "3.10.8"
+        "lerna": "3.13.3"
     }
 }

--- a/@commitlint/config-lerna-scopes/fixtures/lerna-two/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/lerna-two/package.json
@@ -2,6 +2,6 @@
     "name": "version-mismatch",
     "version": "1.0.0",
     "devDependencies": {
-        "lerna": "3.10.8"
+        "lerna": "3.13.3"
     }
 }

--- a/@commitlint/config-lerna-scopes/fixtures/scoped/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/scoped/package.json
@@ -2,6 +2,6 @@
     "name": "scoped",
     "version": "1.0.0",
     "devDependencies": {
-        "lerna": "3.10.8"
+        "lerna": "3.13.3"
     }
 }

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "peerDependencies": {
-    "lerna": "^3.0.0"
+    "lerna": "^3.13.3"
   },
   "dependencies": {
     "import-from": "2.1.0",
@@ -48,8 +48,8 @@
   "devDependencies": {
     "@commitlint/test": "7.5.0",
     "@commitlint/utils": "^7.5.0",
-    "@lerna/project": "3.5.0",
+    "@lerna/project": "3.13.1",
     "ava": "0.22.0",
-    "lerna": "3.10.8"
+    "lerna": "3.13.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@lerna/project": "3.13.1",
     "docsify-cli": "4.3.0",
     "husky": "1.1.2",
-    "lerna": "3.13.1",
+    "lerna": "3.13.3",
     "lint-staged": "8.1.0",
     "prettier": "1.16.4"
   },
@@ -105,6 +105,7 @@
     "docsify-cli/**/braces": "2.3.1",
     "deep-extend": "0.5.1",
     "moment": "2.19.3",
-    "js-yaml": ">=3.13.0"
+    "js-yaml": ">=3.13.1",
+    "tar": ">=4.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,16 +182,6 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@commitlint/test@7.5.0":
-  version "7.5.0"
-  resolved "https://registry.npmjs.org/@commitlint/test/-/test-7.5.0.tgz#2c68ba0b49096978cf6e82fa2f6208a7f3f9bbc9"
-  integrity sha512-LIFXGS2h7VGpNNouJ2ymmqPyF3KjAfIBqJfb6VBEGLAnMgiQeX7Qx3BYMFkZlDFrxSY2GpNKqB3LCITYYMsbDA==
-  dependencies:
-    "@commitlint/utils" "^7.5.0"
-    "@marionebl/sander" "0.6.1"
-    execa "0.9.0"
-    pkg-dir "2.0.0"
-
 "@concordance/react@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz#fcf3cad020e5121bfd1c61d05bc3516aac25f734"
@@ -274,27 +264,14 @@
     pretty-ms "^0.2.1"
     text-table "^0.2.0"
 
-"@lerna/add@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/add/-/add-3.10.6.tgz#6f2c6b26eb905c40fef4180f3ffa34ad9dbb860b"
+"@lerna/add@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/add/-/add-3.13.3.tgz#f4c1674839780e458f0426d4f7b6d0a77b9a2ae9"
+  integrity sha512-T3/Lsbo9ZFq+vL3ssaHxA8oKikZAPTJTGFe4CRuQgWCDd/M61+51jeWsngdaHpwzSSRDRjxg8fJTG10y10pnfA==
   dependencies:
-    "@lerna/bootstrap" "3.10.6"
-    "@lerna/command" "3.10.6"
-    "@lerna/filter-options" "3.10.6"
-    "@lerna/npm-conf" "3.7.0"
-    "@lerna/validation-error" "3.6.0"
-    dedent "^0.7.0"
-    libnpm "^2.0.1"
-    p-map "^1.2.0"
-    semver "^5.5.0"
-
-"@lerna/add@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/add/-/add-3.13.1.tgz#2cd7838857edb3b43ed73e3c21f69a20beb9b702"
-  dependencies:
-    "@lerna/bootstrap" "3.13.1"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
+    "@lerna/bootstrap" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
     "@lerna/npm-conf" "3.13.0"
     "@lerna/validation-error" "3.13.0"
     dedent "^0.7.0"
@@ -302,14 +279,6 @@
     p-map "^1.2.0"
     pacote "^9.5.0"
     semver "^5.5.0"
-
-"@lerna/batch-packages@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.10.6.tgz#2d6dfc9be13ea4da49244dd84bfcd46c3d62f4d0"
-  dependencies:
-    "@lerna/package-graph" "3.10.6"
-    "@lerna/validation-error" "3.6.0"
-    libnpm "^2.0.1"
 
 "@lerna/batch-packages@3.13.0":
   version "3.13.0"
@@ -319,46 +288,19 @@
     "@lerna/validation-error" "3.13.0"
     npmlog "^4.1.2"
 
-"@lerna/bootstrap@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.10.6.tgz#d250baa9cfe9026c4f78e6cf7c9761a90b24e363"
-  dependencies:
-    "@lerna/batch-packages" "3.10.6"
-    "@lerna/command" "3.10.6"
-    "@lerna/filter-options" "3.10.6"
-    "@lerna/has-npm-version" "3.10.0"
-    "@lerna/npm-install" "3.10.0"
-    "@lerna/package-graph" "3.10.6"
-    "@lerna/pulse-till-done" "3.7.1"
-    "@lerna/rimraf-dir" "3.10.0"
-    "@lerna/run-lifecycle" "3.10.5"
-    "@lerna/run-parallel-batches" "3.0.0"
-    "@lerna/symlink-binary" "3.10.0"
-    "@lerna/symlink-dependencies" "3.10.0"
-    "@lerna/validation-error" "3.6.0"
-    dedent "^0.7.0"
-    get-port "^3.2.0"
-    libnpm "^2.0.1"
-    multimatch "^2.1.0"
-    p-finally "^1.0.0"
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
-    p-waterfall "^1.0.0"
-    read-package-tree "^5.1.6"
-    semver "^5.5.0"
-
-"@lerna/bootstrap@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.13.1.tgz#f2edd7c8093c8b139e78b0ca5f845f23efd01f08"
+"@lerna/bootstrap@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.13.3.tgz#a0e5e466de5c100b49d558d39139204fc4db5c95"
+  integrity sha512-2XzijnLHRZOVQh8pwS7+5GR3cG4uh+EiLrWOishCq2TVzkqgjaS3GGBoef7KMCXfWHoLqAZRr/jEdLqfETLVqg==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/has-npm-version" "3.13.0"
-    "@lerna/npm-install" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/has-npm-version" "3.13.3"
+    "@lerna/npm-install" "3.13.3"
     "@lerna/package-graph" "3.13.0"
     "@lerna/pulse-till-done" "3.13.0"
-    "@lerna/rimraf-dir" "3.13.0"
+    "@lerna/rimraf-dir" "3.13.3"
     "@lerna/run-lifecycle" "3.13.0"
     "@lerna/run-parallel-batches" "3.13.0"
     "@lerna/symlink-binary" "3.13.0"
@@ -376,90 +318,47 @@
     read-package-tree "^5.1.6"
     semver "^5.5.0"
 
-"@lerna/changed@3.10.8":
-  version "3.10.8"
-  resolved "https://registry.npmjs.org/@lerna/changed/-/changed-3.10.8.tgz#7ed17a00c4ca0f6437ce9f7d4925d5e779b8553c"
+"@lerna/changed@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/changed/-/changed-3.13.3.tgz#f2a2e982f4317157345f7abb3f6b12cc69394657"
+  integrity sha512-REMZ/1UvYrizUhN7ktlbfMUa0vhMf1ogAe97WQC4I8r3s973Orfhs3aselo1GwudUwM4tMHBH8A9vnll9or3iA==
   dependencies:
-    "@lerna/collect-updates" "3.10.1"
-    "@lerna/command" "3.10.6"
-    "@lerna/listable" "3.10.6"
-    "@lerna/output" "3.6.0"
-    "@lerna/version" "3.10.8"
-
-"@lerna/changed@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/changed/-/changed-3.13.1.tgz#dc92476aad43c932fe741969bbd0bcf6146a4c52"
-  dependencies:
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/listable" "3.13.0"
     "@lerna/output" "3.13.0"
-    "@lerna/version" "3.13.1"
+    "@lerna/version" "3.13.3"
 
-"@lerna/check-working-tree@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.10.0.tgz#5ed9f2c5c942bee92afcd8cb5361be44ed0251e3"
+"@lerna/check-working-tree@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.13.3.tgz#836a3ffd4413a29aca92ccca4a115e4f97109992"
+  integrity sha512-LoGZvTkne+V1WpVdCTU0XNzFKsQa2AiAFKksGRT0v8NQj6VAPp0jfVYDayTqwaWt2Ne0OGKOFE79Y5LStOuhaQ==
   dependencies:
-    "@lerna/describe-ref" "3.10.0"
-    "@lerna/validation-error" "3.6.0"
-
-"@lerna/check-working-tree@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.13.0.tgz#1ddcd4d9b1aceb65efaaa4cd1333a66706d67c9c"
-  dependencies:
-    "@lerna/describe-ref" "3.13.0"
+    "@lerna/describe-ref" "3.13.3"
     "@lerna/validation-error" "3.13.0"
 
-"@lerna/child-process@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.13.0.tgz#84e35adf3217a6983edd28080657b9596a052674"
+"@lerna/child-process@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.13.3.tgz#6c084ee5cca9fc9e04d6bf4fc3f743ed26ff190c"
+  integrity sha512-3/e2uCLnbU+bydDnDwyadpOmuzazS01EcnOleAnuj9235CU2U97DH6OyoG1EW/fU59x11J+HjIqovh5vBaMQjQ==
   dependencies:
     chalk "^2.3.1"
     execa "^1.0.0"
     strong-log-transformer "^2.0.0"
 
-"@lerna/child-process@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.3.0.tgz#71184a763105b6c8ece27f43f166498d90fe680f"
+"@lerna/clean@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/clean/-/clean-3.13.3.tgz#5673a1238e0712d31711e7e4e8cb9641891daaea"
+  integrity sha512-xmNauF1PpmDaKdtA2yuRc23Tru4q7UMO6yB1a/TTwxYPYYsAWG/CBK65bV26J7x4RlZtEv06ztYGMa9zh34UXA==
   dependencies:
-    chalk "^2.3.1"
-    execa "^1.0.0"
-    strong-log-transformer "^2.0.0"
-
-"@lerna/clean@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/clean/-/clean-3.10.6.tgz#31e4a12a722e57ca7adc0c9bc30ba70d55572bb8"
-  dependencies:
-    "@lerna/command" "3.10.6"
-    "@lerna/filter-options" "3.10.6"
-    "@lerna/prompt" "3.6.0"
-    "@lerna/pulse-till-done" "3.7.1"
-    "@lerna/rimraf-dir" "3.10.0"
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
-    p-waterfall "^1.0.0"
-
-"@lerna/clean@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/clean/-/clean-3.13.1.tgz#9a7432efceccd720a51da5c76f849fc59c5a14ce"
-  dependencies:
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
     "@lerna/prompt" "3.13.0"
     "@lerna/pulse-till-done" "3.13.0"
-    "@lerna/rimraf-dir" "3.13.0"
+    "@lerna/rimraf-dir" "3.13.3"
     p-map "^1.2.0"
     p-map-series "^1.0.0"
     p-waterfall "^1.0.0"
-
-"@lerna/cli@3.10.7":
-  version "3.10.7"
-  resolved "https://registry.npmjs.org/@lerna/cli/-/cli-3.10.7.tgz#2f88ae4a3c53fa4d3a4f61b5f447bbbcc69546e2"
-  dependencies:
-    "@lerna/global-options" "3.10.6"
-    dedent "^0.7.0"
-    libnpm "^2.0.1"
-    yargs "^12.0.1"
 
 "@lerna/cli@3.13.0":
   version "3.13.0"
@@ -470,46 +369,23 @@
     npmlog "^4.1.2"
     yargs "^12.0.1"
 
-"@lerna/collect-updates@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.10.1.tgz#3ad60aa31826c0c0cfdf8bf41e58e6c5c86aeb3a"
+"@lerna/collect-updates@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.13.3.tgz#616648da59f0aff4a8e60257795cc46ca6921edd"
+  integrity sha512-sTpALOAxli/ZS+Mjq6fbmjU9YXqFJ2E4FrE1Ijl4wPC5stXEosg2u0Z1uPY+zVKdM+mOIhLxPVdx83rUgRS+Cg==
   dependencies:
-    "@lerna/child-process" "3.3.0"
-    "@lerna/describe-ref" "3.10.0"
-    libnpm "^2.0.1"
-    minimatch "^3.0.4"
-    slash "^1.0.0"
-
-"@lerna/collect-updates@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.13.0.tgz#f0828d84ff959ff153d006765659ffc4d68cdefc"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/describe-ref" "3.13.0"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/describe-ref" "3.13.3"
     minimatch "^3.0.4"
     npmlog "^4.1.2"
     slash "^1.0.0"
 
-"@lerna/command@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/command/-/command-3.10.6.tgz#709bd1c66220da67f65dbe1fc88bb7ba5bb85446"
+"@lerna/command@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/command/-/command-3.13.3.tgz#5b20b3f507224573551039e0460bc36c39f7e9d1"
+  integrity sha512-WHFIQCubJV0T8gSLRNr6exZUxTswrh+iAtJCb86SE0Sa+auMPklE8af7w2Yck5GJfewmxSjke3yrjNxQrstx7w==
   dependencies:
-    "@lerna/child-process" "3.3.0"
-    "@lerna/package-graph" "3.10.6"
-    "@lerna/project" "3.10.0"
-    "@lerna/validation-error" "3.6.0"
-    "@lerna/write-log-file" "3.6.0"
-    dedent "^0.7.0"
-    execa "^1.0.0"
-    is-ci "^1.0.10"
-    libnpm "^2.0.1"
-    lodash "^4.17.5"
-
-"@lerna/command@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/command/-/command-3.13.1.tgz#b60dda2c0d9ffbb6030d61ddf7cceedc1e8f7e6e"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     "@lerna/package-graph" "3.13.0"
     "@lerna/project" "3.13.1"
     "@lerna/validation-error" "3.13.0"
@@ -519,20 +395,6 @@
     is-ci "^1.0.10"
     lodash "^4.17.5"
     npmlog "^4.1.2"
-
-"@lerna/conventional-commits@3.10.8":
-  version "3.10.8"
-  resolved "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.10.8.tgz#b9f6dd8a09bc679f6afbb8296456de59e268fe3e"
-  dependencies:
-    "@lerna/validation-error" "3.6.0"
-    conventional-changelog-angular "^5.0.2"
-    conventional-changelog-core "^3.1.5"
-    conventional-recommended-bump "^4.0.4"
-    fs-extra "^7.0.0"
-    get-stream "^4.0.0"
-    libnpm "^2.0.1"
-    pify "^3.0.0"
-    semver "^5.5.0"
 
 "@lerna/conventional-commits@3.13.0":
   version "3.13.0"
@@ -557,42 +419,13 @@
     fs-extra "^7.0.0"
     npmlog "^4.1.2"
 
-"@lerna/create-symlink@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.6.0.tgz#f1815cde2fc9d8d2315dfea44ee880f2f1bc65f1"
+"@lerna/create@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/create/-/create-3.13.3.tgz#6ded142c54b7f3cea86413c3637b067027b7f55d"
+  integrity sha512-4M5xT1AyUMwt1gCDph4BfW3e6fZmt0KjTa3FoXkUotf/w/eqTsc2IQ+ULz2+gOFQmtuNbqIZEOK3J4P9ArJJ/A==
   dependencies:
-    cmd-shim "^2.0.2"
-    fs-extra "^7.0.0"
-    libnpm "^2.0.1"
-
-"@lerna/create@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/create/-/create-3.10.6.tgz#85c7398cad912516c0ac6054a5c0c4145ab6cadb"
-  dependencies:
-    "@lerna/child-process" "3.3.0"
-    "@lerna/command" "3.10.6"
-    "@lerna/npm-conf" "3.7.0"
-    "@lerna/validation-error" "3.6.0"
-    camelcase "^4.1.0"
-    dedent "^0.7.0"
-    fs-extra "^7.0.0"
-    globby "^8.0.1"
-    init-package-json "^1.10.3"
-    libnpm "^2.0.1"
-    p-reduce "^1.0.0"
-    pify "^3.0.0"
-    semver "^5.5.0"
-    slash "^1.0.0"
-    validate-npm-package-license "^3.0.3"
-    validate-npm-package-name "^3.0.0"
-    whatwg-url "^7.0.0"
-
-"@lerna/create@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/create/-/create-3.13.1.tgz#2c1284cfdc59f0d2b88286d78bc797f4ab330f79"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/npm-conf" "3.13.0"
     "@lerna/validation-error" "3.13.0"
     camelcase "^5.0.0"
@@ -610,83 +443,44 @@
     validate-npm-package-name "^3.0.0"
     whatwg-url "^7.0.0"
 
-"@lerna/describe-ref@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.10.0.tgz#266380feece6013ab9674f52bd35bf0be5b0460d"
+"@lerna/describe-ref@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.13.3.tgz#13318513613f6a407d37fc5dc025ec2cfb705606"
+  integrity sha512-5KcLTvjdS4gU5evW8ESbZ0BF44NM5HrP3dQNtWnOUSKJRgsES8Gj0lq9AlB2+YglZfjEftFT03uOYOxnKto4Uw==
   dependencies:
-    "@lerna/child-process" "3.3.0"
-    libnpm "^2.0.1"
-
-"@lerna/describe-ref@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.13.0.tgz#fb4c3863fd6bcccad67ce7b183887a5fc1942bb6"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     npmlog "^4.1.2"
 
-"@lerna/diff@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/diff/-/diff-3.10.6.tgz#b4c5a50d8c7e79619376e2c913ec1c627dfd0cdf"
+"@lerna/diff@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/diff/-/diff-3.13.3.tgz#883cb3a83a956dbfc2c17bc9a156468a5d3fae17"
+  integrity sha512-/DRS2keYbnKaAC+5AkDyZRGkP/kT7v1GlUS0JGZeiRDPQ1H6PzhX09EgE5X6nj0Ytrm0sUasDeN++CDVvgaI+A==
   dependencies:
-    "@lerna/child-process" "3.3.0"
-    "@lerna/command" "3.10.6"
-    "@lerna/validation-error" "3.6.0"
-    libnpm "^2.0.1"
-
-"@lerna/diff@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/diff/-/diff-3.13.1.tgz#5c734321b0f6c46a3c87f55c99afef3b01d46520"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/validation-error" "3.13.0"
     npmlog "^4.1.2"
 
-"@lerna/exec@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/exec/-/exec-3.10.6.tgz#5564b614b7e39c1f034f5e0736c9e020945f2f12"
-  dependencies:
-    "@lerna/batch-packages" "3.10.6"
-    "@lerna/child-process" "3.3.0"
-    "@lerna/command" "3.10.6"
-    "@lerna/filter-options" "3.10.6"
-    "@lerna/run-parallel-batches" "3.0.0"
-    "@lerna/validation-error" "3.6.0"
-
-"@lerna/exec@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/exec/-/exec-3.13.1.tgz#4439e90fb0877ec38a6ef933c86580d43eeaf81b"
+"@lerna/exec@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/exec/-/exec-3.13.3.tgz#5d2eda3f6e584f2f15b115e8a4b5bc960ba5de85"
+  integrity sha512-c0bD4XqM96CTPV8+lvkxzE7mkxiFyv/WNM4H01YvvbFAJzk+S4Y7cBtRkIYFTfkFZW3FLo8pEgtG1ONtIdM+tg==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
     "@lerna/run-parallel-batches" "3.13.0"
     "@lerna/validation-error" "3.13.0"
 
-"@lerna/filter-options@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.10.6.tgz#e05a8b8de6efc16c47c83f0ac58291008efba4b8"
+"@lerna/filter-options@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.13.3.tgz#aa42a4ab78837b8a6c4278ba871d27e92d77c54f"
+  integrity sha512-DbtQX4eRgrBz1wCFWRP99JBD7ODykYme9ykEK79+RrKph40znhJQRlLg4idogj6IsUEzwo1OHjihCzSfnVo6Cg==
   dependencies:
-    "@lerna/collect-updates" "3.10.1"
-    "@lerna/filter-packages" "3.10.0"
-    dedent "^0.7.0"
-
-"@lerna/filter-options@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.13.0.tgz#976e3d8b9fcd47001ab981d276565c1e9f767868"
-  dependencies:
-    "@lerna/collect-updates" "3.13.0"
+    "@lerna/collect-updates" "3.13.3"
     "@lerna/filter-packages" "3.13.0"
     dedent "^0.7.0"
-
-"@lerna/filter-packages@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.10.0.tgz#75f9a08184fc4046da2057e0218253cd6f493f05"
-  dependencies:
-    "@lerna/validation-error" "3.6.0"
-    libnpm "^2.0.1"
-    multimatch "^2.1.0"
 
 "@lerna/filter-packages@3.13.0":
   version "3.13.0"
@@ -702,12 +496,6 @@
   dependencies:
     npmlog "^4.1.2"
 
-"@lerna/get-npm-exec-opts@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.6.0.tgz#ea595eb28d1f34ba61a92ee8391f374282b4b76e"
-  dependencies:
-    libnpm "^2.0.1"
-
 "@lerna/get-packed@3.13.0":
   version "3.13.0"
   resolved "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.13.0.tgz#335e40d77f3c1855aa248587d3e0b2d8f4b06e16"
@@ -716,65 +504,36 @@
     ssri "^6.0.1"
     tar "^4.4.8"
 
-"@lerna/get-packed@3.7.0":
-  version "3.7.0"
-  resolved "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.7.0.tgz#549c7738f7be5e3b1433e82ed9cda9123bcd1ed5"
+"@lerna/github-client@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.13.3.tgz#bcf9b4ff40bdd104cb40cd257322f052b41bb9ce"
+  integrity sha512-fcJkjab4kX0zcLLSa/DCUNvU3v8wmy2c1lhdIbL7s7gABmDcV0QZq93LhnEee3VkC9UpnJ6GKG4EkD7eIifBnA==
   dependencies:
-    fs-extra "^7.0.0"
-    ssri "^6.0.1"
-    tar "^4.4.8"
-
-"@lerna/github-client@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.13.1.tgz#cb9bf9f01685a0cee0fac63f287f6c3673e45aa3"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     "@octokit/plugin-enterprise-rest" "^2.1.1"
     "@octokit/rest" "^16.16.0"
     git-url-parse "^11.1.2"
     npmlog "^4.1.2"
 
-"@lerna/global-options@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.10.6.tgz#c491a64b0be47eca4ffc875011958a5ee70a9a3e"
-
 "@lerna/global-options@3.13.0":
   version "3.13.0"
   resolved "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.13.0.tgz#217662290db06ad9cf2c49d8e3100ee28eaebae1"
 
-"@lerna/has-npm-version@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.10.0.tgz#d3a73c0fedd2f2e9c6fbe166c41809131dc939d2"
+"@lerna/has-npm-version@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.13.3.tgz#167e3f602a2fb58f84f93cf5df39705ca6432a2d"
+  integrity sha512-mQzoghRw4dBg0R9FFfHrj0TH0glvXyzdEZmYZ8Isvx5BSuEEwpsryoywuZSdppcvLu8o7NAdU5Tac8cJ/mT52w==
   dependencies:
-    "@lerna/child-process" "3.3.0"
+    "@lerna/child-process" "3.13.3"
     semver "^5.5.0"
 
-"@lerna/has-npm-version@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.13.0.tgz#6e1f7e9336cce3e029066f0175f06dd9d51ad09f"
+"@lerna/import@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/import/-/import-3.13.3.tgz#1dc84f2c5644ba874be9552395a3b158688b263c"
+  integrity sha512-gDjLAFVavG/CMvj9leBfiwd7vrXqtdFXPIz1oXmghBMnje7nCTbodbNWFe4VDDWx7reDaZIN+6PxTSvrPcF//A==
   dependencies:
-    "@lerna/child-process" "3.13.0"
-    semver "^5.5.0"
-
-"@lerna/import@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/import/-/import-3.10.6.tgz#36b65854857e8ab5dfd98a1caea4d365ecc06578"
-  dependencies:
-    "@lerna/child-process" "3.3.0"
-    "@lerna/command" "3.10.6"
-    "@lerna/prompt" "3.6.0"
-    "@lerna/pulse-till-done" "3.7.1"
-    "@lerna/validation-error" "3.6.0"
-    dedent "^0.7.0"
-    fs-extra "^7.0.0"
-    p-map-series "^1.0.0"
-
-"@lerna/import@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/import/-/import-3.13.1.tgz#69d641341a38b79bd379129da1c717d51dd728c7"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/prompt" "3.13.0"
     "@lerna/pulse-till-done" "3.13.0"
     "@lerna/validation-error" "3.13.0"
@@ -782,71 +541,37 @@
     fs-extra "^7.0.0"
     p-map-series "^1.0.0"
 
-"@lerna/init@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/init/-/init-3.10.6.tgz#b5c5166b2ddf00ea0f2742a1f53f59221478cf9a"
+"@lerna/init@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/init/-/init-3.13.3.tgz#ebd522fee9b9d7d3b2dacb0261eaddb4826851ff"
+  integrity sha512-bK/mp0sF6jT0N+c+xrbMCqN4xRoiZCXQzlYsyACxPK99KH/mpHv7hViZlTYUGlYcymtew6ZC770miv5A9wF9hA==
   dependencies:
-    "@lerna/child-process" "3.3.0"
-    "@lerna/command" "3.10.6"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
     fs-extra "^7.0.0"
     p-map "^1.2.0"
     write-json-file "^2.3.0"
 
-"@lerna/init@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/init/-/init-3.13.1.tgz#0392c822abb3d63a75be4916c5e761cfa7b34dda"
+"@lerna/link@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/link/-/link-3.13.3.tgz#11124d4a0c8d0b79752fbda3babedfd62dd57847"
+  integrity sha512-IHhtdhA0KlIdevCsq6WHkI2rF3lHWHziJs2mlrEWAKniVrFczbELON1KJAgdJS1k3kAP/WeWVqmIYZ2hJDxMvg==
   dependencies:
-    "@lerna/child-process" "3.13.0"
-    "@lerna/command" "3.13.1"
-    fs-extra "^7.0.0"
-    p-map "^1.2.0"
-    write-json-file "^2.3.0"
-
-"@lerna/link@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/link/-/link-3.10.6.tgz#4201cabbfc27bebaf1a400f8cfbd238f285dd3c7"
-  dependencies:
-    "@lerna/command" "3.10.6"
-    "@lerna/package-graph" "3.10.6"
-    "@lerna/symlink-dependencies" "3.10.0"
-    p-map "^1.2.0"
-    slash "^1.0.0"
-
-"@lerna/link@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/link/-/link-3.13.1.tgz#7d8ed4774bfa198d1780f790a14abb8722a3aad1"
-  dependencies:
-    "@lerna/command" "3.13.1"
+    "@lerna/command" "3.13.3"
     "@lerna/package-graph" "3.13.0"
     "@lerna/symlink-dependencies" "3.13.0"
     p-map "^1.2.0"
     slash "^1.0.0"
 
-"@lerna/list@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/list/-/list-3.10.6.tgz#7c43c09301ea01528f4dab3b22666f021e8ba9a5"
+"@lerna/list@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/list/-/list-3.13.3.tgz#fa93864d43cadeb4cd540a4e78a52886c57dbe74"
+  integrity sha512-rLRDsBCkydMq2FL6WY1J/elvnXIjxxRtb72lfKHdvDEqVdquT5Qgt9ci42hwjmcocFwWcFJgF6BZozj5pbc13A==
   dependencies:
-    "@lerna/command" "3.10.6"
-    "@lerna/filter-options" "3.10.6"
-    "@lerna/listable" "3.10.6"
-    "@lerna/output" "3.6.0"
-
-"@lerna/list@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/list/-/list-3.13.1.tgz#f9513ed143e52156c10ada4070f903c5847dcd10"
-  dependencies:
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
     "@lerna/listable" "3.13.0"
     "@lerna/output" "3.13.0"
-
-"@lerna/listable@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/listable/-/listable-3.10.6.tgz#cea92de89d9f293c6d63e00be662bed03f85c496"
-  dependencies:
-    "@lerna/batch-packages" "3.10.6"
-    chalk "^2.3.1"
-    columnify "^1.5.4"
 
 "@lerna/listable@3.13.0":
   version "3.13.0"
@@ -865,25 +590,9 @@
     has-unicode "^2.0.1"
     npmlog "^4.1.2"
 
-"@lerna/log-packed@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.6.0.tgz#bed96c2bdd47f076d9957d0c6069b2edc1518145"
-  dependencies:
-    byte-size "^4.0.3"
-    columnify "^1.5.4"
-    has-unicode "^2.0.1"
-    libnpm "^2.0.1"
-
 "@lerna/npm-conf@3.13.0":
   version "3.13.0"
   resolved "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.13.0.tgz#6b434ed75ff757e8c14381b9bbfe5d5ddec134a7"
-  dependencies:
-    config-chain "^1.1.11"
-    pify "^3.0.0"
-
-"@lerna/npm-conf@3.7.0":
-  version "3.7.0"
-  resolved "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.7.0.tgz#f101d4fdf07cefcf1161bcfaf3c0f105b420a450"
   dependencies:
     config-chain "^1.1.11"
     pify "^3.0.0"
@@ -897,29 +606,12 @@
     npm-registry-fetch "^3.9.0"
     npmlog "^4.1.2"
 
-"@lerna/npm-dist-tag@3.8.5":
-  version "3.8.5"
-  resolved "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.8.5.tgz#5ce22a72576badc8cb6baf85550043d63e66ea44"
+"@lerna/npm-install@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.13.3.tgz#9b09852732e51c16d2e060ff2fd8bfbbb49cf7ba"
+  integrity sha512-7Jig9MLpwAfcsdQ5UeanAjndChUjiTjTp50zJ+UZz4CbIBIDhoBehvNMTCL2G6pOEC7sGEg6sAqJINAqred6Tg==
   dependencies:
-    figgy-pudding "^3.5.1"
-    libnpm "^2.0.1"
-
-"@lerna/npm-install@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.10.0.tgz#fcd6688a3a2cd0e702a03c54c22eb7ae8b3dacb0"
-  dependencies:
-    "@lerna/child-process" "3.3.0"
-    "@lerna/get-npm-exec-opts" "3.6.0"
-    fs-extra "^7.0.0"
-    libnpm "^2.0.1"
-    signal-exit "^3.0.2"
-    write-pkg "^3.1.0"
-
-"@lerna/npm-install@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.13.0.tgz#88f4cc39f4f737c8a8721256b915ea1bcc6a7227"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     "@lerna/get-npm-exec-opts" "3.13.0"
     fs-extra "^7.0.0"
     npm-package-arg "^6.1.0"
@@ -927,40 +619,26 @@
     signal-exit "^3.0.2"
     write-pkg "^3.1.0"
 
-"@lerna/npm-publish@3.10.7":
-  version "3.10.7"
-  resolved "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.10.7.tgz#9326b747b905a7f0e69d4be3f557859c3e359649"
-  dependencies:
-    "@lerna/run-lifecycle" "3.10.5"
-    figgy-pudding "^3.5.1"
-    fs-extra "^7.0.0"
-    libnpm "^2.0.1"
-
-"@lerna/npm-publish@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.13.0.tgz#5c74808376e778865ffdc5885fe83935e15e60c3"
+"@lerna/npm-publish@3.13.2":
+  version "3.13.2"
+  resolved "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.13.2.tgz#ad713ca6f91a852687d7d0e1bda7f9c66df21768"
+  integrity sha512-HMucPyEYZfom5tRJL4GsKBRi47yvSS2ynMXYxL3kO0ie+j9J7cb0Ir8NmaAMEd3uJWJVFCPuQarehyfTDZsSxg==
   dependencies:
     "@lerna/run-lifecycle" "3.13.0"
     figgy-pudding "^3.5.1"
     fs-extra "^7.0.0"
     libnpmpublish "^1.1.1"
+    npm-package-arg "^6.1.0"
     npmlog "^4.1.2"
     pify "^3.0.0"
     read-package-json "^2.0.13"
 
-"@lerna/npm-run-script@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.10.0.tgz#49a9204eddea136da15a8d8d9eba2c3175b77ddd"
+"@lerna/npm-run-script@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.13.3.tgz#9bb6389ed70cd506905d6b05b6eab336b4266caf"
+  integrity sha512-qR4o9BFt5hI8Od5/DqLalOJydnKpiQFEeN0h9xZi7MwzuX1Ukwh3X22vqsX4YRbipIelSFtrDzleNVUm5jj0ow==
   dependencies:
-    "@lerna/child-process" "3.3.0"
-    "@lerna/get-npm-exec-opts" "3.6.0"
-    libnpm "^2.0.1"
-
-"@lerna/npm-run-script@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.13.0.tgz#e5997f045402b9948bdc066033ebb36bf94fc9e4"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     "@lerna/get-npm-exec-opts" "3.13.0"
     npmlog "^4.1.2"
 
@@ -969,25 +647,6 @@
   resolved "https://registry.npmjs.org/@lerna/output/-/output-3.13.0.tgz#3ded7cc908b27a9872228a630d950aedae7a4989"
   dependencies:
     npmlog "^4.1.2"
-
-"@lerna/output@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/@lerna/output/-/output-3.6.0.tgz#a69384bc685cf3b21aa1bfc697eb2b9db3333d0b"
-  dependencies:
-    libnpm "^2.0.1"
-
-"@lerna/pack-directory@3.10.5":
-  version "3.10.5"
-  resolved "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.10.5.tgz#9bdabceacb74e1f54e47bae925e193978f2aae51"
-  dependencies:
-    "@lerna/get-packed" "3.7.0"
-    "@lerna/package" "3.7.2"
-    "@lerna/run-lifecycle" "3.10.5"
-    figgy-pudding "^3.5.1"
-    libnpm "^2.0.1"
-    npm-packlist "^1.1.12"
-    tar "^4.4.8"
-    temp-write "^3.4.0"
 
 "@lerna/pack-directory@3.13.1":
   version "3.13.1"
@@ -1001,14 +660,6 @@
     npmlog "^4.1.2"
     tar "^4.4.8"
     temp-write "^3.4.0"
-
-"@lerna/package-graph@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.10.6.tgz#8940d1ed7003100117cb1b618f7690585c00db81"
-  dependencies:
-    "@lerna/validation-error" "3.6.0"
-    libnpm "^2.0.1"
-    semver "^5.5.0"
 
 "@lerna/package-graph@3.13.0":
   version "3.13.0"
@@ -1025,38 +676,6 @@
     load-json-file "^4.0.0"
     npm-package-arg "^6.1.0"
     write-pkg "^3.1.0"
-
-"@lerna/package@3.7.2":
-  version "3.7.2"
-  resolved "https://registry.npmjs.org/@lerna/package/-/package-3.7.2.tgz#03c69fd7fb965c372c8c969165a2f7d6dfe2dfcb"
-  dependencies:
-    libnpm "^2.0.1"
-    load-json-file "^4.0.0"
-    write-pkg "^3.1.0"
-
-"@lerna/package@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/@lerna/package/-/package-3.0.0.tgz#14afc9a6cb1f7f7b23c1d7c7aa81bdac7d44c0e5"
-  dependencies:
-    npm-package-arg "^6.0.0"
-    write-pkg "^3.1.0"
-
-"@lerna/project@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/project/-/project-3.10.0.tgz#98272bf2eb93e9b21850edae568d696bf7fdebda"
-  dependencies:
-    "@lerna/package" "3.7.2"
-    "@lerna/validation-error" "3.6.0"
-    cosmiconfig "^5.0.2"
-    dedent "^0.7.0"
-    dot-prop "^4.2.0"
-    glob-parent "^3.1.0"
-    globby "^8.0.1"
-    libnpm "^2.0.1"
-    load-json-file "^4.0.0"
-    p-map "^1.2.0"
-    resolve-from "^4.0.0"
-    write-json-file "^2.3.0"
 
 "@lerna/project@3.13.1":
   version "3.13.1"
@@ -1075,23 +694,6 @@
     resolve-from "^4.0.0"
     write-json-file "^2.3.0"
 
-"@lerna/project@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/@lerna/project/-/project-3.5.0.tgz#ac5c7b3c49318552b29ccb7a471a657fd57d3091"
-  dependencies:
-    "@lerna/package" "^3.0.0"
-    "@lerna/validation-error" "^3.0.0"
-    cosmiconfig "^5.0.2"
-    dedent "^0.7.0"
-    dot-prop "^4.2.0"
-    glob-parent "^3.1.0"
-    globby "^8.0.1"
-    load-json-file "^4.0.0"
-    npmlog "^4.1.2"
-    p-map "^1.2.0"
-    resolve-from "^4.0.0"
-    write-json-file "^2.3.0"
-
 "@lerna/prompt@3.13.0":
   version "3.13.0"
   resolved "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.13.0.tgz#53571462bb3f5399cc1ca6d335a411fe093426a5"
@@ -1099,58 +701,21 @@
     inquirer "^6.2.0"
     npmlog "^4.1.2"
 
-"@lerna/prompt@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.6.0.tgz#b17cc464dec9d830619723e879dc747367378217"
-  dependencies:
-    inquirer "^6.2.0"
-    libnpm "^2.0.1"
-
-"@lerna/publish@3.10.8":
-  version "3.10.8"
-  resolved "https://registry.npmjs.org/@lerna/publish/-/publish-3.10.8.tgz#fcf73ab2468807f5a8f3339234c2f66f0f65b088"
-  dependencies:
-    "@lerna/batch-packages" "3.10.6"
-    "@lerna/check-working-tree" "3.10.0"
-    "@lerna/child-process" "3.3.0"
-    "@lerna/collect-updates" "3.10.1"
-    "@lerna/command" "3.10.6"
-    "@lerna/describe-ref" "3.10.0"
-    "@lerna/log-packed" "3.6.0"
-    "@lerna/npm-conf" "3.7.0"
-    "@lerna/npm-dist-tag" "3.8.5"
-    "@lerna/npm-publish" "3.10.7"
-    "@lerna/output" "3.6.0"
-    "@lerna/pack-directory" "3.10.5"
-    "@lerna/prompt" "3.6.0"
-    "@lerna/pulse-till-done" "3.7.1"
-    "@lerna/run-lifecycle" "3.10.5"
-    "@lerna/run-parallel-batches" "3.0.0"
-    "@lerna/validation-error" "3.6.0"
-    "@lerna/version" "3.10.8"
-    figgy-pudding "^3.5.1"
-    fs-extra "^7.0.0"
-    libnpm "^2.0.1"
-    p-finally "^1.0.0"
-    p-map "^1.2.0"
-    p-pipe "^1.2.0"
-    p-reduce "^1.0.0"
-    semver "^5.5.0"
-
-"@lerna/publish@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/publish/-/publish-3.13.1.tgz#217e401dcb5824cdd6d36555a36303fb7520c514"
+"@lerna/publish@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/publish/-/publish-3.13.3.tgz#9adde543064e85851f02c0c2dbd40d52d1c519a4"
+  integrity sha512-Ni3pZKueIfgJJoL0OXfbAuWhGlJrDNwGx3CYWp2dbNqJmKD6uBZmsDtmeARKDp92oUK60W0drXCMydkIFFHMDQ==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/check-working-tree" "3.13.0"
-    "@lerna/child-process" "3.13.0"
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/describe-ref" "3.13.0"
+    "@lerna/check-working-tree" "3.13.3"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/describe-ref" "3.13.3"
     "@lerna/log-packed" "3.13.0"
     "@lerna/npm-conf" "3.13.0"
     "@lerna/npm-dist-tag" "3.13.0"
-    "@lerna/npm-publish" "3.13.0"
+    "@lerna/npm-publish" "3.13.2"
     "@lerna/output" "3.13.0"
     "@lerna/pack-directory" "3.13.1"
     "@lerna/prompt" "3.13.0"
@@ -1158,7 +723,7 @@
     "@lerna/run-lifecycle" "3.13.0"
     "@lerna/run-parallel-batches" "3.13.0"
     "@lerna/validation-error" "3.13.0"
-    "@lerna/version" "3.13.1"
+    "@lerna/version" "3.13.3"
     figgy-pudding "^3.5.1"
     fs-extra "^7.0.0"
     libnpmaccess "^3.0.1"
@@ -1178,12 +743,6 @@
   dependencies:
     npmlog "^4.1.2"
 
-"@lerna/pulse-till-done@3.7.1":
-  version "3.7.1"
-  resolved "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.7.1.tgz#a9e55380fa18f6896a3e5b23621a4227adfb8f85"
-  dependencies:
-    libnpm "^2.0.1"
-
 "@lerna/resolve-symlink@3.13.0":
   version "3.13.0"
   resolved "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz#3e6809ef53b63fe914814bfa071cd68012e22fbb"
@@ -1192,39 +751,15 @@
     npmlog "^4.1.2"
     read-cmd-shim "^1.0.1"
 
-"@lerna/resolve-symlink@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.6.0.tgz#985344796b704ff32afa923901e795e80741b86e"
+"@lerna/rimraf-dir@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.13.3.tgz#3a8e71317fde853893ef0262bc9bba6a180b7227"
+  integrity sha512-d0T1Hxwu3gpYVv73ytSL+/Oy8JitsmvOYUR5ouRSABsmqS7ZZCh5t6FgVDDGVXeuhbw82+vuny1Og6Q0k4ilqw==
   dependencies:
-    fs-extra "^7.0.0"
-    libnpm "^2.0.1"
-    read-cmd-shim "^1.0.1"
-
-"@lerna/rimraf-dir@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.10.0.tgz#2d9435054ab7bbc5519db0a2654c5d8cacd27f98"
-  dependencies:
-    "@lerna/child-process" "3.3.0"
-    libnpm "^2.0.1"
-    path-exists "^3.0.0"
-    rimraf "^2.6.2"
-
-"@lerna/rimraf-dir@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.13.0.tgz#bb1006104b4aabcb6985624273254648f872b278"
-  dependencies:
-    "@lerna/child-process" "3.13.0"
+    "@lerna/child-process" "3.13.3"
     npmlog "^4.1.2"
     path-exists "^3.0.0"
     rimraf "^2.6.2"
-
-"@lerna/run-lifecycle@3.10.5":
-  version "3.10.5"
-  resolved "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.10.5.tgz#ea4422bb70c0f8d4382ecb2a626c8ba0ca88550b"
-  dependencies:
-    "@lerna/npm-conf" "3.7.0"
-    figgy-pudding "^3.5.1"
-    libnpm "^2.0.1"
 
 "@lerna/run-lifecycle@3.13.0":
   version "3.13.0"
@@ -1235,13 +770,6 @@
     npm-lifecycle "^2.1.0"
     npmlog "^4.1.2"
 
-"@lerna/run-parallel-batches@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.0.0.tgz#468704934084c74991d3124d80607857d4dfa840"
-  dependencies:
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
-
 "@lerna/run-parallel-batches@3.13.0":
   version "3.13.0"
   resolved "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz#0276bb4e7cd0995297db82d134ca2bd08d63e311"
@@ -1249,41 +777,19 @@
     p-map "^1.2.0"
     p-map-series "^1.0.0"
 
-"@lerna/run@3.10.6":
-  version "3.10.6"
-  resolved "https://registry.npmjs.org/@lerna/run/-/run-3.10.6.tgz#4c159a719b0ec010409dfe8f9535c9a3c3f3e06a"
-  dependencies:
-    "@lerna/batch-packages" "3.10.6"
-    "@lerna/command" "3.10.6"
-    "@lerna/filter-options" "3.10.6"
-    "@lerna/npm-run-script" "3.10.0"
-    "@lerna/output" "3.6.0"
-    "@lerna/run-parallel-batches" "3.0.0"
-    "@lerna/timer" "3.5.0"
-    "@lerna/validation-error" "3.6.0"
-    p-map "^1.2.0"
-
-"@lerna/run@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/run/-/run-3.13.1.tgz#87e174c1d271894ddd29adc315c068fb7b1b0117"
+"@lerna/run@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/run/-/run-3.13.3.tgz#0781c82d225ef6e85e28d3e763f7fc090a376a21"
+  integrity sha512-ygnLIfIYS6YY1JHWOM4CsdZiY8kTYPsDFOLAwASlRnlAXF9HiMT08GFXLmMHIblZJ8yJhsM2+QgraCB0WdxzOQ==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/command" "3.13.1"
-    "@lerna/filter-options" "3.13.0"
-    "@lerna/npm-run-script" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/npm-run-script" "3.13.3"
     "@lerna/output" "3.13.0"
     "@lerna/run-parallel-batches" "3.13.0"
     "@lerna/timer" "3.13.0"
     "@lerna/validation-error" "3.13.0"
-    p-map "^1.2.0"
-
-"@lerna/symlink-binary@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.10.0.tgz#5acdde86dfd50c9270d7d2a93bade203cff41b3d"
-  dependencies:
-    "@lerna/create-symlink" "3.6.0"
-    "@lerna/package" "3.7.2"
-    fs-extra "^7.0.0"
     p-map "^1.2.0"
 
 "@lerna/symlink-binary@3.13.0":
@@ -1294,18 +800,6 @@
     "@lerna/package" "3.13.0"
     fs-extra "^7.0.0"
     p-map "^1.2.0"
-
-"@lerna/symlink-dependencies@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.10.0.tgz#a20226e8e97af6a6bc4b416bfc28c0c5e3ba9ddd"
-  dependencies:
-    "@lerna/create-symlink" "3.6.0"
-    "@lerna/resolve-symlink" "3.6.0"
-    "@lerna/symlink-binary" "3.10.0"
-    fs-extra "^7.0.0"
-    p-finally "^1.0.0"
-    p-map "^1.2.0"
-    p-map-series "^1.0.0"
 
 "@lerna/symlink-dependencies@3.13.0":
   version "3.13.0"
@@ -1323,65 +817,24 @@
   version "3.13.0"
   resolved "https://registry.npmjs.org/@lerna/timer/-/timer-3.13.0.tgz#bcd0904551db16e08364d6c18e5e2160fc870781"
 
-"@lerna/timer@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/@lerna/timer/-/timer-3.5.0.tgz#8dee6acf002c55de64678c66ef37ca52143f1b9b"
-
 "@lerna/validation-error@3.13.0":
   version "3.13.0"
   resolved "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.13.0.tgz#c86b8f07c5ab9539f775bd8a54976e926f3759c3"
   dependencies:
     npmlog "^4.1.2"
 
-"@lerna/validation-error@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.6.0.tgz#550cf66bb2ef88edc02e36017b575a7a9100d5d8"
-  dependencies:
-    libnpm "^2.0.1"
-
-"@lerna/validation-error@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.0.0.tgz#a27e90051c3ba71995e2a800a43d94ad04b3e3f4"
-  dependencies:
-    npmlog "^4.1.2"
-
-"@lerna/version@3.10.8":
-  version "3.10.8"
-  resolved "https://registry.npmjs.org/@lerna/version/-/version-3.10.8.tgz#14a645724b0369f84a0bf4c1eb093e8e96a219f1"
-  dependencies:
-    "@lerna/batch-packages" "3.10.6"
-    "@lerna/check-working-tree" "3.10.0"
-    "@lerna/child-process" "3.3.0"
-    "@lerna/collect-updates" "3.10.1"
-    "@lerna/command" "3.10.6"
-    "@lerna/conventional-commits" "3.10.8"
-    "@lerna/output" "3.6.0"
-    "@lerna/prompt" "3.6.0"
-    "@lerna/run-lifecycle" "3.10.5"
-    "@lerna/validation-error" "3.6.0"
-    chalk "^2.3.1"
-    dedent "^0.7.0"
-    libnpm "^2.0.1"
-    minimatch "^3.0.4"
-    p-map "^1.2.0"
-    p-pipe "^1.2.0"
-    p-reduce "^1.0.0"
-    p-waterfall "^1.0.0"
-    semver "^5.5.0"
-    slash "^1.0.0"
-    temp-write "^3.4.0"
-
-"@lerna/version@3.13.1":
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/@lerna/version/-/version-3.13.1.tgz#5e919d13abb13a663dcc7922bb40931f12fb137b"
+"@lerna/version@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/@lerna/version/-/version-3.13.3.tgz#3ec1b5aee2fd42353b95452c38cc0b284b93a1f0"
+  integrity sha512-o/yQGAwDHmyu17wTj4Kat1/uDhjYFMeG+H0Y0HC4zJ4a/T6rEiXx7jJrnucPTmTQTDcUBoH/It5LrPYGOPsExA==
   dependencies:
     "@lerna/batch-packages" "3.13.0"
-    "@lerna/check-working-tree" "3.13.0"
-    "@lerna/child-process" "3.13.0"
-    "@lerna/collect-updates" "3.13.0"
-    "@lerna/command" "3.13.1"
+    "@lerna/check-working-tree" "3.13.3"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/command" "3.13.3"
     "@lerna/conventional-commits" "3.13.0"
-    "@lerna/github-client" "3.13.1"
+    "@lerna/github-client" "3.13.3"
     "@lerna/output" "3.13.0"
     "@lerna/prompt" "3.13.0"
     "@lerna/run-lifecycle" "3.13.0"
@@ -1403,13 +856,6 @@
   resolved "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.13.0.tgz#b78d9e4cfc1349a8be64d91324c4c8199e822a26"
   dependencies:
     npmlog "^4.1.2"
-    write-file-atomic "^2.3.0"
-
-"@lerna/write-log-file@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.6.0.tgz#b8d5a7efc84fa93cbd67d724d11120343b2a849a"
-  dependencies:
-    libnpm "^2.0.1"
     write-file-atomic "^2.3.0"
 
 "@marionebl/sander@0.6.1", "@marionebl/sander@^0.6.0":
@@ -1782,6 +1228,7 @@ alva@1.0.17:
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
 ansi-align@^1.1.0:
   version "1.1.0"
@@ -1882,11 +1329,11 @@ append-transform@^0.4.0:
   dependencies:
     default-require-extensions "^1.0.0"
 
-aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2:
+aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
 
-"aproba@^1.1.2 || 2", aproba@^2.0.0:
+aproba@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
 
@@ -3657,16 +3104,6 @@ big.js@^5.2.2:
   resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-bin-links@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/bin-links/-/bin-links-1.1.2.tgz#fb74bd54bae6b7befc6c6221f25322ac830d9757"
-  dependencies:
-    bluebird "^3.5.0"
-    cmd-shim "^2.0.2"
-    gentle-fs "^2.0.0"
-    graceful-fs "^4.1.11"
-    write-file-atomic "^2.3.0"
-
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
@@ -3694,17 +3131,11 @@ bl@^2.2.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  dependencies:
-    inherits "~2.0.0"
-
 bluebird@3.5.1, bluebird@^3.0.0, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
-bluebird@^3.4.7, bluebird@^3.5.0, bluebird@^3.5.3:
+bluebird@^3.4.7, bluebird@^3.5.3:
   version "3.5.3"
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
 
@@ -4954,37 +4385,12 @@ conventional-changelog-angular@^1.3.3:
     compare-func "^1.3.1"
     q "^1.4.1"
 
-conventional-changelog-angular@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.2.tgz#39d945635e03b6d0c9d4078b1df74e06163dc66a"
-  dependencies:
-    compare-func "^1.3.1"
-    q "^1.5.1"
-
 conventional-changelog-angular@^5.0.3:
   version "5.0.3"
   resolved "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz#299fdd43df5a1f095283ac16aeedfb0a682ecab0"
   dependencies:
     compare-func "^1.3.1"
     q "^1.5.1"
-
-conventional-changelog-core@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.5.tgz#c2edf928539308b54fe1b90a2fc731abc021852c"
-  dependencies:
-    conventional-changelog-writer "^4.0.2"
-    conventional-commits-parser "^3.0.1"
-    dateformat "^3.0.0"
-    get-pkg-repo "^1.0.0"
-    git-raw-commits "2.0.0"
-    git-remote-origin-url "^2.0.0"
-    git-semver-tags "^2.0.2"
-    lodash "^4.2.1"
-    normalize-package-data "^2.3.5"
-    q "^1.5.1"
-    read-pkg "^3.0.0"
-    read-pkg-up "^3.0.0"
-    through2 "^2.0.0"
 
 conventional-changelog-core@^3.1.6:
   version "3.1.6"
@@ -5007,21 +4413,6 @@ conventional-changelog-core@^3.1.6:
 conventional-changelog-preset-loader@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz#81d1a07523913f3d17da3a49f0091f967ad345b0"
-
-conventional-changelog-writer@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.2.tgz#eb493ed84269e7a663da36e49af51c54639c9a67"
-  dependencies:
-    compare-func "^1.3.1"
-    conventional-commits-filter "^2.0.1"
-    dateformat "^3.0.0"
-    handlebars "^4.0.2"
-    json-stringify-safe "^5.0.1"
-    lodash "^4.2.1"
-    meow "^4.0.0"
-    semver "^5.5.0"
-    split "^1.0.0"
-    through2 "^2.0.0"
 
 conventional-changelog-writer@^4.0.3:
   version "4.0.3"
@@ -5170,14 +4561,6 @@ cosmiconfig@^4.0.0:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
-
-cosmiconfig@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
-  dependencies:
-    is-directory "^0.3.1"
-    js-yaml "^3.9.0"
-    parse-json "^4.0.0"
 
 cosmiconfig@^5.0.5, cosmiconfig@^5.2.0:
   version "5.2.0"
@@ -7038,10 +6421,6 @@ find-node-modules@1.0.4:
     findup-sync "0.4.2"
     merge "^1.2.0"
 
-find-npm-prefix@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz#8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf"
-
 find-parent-dir@^0.3.0, find-parent-dir@~0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
@@ -7251,14 +6630,6 @@ fs-readdir-recursive@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
 
-fs-vacuum@^1.2.10:
-  version "1.2.10"
-  resolved "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz#b7629bec07a4031a2548fdf99f5ecf1cc8b31e36"
-  dependencies:
-    graceful-fs "^4.1.2"
-    path-is-inside "^1.0.1"
-    rimraf "^2.5.2"
-
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -7295,7 +6666,7 @@ fstream-ignore@^1.0.5:
     inherits "2"
     minimatch "^3.0.0"
 
-fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
+fstream@^1.0.0, fstream@^1.0.10:
   version "1.0.11"
   resolved "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
   dependencies:
@@ -7351,19 +6722,6 @@ gauge@~2.7.3:
 genfun@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
-
-gentle-fs@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz#585cfd612bfc5cd52471fdb42537f016a5ce3687"
-  dependencies:
-    aproba "^1.1.2"
-    fs-vacuum "^1.2.10"
-    graceful-fs "^4.1.11"
-    iferr "^0.1.5"
-    mkdirp "^0.5.1"
-    path-is-inside "^1.0.2"
-    read-cmd-shim "^1.0.1"
-    slide "^1.1.6"
 
 get-caller-file@^1.0.1:
   version "1.0.2"
@@ -7692,9 +7050,10 @@ handle-thing@^2.0.0:
   resolved "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@4.0.11, handlebars@^4.0.2:
+handlebars@4.0.11:
   version "4.0.11"
   resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
+  integrity sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -7702,22 +7061,12 @@ handlebars@4.0.11, handlebars@^4.0.2:
   optionalDependencies:
     uglify-js "^2.6"
 
-handlebars@^4.0.3:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
-  integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
+handlebars@^4.0.3, handlebars@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
     neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-handlebars@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
-  dependencies:
-    async "^2.5.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
   optionalDependencies:
@@ -8291,10 +7640,6 @@ inherits@2.0.1:
 ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-
-ini@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
 init-package-json@^1.10.3:
   version "1.10.3"
@@ -9322,10 +8667,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@>=3.13.0, js-yaml@^3.10.0, js-yaml@^3.13.0, js-yaml@^3.7.0, js-yaml@^3.8.2, js-yaml@^3.9.0, js-yaml@^3.9.1, js-yaml@~3.7.0:
-  version "3.13.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
-  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+js-yaml@>=3.13.1, js-yaml@^3.10.0, js-yaml@^3.13.0, js-yaml@^3.7.0, js-yaml@^3.8.2, js-yaml@^3.9.0, js-yaml@^3.9.1, js-yaml@~3.7.0:
+  version "3.13.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -9543,47 +8888,26 @@ left-pad@^1.3.0:
   resolved "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-lerna@3.10.8:
-  version "3.10.8"
-  resolved "https://registry.npmjs.org/lerna/-/lerna-3.10.8.tgz#89e04b5e29f7d6acb3cec7ce59cec2d4343e5cf4"
+lerna@3.13.3:
+  version "3.13.3"
+  resolved "https://registry.npmjs.org/lerna/-/lerna-3.13.3.tgz#bfd64e99466eaaf35b5d27994973b9f694796181"
+  integrity sha512-0TkG40F02A4wjKraJBztPtj87BjUezFmaZKAha8eLdtngZkSpAdrSANa5K7jnnA8mywmpQwrKJuBmjdNpm9cBw==
   dependencies:
-    "@lerna/add" "3.10.6"
-    "@lerna/bootstrap" "3.10.6"
-    "@lerna/changed" "3.10.8"
-    "@lerna/clean" "3.10.6"
-    "@lerna/cli" "3.10.7"
-    "@lerna/create" "3.10.6"
-    "@lerna/diff" "3.10.6"
-    "@lerna/exec" "3.10.6"
-    "@lerna/import" "3.10.6"
-    "@lerna/init" "3.10.6"
-    "@lerna/link" "3.10.6"
-    "@lerna/list" "3.10.6"
-    "@lerna/publish" "3.10.8"
-    "@lerna/run" "3.10.6"
-    "@lerna/version" "3.10.8"
-    import-local "^1.0.0"
-    libnpm "^2.0.1"
-
-lerna@3.13.1:
-  version "3.13.1"
-  resolved "https://registry.npmjs.org/lerna/-/lerna-3.13.1.tgz#feaff562176f304bd82329ca29ce46ab6c033463"
-  dependencies:
-    "@lerna/add" "3.13.1"
-    "@lerna/bootstrap" "3.13.1"
-    "@lerna/changed" "3.13.1"
-    "@lerna/clean" "3.13.1"
+    "@lerna/add" "3.13.3"
+    "@lerna/bootstrap" "3.13.3"
+    "@lerna/changed" "3.13.3"
+    "@lerna/clean" "3.13.3"
     "@lerna/cli" "3.13.0"
-    "@lerna/create" "3.13.1"
-    "@lerna/diff" "3.13.1"
-    "@lerna/exec" "3.13.1"
-    "@lerna/import" "3.13.1"
-    "@lerna/init" "3.13.1"
-    "@lerna/link" "3.13.1"
-    "@lerna/list" "3.13.1"
-    "@lerna/publish" "3.13.1"
-    "@lerna/run" "3.13.1"
-    "@lerna/version" "3.13.1"
+    "@lerna/create" "3.13.3"
+    "@lerna/diff" "3.13.3"
+    "@lerna/exec" "3.13.3"
+    "@lerna/import" "3.13.3"
+    "@lerna/init" "3.13.3"
+    "@lerna/link" "3.13.3"
+    "@lerna/list" "3.13.3"
+    "@lerna/publish" "3.13.3"
+    "@lerna/run" "3.13.3"
+    "@lerna/version" "3.13.3"
     import-local "^1.0.0"
     npmlog "^4.1.2"
 
@@ -9599,31 +8923,6 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libnpm@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/libnpm/-/libnpm-2.0.1.tgz#a48fcdee3c25e13c77eb7c60a0efe561d7fb0d8f"
-  dependencies:
-    bin-links "^1.1.2"
-    bluebird "^3.5.3"
-    find-npm-prefix "^1.0.2"
-    libnpmaccess "^3.0.1"
-    libnpmconfig "^1.2.1"
-    libnpmhook "^5.0.2"
-    libnpmorg "^1.0.0"
-    libnpmpublish "^1.1.0"
-    libnpmsearch "^2.0.0"
-    libnpmteam "^1.0.1"
-    lock-verify "^2.0.2"
-    npm-lifecycle "^2.1.0"
-    npm-logical-tree "^1.2.1"
-    npm-package-arg "^6.1.0"
-    npm-profile "^4.0.1"
-    npm-registry-fetch "^3.8.0"
-    npmlog "^4.1.2"
-    pacote "^9.2.3"
-    read-package-json "^2.0.13"
-    stringify-package "^1.0.0"
-
 libnpmaccess@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
@@ -9633,33 +8932,7 @@ libnpmaccess@^3.0.1:
     npm-package-arg "^6.1.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmconfig@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz#c0c2f793a74e67d4825e5039e7a02a0044dfcbc0"
-  dependencies:
-    figgy-pudding "^3.5.1"
-    find-up "^3.0.0"
-    ini "^1.3.5"
-
-libnpmhook@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.2.tgz#d12817b0fb893f36f1d5be20017f2aea25825d94"
-  dependencies:
-    aproba "^2.0.0"
-    figgy-pudding "^3.4.1"
-    get-stream "^4.0.0"
-    npm-registry-fetch "^3.8.0"
-
-libnpmorg@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.0.tgz#979b868c48ba28c5820e3bb9d9e73c883c16a232"
-  dependencies:
-    aproba "^2.0.0"
-    figgy-pudding "^3.4.1"
-    get-stream "^4.0.0"
-    npm-registry-fetch "^3.8.0"
-
-libnpmpublish@^1.1.0, libnpmpublish@^1.1.1:
+libnpmpublish@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.1.tgz#ff0c6bb0b4ad2bda2ad1f5fba6760a4af37125f0"
   dependencies:
@@ -9672,23 +8945,6 @@ libnpmpublish@^1.1.0, libnpmpublish@^1.1.1:
     npm-registry-fetch "^3.8.0"
     semver "^5.5.1"
     ssri "^6.0.1"
-
-libnpmsearch@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.0.tgz#de05af47ada81554a5f64276a69599070d4a5685"
-  dependencies:
-    figgy-pudding "^3.5.1"
-    get-stream "^4.0.0"
-    npm-registry-fetch "^3.8.0"
-
-libnpmteam@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.1.tgz#ff704b1b6c06ea674b3b1101ac3e305f5114f213"
-  dependencies:
-    aproba "^2.0.0"
-    figgy-pudding "^3.4.1"
-    get-stream "^4.0.0"
-    npm-registry-fetch "^3.8.0"
 
 lint-staged@8.1.0:
   version "8.1.0"
@@ -9851,13 +9107,6 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
-
-lock-verify@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/lock-verify/-/lock-verify-2.0.2.tgz#148e4f85974915c9e3c34d694b7de9ecb18ee7a8"
-  dependencies:
-    npm-package-arg "^5.1.2 || 6"
-    semver "^5.4.1"
 
 lock@^0.1.2:
   version "0.1.4"
@@ -10943,11 +10192,7 @@ npm-lifecycle@^2.1.0:
     umask "^1.1.0"
     which "^1.3.1"
 
-npm-logical-tree@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz#44610141ca24664cad35d1e607176193fd8f5b88"
-
-"npm-package-arg@^4.0.0 || ^5.0.0 || ^6.0.0", "npm-package-arg@^5.1.2 || 6", npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
+"npm-package-arg@^4.0.0 || ^5.0.0 || ^6.0.0", npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
   version "6.1.0"
   resolved "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz#15ae1e2758a5027efb4c250554b85a737db7fcc1"
   dependencies:
@@ -10983,14 +10228,6 @@ npm-pick-manifest@^2.2.3:
     figgy-pudding "^3.5.1"
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
-
-npm-profile@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
-  dependencies:
-    aproba "^1.1.2 || 2"
-    figgy-pudding "^3.4.1"
-    npm-registry-fetch "^3.8.0"
 
 npm-registry-fetch@^3.8.0, npm-registry-fetch@^3.9.0:
   version "3.9.0"
@@ -11471,38 +10708,6 @@ package-json@^4.0.0:
     registry-auth-token "^3.0.1"
     registry-url "^3.0.3"
     semver "^5.1.0"
-
-pacote@^9.2.3:
-  version "9.4.1"
-  resolved "https://registry.npmjs.org/pacote/-/pacote-9.4.1.tgz#f0af2a52d241bce523d39280ac810c671db62279"
-  dependencies:
-    bluebird "^3.5.3"
-    cacache "^11.3.2"
-    figgy-pudding "^3.5.1"
-    get-stream "^4.1.0"
-    glob "^7.1.3"
-    lru-cache "^5.1.1"
-    make-fetch-happen "^4.0.1"
-    minimatch "^3.0.4"
-    minipass "^2.3.5"
-    mississippi "^3.0.0"
-    mkdirp "^0.5.1"
-    normalize-package-data "^2.4.0"
-    npm-package-arg "^6.1.0"
-    npm-packlist "^1.1.12"
-    npm-pick-manifest "^2.2.3"
-    npm-registry-fetch "^3.8.0"
-    osenv "^0.1.5"
-    promise-inflight "^1.0.1"
-    promise-retry "^1.1.1"
-    protoduck "^5.0.1"
-    rimraf "^2.6.2"
-    safe-buffer "^5.1.2"
-    semver "^5.6.0"
-    ssri "^6.0.1"
-    tar "^4.4.8"
-    unique-filename "^1.1.1"
-    which "^1.3.1"
 
 pacote@^9.5.0:
   version "9.5.0"
@@ -14092,6 +13297,7 @@ source-map@0.5.6:
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
   dependencies:
     amdefine ">=0.0.4"
 
@@ -14403,10 +13609,6 @@ stringify-object@^3.2.2:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-stringify-package@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz#e02828089333d7d45cd8c287c30aa9a13375081b"
-
 stringstream@0.0.6, stringstream@~0.0.4:
   version "0.0.6"
   resolved "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
@@ -14699,17 +13901,10 @@ tar-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^2.0.0, tar@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.2"
-    inherits "2"
-
-tar@^4, tar@^4.4.8:
+tar@>=4.4.2, tar@^2.0.0, tar@^2.2.1, tar@^4, tar@^4.4.8:
   version "4.4.8"
   resolved "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"


### PR DESCRIPTION
Resolving following audit issues:
- handlebars: by updating lerna to latest version
- tar: by adding a resolution to `package.json` because outdated versions are used by too many deps
  - https://github.com/npm/npm-lifecycle/issues/28
  - `docsify-cli > livereload > chokidar > fsevents > node-pre-gyp > tar`   
      `docsify-cli` seems outdated, not sure about `livereload`, the rest was updated pretty recently.  
      is there an easy way to see which dep is the problematic one?
- js-yaml: by adding a resolution to `package.json` till cosmiconfig released a fix version (again, yes. not their fault). Watching this now: https://github.com/davidtheclark/cosmiconfig/issues/183