### PR TITLE
fix: modify the parameters for the sander.readFile function (#448)

### DIFF
--- a/@commitlint/read/src/index.js
+++ b/@commitlint/read/src/index.js
@@ -59,7 +59,7 @@ async function getEditFilePath(top, edit) {
 		if (dotgitStats.isDirectory()) {
 			editFilePath = path.join(top, '.git/COMMIT_EDITMSG');
 		} else {
-			const gitFile = await sander.readFile(dotgitPath, { encoding: 'utf-8' });
+			const gitFile = await sander.readFile(dotgitPath, {encoding: 'utf-8'});
 			const relativeGitPath = gitFile.replace('gitdir: ', '').replace('\n', '');
 			editFilePath = path.resolve(top, relativeGitPath, 'COMMIT_EDITMSG');
 		}

--- a/@commitlint/read/src/index.js
+++ b/@commitlint/read/src/index.js
@@ -59,7 +59,7 @@ async function getEditFilePath(top, edit) {
 		if (dotgitStats.isDirectory()) {
 			editFilePath = path.join(top, '.git/COMMIT_EDITMSG');
 		} else {
-			const gitFile = await sander.readFile(dotgitPath, 'utf8');
+			const gitFile = await sander.readFile(dotgitPath, { encoding: 'utf-8' });
 			const relativeGitPath = gitFile.replace('gitdir: ', '').replace('\n', '');
 			editFilePath = path.resolve(top, relativeGitPath, 'COMMIT_EDITMSG');
 		}


### PR DESCRIPTION
# Fix this PR issue [#469](https://github.com/conventional-changelog/commitlint/pull/469)

## Description

check the [readme](https://github.com/Rich-Harris/sander) from the sander repo:
> The same is true for methods like readFile - whereas in node you can do fs.readFile('path/to/file.txt', 'utf-8') if you want to specify utf-8 encoding, with sander the final argument should be a {encoding: 'utf-8'} object.


So we should fix the usage like this:
```js
const gitFile = await sander.readFile(dotgitPath, { encoding: 'utf-8' });
```
