### PR TITLE
fix: load and copy config module without mutation

### DIFF
--- a/@commitlint/load/src/index.js
+++ b/@commitlint/load/src/index.js
@@ -24,7 +24,7 @@ export default async (seed = {}, options = {cwd: process.cwd()}) => {
 	const base = loaded.filepath ? path.dirname(loaded.filepath) : options.cwd;
 
 	// Merge passed config with file based options
-	const config = valid(merge(loaded.config, seed));
+	const config = valid(merge({}, loaded.config, seed));
 	const opts = merge(
 		{extends: [], rules: {}, formatter: '@commitlint/format'},
 		pick(config, 'extends', 'plugins', 'ignores', 'defaultIgnores')

--- a/@commitlint/load/src/index.test.js
+++ b/@commitlint/load/src/index.test.js
@@ -308,3 +308,15 @@ test('returns formatter name when unable to resolve from config directory', asyn
 		rules: {}
 	});
 });
+
+test('does not mutate config module reference', async t => {
+	const file = 'config/commitlint.config.js';
+	const cwd = await git.bootstrap('fixtures/specify-config-file');
+
+	const configPath = path.join(cwd, file);
+	const before = JSON.stringify(require(configPath));
+	await load({arbitraryField: true}, {cwd, file});
+	const after = JSON.stringify(require(configPath));
+
+	t.is(before, after);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`commitlint/load` uses `_.merge()` from lodash to combine properties from the "seed" config into the config module being loaded.  `merge()` mutates its first argument -- much like `Object.assign()` -- so a blank object can be prepended to the argument list to yield similar results while leaving the config module reference itself unmodified.

## Motivation and Context
Mutation of the reference loaded (and cached) by the built-in `require()` can have very surprising effects on otherwise unrelated consumers of the config.

## How Has This Been Tested?
A test was added that compares serializations of the config module from before and after loading.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
