### PR TITLE
fix: pass ignores from configuration in @commitlint/cli

### DIFF
--- a/@commitlint/cli/fixtures/ignores/commitlint.config.js
+++ b/@commitlint/cli/fixtures/ignores/commitlint.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	rules: {
+		'type-enum': [2, 'always', ['type']],
+		'scope-enum': [2, 'always', ['scope']],
+		'subject-empty': [2, 'never']
+	},
+	ignores: [
+		commit => {
+			return commit.includes('WIP');
+		}
+	]
+};

--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -146,13 +146,17 @@ async function main(options) {
 	const parserOpts = selectParserOpts(loaded.parserPreset);
 	const opts = {
 		parserOpts: {},
-		plugins: {}
+		plugins: {},
+		ignores: []
 	};
 	if (parserOpts) {
 		opts.parserOpts = parserOpts;
 	}
 	if (loaded.plugins) {
 		opts.plugins = loaded.plugins;
+	}
+	if (loaded.ignores) {
+		opts.ignores = loaded.ignores;
 	}
 	const format = loadFormatter(loaded, flags);
 

--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -306,6 +306,18 @@ test('should fail for invalid formatters from configuration', async t => {
 	t.is(actual.code, 1);
 });
 
+test('should skip linting if message matches ignores config', async t => {
+	const cwd = await git.bootstrap('fixtures/ignores');
+	const actual = await cli([], {cwd})('WIP');
+	t.is(actual.code, 0);
+});
+
+test('should not skip linting if message does not match ignores config', async t => {
+	const cwd = await git.bootstrap('fixtures/ignores');
+	const actual = await cli([], {cwd})('foo');
+	t.is(actual.code, 1);
+});
+
 test('should fail for invalid formatters from flags', async t => {
 	const cwd = await git.bootstrap('fixtures/custom-formatter');
 	const actual = await cli(['--format', 'through-flag'], {cwd})('foo: bar');


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
pass ignores from configuration to the linter

## Description
<!--- Describe your changes in detail -->
add `ignores` to the opts that get passed in to the lint function in @commitlint/cli

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `ignores` configuration property was not being used 

<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples
<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
	rules: {
		'type-enum': [2, 'always', ['type']],
		'scope-enum': [2, 'always', ['scope']],
		'subject-empty': [2, 'never']
	},
	ignores: [
		commit => {
			return commit.includes('WIP');
		}
	]
};
```

```sh
git commit -m "WIP"
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Wrote 2 tests and tried committing with the ignores 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
