### PR TITLE
fix: ignore empty commit messages #615

### DIFF
--- a/@commitlint/lint/src/lint.test.ts
+++ b/@commitlint/lint/src/lint.test.ts
@@ -5,9 +5,12 @@ test('throws without params', async () => {
 	await expect(error).rejects.toThrow('Expected a raw commit');
 });
 
-test('throws with empty message', async () => {
-	const error = (lint as any)('');
-	await expect(error).rejects.toThrow('Expected a raw commit');
+test('positive on empty message', async () => {
+	expect(await lint('')).toMatchObject({
+		valid: true,
+		errors: [],
+		warnings: []
+	});
 });
 
 test('positive on stub message and no rule', async () => {

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -36,9 +36,10 @@ export default async function lint(
 	}
 
 	// Parse the commit message
-	const parsed = message === ''
-		? { header: null, body: null, footer: null }
-		: await parse(message, undefined, opts.parserOpts);
+	const parsed =
+		message === ''
+			? {header: null, body: null, footer: null}
+			: await parse(message, undefined, opts.parserOpts);
 
 	if (
 		parsed.header === null &&

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -35,6 +35,21 @@ export default async function lint(
 
 	// Parse the commit message
 	const parsed = await parse(message, undefined, opts.parserOpts);
+
+	if (
+		parsed.header === null &&
+		parsed.body === null &&
+		parsed.footer === null
+	) {
+		// Commit is empty, skip
+		return {
+			valid: true,
+			errors: [],
+			warnings: [],
+			input: message
+		};
+	}
+
 	const allRules: Map<string, Rule<unknown> | Rule<never>> = new Map(
 		Object.entries(defaultRules)
 	);

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -36,7 +36,9 @@ export default async function lint(
 	}
 
 	// Parse the commit message
-	const parsed = await parse(message, undefined, opts.parserOpts);
+	const parsed = message === ''
+		? { header: null, body: null, footer: null }
+		: await parse(message, undefined, opts.parserOpts);
 
 	if (
 		parsed.header === null &&


### PR DESCRIPTION
bypass rules for completely empty commit messages (only of blank
lines/comments in message)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A commit consisting of only newlines and/or comments (i.e. an empty commit) will bypass any rules and return as a valid commit. Empty commit messages will cause git to abort the commit, unless the user has specified the `allow-empty-message` option. The code change in this pull request preserves all git behavior.

I believe this is just a fix, and _not_ a BREAKING CHANGE since it fixes an unintended error from occurring.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change fixes #615 - it allows users to abort a commit without an error. A standard way to abort a commit once in the commit editor is to write an empty file, or a file consisting of only newlines and comments. Before this change, a user would encounter an error from the linter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I added two test cases to `@commitlint/lint` test file. They test the cases where a commit messages consists only of comments or where the commit message contains only comments and newlines. 

I also manually tested several different commint message input files provided as input to `@commitlint/cli` command. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
