### PR TITLE
chore: centralize typescript and jest setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 lib/
 package.json.lerna_backup
 /*.iml
+tsconfig.tsbuildinfo

--- a/@commitlint/ensure/package.json
+++ b/@commitlint/ensure/package.json
@@ -3,16 +3,13 @@
   "version": "8.0.0",
   "description": "Lint your commit messages",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib/"
   ],
   "scripts": {
-    "build": "tsc",
     "deps": "dep-check",
-    "pkg": "pkg-check",
-    "start": "concurrently \"yarn test --watchAll\" \"yarn run watch\"",
-    "test": "jest",
-    "watch": "tsc -w"
+    "pkg": "pkg-check"
   },
   "engines": {
     "node": ">=4"
@@ -38,12 +35,7 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/utils": "^8.0.0",
-    "@types/jest": "24.0.15",
-    "concurrently": "3.5.1",
-    "globby": "10.0.1",
-    "jest": "24.8.0",
-    "ts-jest": "24.0.2",
-    "typescript": "3.5.2"
+    "globby": "10.0.1"
   },
   "dependencies": {
     "lodash": "4.17.11"

--- a/@commitlint/ensure/tsconfig.json
+++ b/@commitlint/ensure/tsconfig.json
@@ -1,22 +1,15 @@
 {
+	"extends": "../../tsconfig.shared.json",
 	"compilerOptions": {
-		"lib": [
-			"dom",
-			"es2015"
-		],
-		"rootDir": "src",
-		"outDir": "lib",
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"strict": true
+		"composite": true,
+		"rootDir": "./src",
+		"outDir": "./lib"
 	},
 	"include": [
 		"./src"
 	],
 	"exclude": [
-		"./src/**/*.test.ts"
+		"./src/**/*.test.ts",
+		"./lib/**/*"
 	]
 }

--- a/@commitlint/execute-rule/index.d.ts
+++ b/@commitlint/execute-rule/index.d.ts
@@ -1,1 +1,0 @@
-export * from './lib';

--- a/@commitlint/execute-rule/index.js
+++ b/@commitlint/execute-rule/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib');

--- a/@commitlint/execute-rule/package.json
+++ b/@commitlint/execute-rule/package.json
@@ -3,16 +3,13 @@
   "version": "8.0.0",
   "description": "Lint your commit messages",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib/"
   ],
   "scripts": {
-    "build": "tsc",
     "deps": "dep-check",
-    "pkg": "pkg-check",
-    "start": "concurrently \"yarn test --watchAll\" \"yarn run watch\"",
-    "test": "jest",
-    "watch": "tsc -w"
+    "pkg": "pkg-check"
   },
   "engines": {
     "node": ">=4"
@@ -41,9 +38,7 @@
     "@commitlint/utils": "^8.0.0",
     "@types/jest": "24.0.15",
     "@types/lodash": "4.14.134",
-    "concurrently": "3.5.1",
     "jest": "24.8.0",
-    "ts-jest": "24.0.2",
-    "typescript": "3.5.2"
+    "ts-jest": "24.0.2"
   }
 }

--- a/@commitlint/execute-rule/tsconfig.json
+++ b/@commitlint/execute-rule/tsconfig.json
@@ -1,22 +1,15 @@
 {
+	"extends": "../../tsconfig.shared.json",
 	"compilerOptions": {
-		"lib": [
-			"dom",
-			"es2015"
-		],
-		"rootDir": "src",
-		"outDir": "lib",
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"strict": true
+		"composite": true,
+		"rootDir": "./src",
+		"outDir": "./lib"
 	},
 	"include": [
 		"./src"
 	],
 	"exclude": [
-		"./src/**/*.test.ts"
+		"./src/**/*.test.ts",
+		"./lib/**/*"
 	]
 }

--- a/@commitlint/format/index.d.ts
+++ b/@commitlint/format/index.d.ts
@@ -1,1 +1,0 @@
-export * from './lib';

--- a/@commitlint/format/index.js
+++ b/@commitlint/format/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib');

--- a/@commitlint/format/package.json
+++ b/@commitlint/format/package.json
@@ -3,16 +3,13 @@
   "version": "8.0.0",
   "description": "Format commitlint reports",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib/"
   ],
   "scripts": {
-    "build": "tsc",
     "deps": "dep-check",
-    "pkg": "pkg-check --skip-import",
-    "start": "concurrently \"yarn test --watchAll\" \"yarn run watch\"",
-    "test": "jest",
-    "watch": "tsc -w"
+    "pkg": "pkg-check --skip-import"
   },
   "engines": {
     "node": ">=4"
@@ -38,11 +35,7 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/utils": "^8.0.0",
-    "@types/jest": "24.0.15",
     "@types/lodash": "4.14.134",
-    "concurrently": "3.5.1",
-    "jest": "24.8.0",
-    "ts-jest": "24.0.2",
     "typescript": "3.5.2",
     "lodash": "4.17.11"
   },

--- a/@commitlint/format/tsconfig.json
+++ b/@commitlint/format/tsconfig.json
@@ -1,15 +1,15 @@
 {
+	"extends": "../../tsconfig.shared.json",
 	"compilerOptions": {
-		"lib": ["dom", "es2015"],
-		"rootDir": "src",
-		"outDir": "lib",
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"strict": true
+		"composite": true,
+		"rootDir": "./src",
+		"outDir": "./lib"
 	},
-	"include": ["./src"],
-	"exclude": ["./src/**/*.test.ts"]
+	"include": [
+		"./src"
+	],
+	"exclude": [
+		"./src/**/*.test.ts",
+		"./lib/**/*"
+	]
 }

--- a/@commitlint/is-ignored/index.d.ts
+++ b/@commitlint/is-ignored/index.d.ts
@@ -1,1 +1,0 @@
-export * from './lib';

--- a/@commitlint/is-ignored/index.js
+++ b/@commitlint/is-ignored/index.js
@@ -1,2 +1,0 @@
-module.exports = require('./lib').default;
-module.exports.default = module.exports;

--- a/@commitlint/is-ignored/jest.config.js
+++ b/@commitlint/is-ignored/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-	preset: 'ts-jest',
-	testEnvironment: 'node'
-};

--- a/@commitlint/is-ignored/package.json
+++ b/@commitlint/is-ignored/package.json
@@ -2,16 +2,14 @@
   "name": "@commitlint/is-ignored",
   "version": "8.0.0",
   "description": "Lint your commit messages",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib/"
   ],
   "scripts": {
-    "build": "tsc",
     "deps": "dep-check",
-    "pkg": "pkg-check",
-    "start": "concurrently \"jest --watchAll\" \"tsc -w\"",
-    "test": "jest",
-    "watch": "tsc -w"
+    "pkg": "pkg-check"
   },
   "engines": {
     "node": ">=4"
@@ -38,15 +36,10 @@
   "devDependencies": {
     "@commitlint/parse": "8.0.0",
     "@commitlint/test": "8.0.0",
-    "@commitlint/utils": "8.0.0",
-    "@types/jest": "24.0.15",
-    "concurrently": "3.5.1",
-    "jest": "24.8.0",
-    "ts-jest": "24.0.2",
-    "typescript": "3.5.2"
+    "@commitlint/utils": "8.0.0"
   },
   "dependencies": {
-    "@types/semver": "6.0.0",
+    "@types/semver": "^6.0.1",
     "semver": "6.1.1"
   }
 }

--- a/@commitlint/is-ignored/src/defaults.ts
+++ b/@commitlint/is-ignored/src/defaults.ts
@@ -1,4 +1,4 @@
-import semver from 'semver';
+import * as semver from 'semver';
 
 export type Matcher = (commit: string) => boolean;
 

--- a/@commitlint/is-ignored/tsconfig.json
+++ b/@commitlint/is-ignored/tsconfig.json
@@ -1,22 +1,15 @@
 {
+	"extends": "../../tsconfig.shared.json",
 	"compilerOptions": {
-		"lib": [
-			"dom",
-			"es2015"
-		],
-		"rootDir": "src",
-		"outDir": "lib",
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"strict": true
+		"composite": true,
+		"rootDir": "./src",
+		"outDir": "./lib"
 	},
 	"include": [
 		"./src"
 	],
 	"exclude": [
-		"./src/**/*.test.ts"
+		"./src/**/*.test.ts",
+		"./lib/**/*"
 	]
 }

--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -3,15 +3,13 @@
   "version": "8.0.0",
   "description": "Lint your commit messages",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib/"
   ],
   "scripts": {
-    "build": "tsc",
     "deps": "dep-check",
-    "pkg": "pkg-check",
-    "start": "concurrently \"jest --watchAll\" \"tsc -w\"",
-    "test": "jest"
+    "pkg": "pkg-check"
   },
   "engines": {
     "node": ">=4"
@@ -38,13 +36,8 @@
   "devDependencies": {
     "@commitlint/parse": "^8.0.0",
     "@commitlint/utils": "^8.0.0",
-    "@types/jest": "24.0.15",
     "@types/lodash": "4.14.134",
-    "@types/resolve-from": "5.0.1",
-    "concurrently": "3.5.1",
-    "jest": "24.8.0",
-    "ts-jest": "24.0.2",
-    "typescript": "3.5.2"
+    "@types/resolve-from": "5.0.1"
   },
   "dependencies": {
     "@types/node": "^12.0.2",

--- a/@commitlint/resolve-extends/tsconfig.json
+++ b/@commitlint/resolve-extends/tsconfig.json
@@ -1,15 +1,15 @@
 {
+	"extends": "../../tsconfig.shared.json",
 	"compilerOptions": {
-		"lib": ["dom", "es2015"],
-		"rootDir": "src",
-		"outDir": "lib",
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"strict": true
+		"composite": true,
+		"rootDir": "./src",
+		"outDir": "./lib"
 	},
-	"include": ["./src"],
-	"exclude": ["./src/**/*.test.ts"]
+	"include": [
+		"./src"
+	],
+	"exclude": [
+		"./src/**/*.test.ts",
+		"./lib/**/*"
+	]
 }

--- a/@commitlint/to-lines/package.json
+++ b/@commitlint/to-lines/package.json
@@ -3,16 +3,13 @@
   "version": "8.0.0",
   "description": "Lint your commit messages",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib/"
   ],
   "scripts": {
-    "build": "tsc",
     "deps": "dep-check",
-    "pkg": "pkg-check",
-    "start": "concurrently \"yarn test --watchAll\" \"yarn run watch\"",
-    "test": "jest",
-    "watch": "tsc -w"
+    "pkg": "pkg-check"
   },
   "engines": {
     "node": ">=4"
@@ -38,11 +35,6 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/parse": "^8.0.0",
-    "@commitlint/utils": "^8.0.0",
-    "concurrently": "3.5.1",
-    "@types/jest": "24.0.15",
-    "jest": "24.8.0",
-    "ts-jest": "24.0.2",
-    "typescript": "3.5.2"
+    "@commitlint/utils": "^8.0.0"
   }
 }

--- a/@commitlint/to-lines/tsconfig.json
+++ b/@commitlint/to-lines/tsconfig.json
@@ -1,22 +1,15 @@
 {
+	"extends": "../../tsconfig.shared.json",
 	"compilerOptions": {
-		"lib": [
-			"dom",
-			"es2015"
-		],
-		"rootDir": "src",
-		"outDir": "lib",
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"strict": true
+		"composite": true,
+		"rootDir": "./src",
+		"outDir": "./lib"
 	},
 	"include": [
 		"./src"
 	],
 	"exclude": [
-		"./src/**/*.test.ts"
+		"./src/**/*.test.ts",
+		"./lib/**/*"
 	]
 }

--- a/@commitlint/top-level/index.d.ts
+++ b/@commitlint/top-level/index.d.ts
@@ -1,1 +1,0 @@
-export * from './lib';

--- a/@commitlint/top-level/index.js
+++ b/@commitlint/top-level/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib');

--- a/@commitlint/top-level/package.json
+++ b/@commitlint/top-level/package.json
@@ -3,15 +3,13 @@
   "version": "8.0.0",
   "description": "Lint your commit messages",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib/"
   ],
   "scripts": {
-    "build": "tsc",
     "deps": "dep-check",
-    "pkg": "pkg-check",
-    "start": "yarn watch",
-    "watch": "tsc -w"
+    "pkg": "pkg-check"
   },
   "babel": {
     "presets": [
@@ -42,12 +40,8 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/utils": "^8.0.0",
-    "@types/node": "12.0.8",
-    "babel-cli": "6.26.0",
-    "babel-preset-commitlint": "^8.0.0",
-    "babel-register": "6.26.0",
-    "cross-env": "5.1.1",
-    "typescript": "3.5.2"
+    "@types/find-up": "^2.1.1",
+    "@types/node": "12.0.8"
   },
   "dependencies": {
     "find-up": "^4.0.0"

--- a/@commitlint/top-level/src/index.ts
+++ b/@commitlint/top-level/src/index.ts
@@ -1,6 +1,13 @@
 import path from 'path';
 import up from 'find-up';
 
+declare module 'find-up' {
+	interface Options {
+		cwd?: string;
+		type?: 'file' | 'directory';
+	}
+}
+
 export default toplevel;
 
 /**

--- a/@commitlint/top-level/tsconfig.json
+++ b/@commitlint/top-level/tsconfig.json
@@ -1,22 +1,15 @@
 {
+	"extends": "../../tsconfig.shared.json",
 	"compilerOptions": {
-		"lib": [
-			"dom",
-			"es2015"
-		],
-		"rootDir": "src",
-		"outDir": "lib",
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"strict": true
+		"composite": true,
+		"rootDir": "./src",
+		"outDir": "./lib"
 	},
 	"include": [
 		"./src"
 	],
 	"exclude": [
-		"./src/**/*.test.ts"
+		"./src/**/*.test.ts",
+		"./lib/**/*"
 	]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	testRegex: undefined,
+	testMatch: ['**/*.test.ts?(x)']
+};

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "lerna run build --stream --parallel --include-filtered-dependencies",
+    "build": "tsc -b && lerna run build --stream --parallel --include-filtered-dependencies",
     "watch": "lerna run watch --stream --parallel --include-filtered-dependencies",
-    "clean": "lerna clean --yes && lerna exec 'git clean -xdf lib' && git clean -xdf node_modules",
+    "clean": "tsc -b --clean && lerna clean --yes && lerna exec 'git clean -xdf lib' && git clean -xdf node_modules",
     "commit": "node @commitlint/prompt-cli/cli.js",
     "deps": "lerna run deps",
     "pkg": "lerna run pkg",
@@ -16,7 +16,7 @@
     "publish": "lerna publish --conventional-commits",
     "reinstall": "yarn clean && yarn install",
     "start": "lerna run start --stream --parallel --include-filtered-dependencies",
-    "test": "lerna run test --stream --parallel --include-filtered-dependencies"
+    "test": "jest && lerna run test --stream --parallel --include-filtered-dependencies"
   },
   "commitlint": {
     "extends": [
@@ -83,11 +83,15 @@
   },
   "devDependencies": {
     "@lerna/project": "3.15.0",
+    "@types/jest": "24.0.15",
     "docsify-cli": "4.3.0",
     "husky": "2.4.0",
+    "jest": "24.8.0",
     "lerna": "3.15.0",
     "lint-staged": "8.2.1",
-    "prettier": "1.17.1"
+    "prettier": "1.17.1",
+    "ts-jest": "24.0.2",
+    "typescript": "^3.5.2"
   },
   "husky": {
     "hooks": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "files": [],
+    "include": [],
+    "extends": "./tsconfig.shared.json",
+    "references": [
+        { "path": "@commitlint/ensure" },
+        { "path": "@commitlint/execute-rule" },
+        { "path": "@commitlint/format" },
+        { "path": "@commitlint/is-ignored" },
+        { "path": "@commitlint/resolve-extends" },
+        { "path": "@commitlint/to-lines" },
+        { "path": "@commitlint/top-level" },
+    ]
+}

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "lib": [
+            "es2015"
+        ],
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,6 +1239,11 @@
   resolved "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/find-up@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@types/find-up/-/find-up-2.1.1.tgz#1cd2d240f1ad1f48d32346074724dc3107248a11"
+  integrity sha512-60LC501bQRN9/3yfVaEEMd7IndaufffL56PBRAejPpUrY304Ps1jfnjNqPw5jmM5R8JHWiKBAe5IHzNcPV41AA==
+
 "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
@@ -1312,10 +1317,10 @@
   dependencies:
     resolve-from "*"
 
-"@types/semver@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/@types/semver/-/semver-6.0.0.tgz#86ba89f02a414e39c68d02b351872e4ed31bd773"
-  integrity sha512-OO0srjOGH99a4LUN2its3+r6CBYcplhJ466yLqs+zvAWgphCpS8hYZEZ797tRDP/QKcqTdb/YCN6ifASoAWkrQ==
+"@types/semver@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/@types/semver/-/semver-6.0.1.tgz#a984b405c702fa5a7ec6abc56b37f2ba35ef5af6"
+  integrity sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -10824,7 +10829,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.5.2:
+typescript@3.5.2, typescript@^3.5.2:
   version "3.5.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
   integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==


### PR DESCRIPTION
Centralize TypeScript and jest setups. Doing this primarily to avoid memory issues on CircleCI.