### PR TITLE
fix: pass defaultIgnores from configuration in @commitlint/cli

### DIFF
--- a/@commitlint/cli/fixtures/default-ignores-false/commitlint.config.js
+++ b/@commitlint/cli/fixtures/default-ignores-false/commitlint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	defaultIgnores: false,
+	rules: {
+		'subject-empty': [2, 'never']
+	}
+};

--- a/@commitlint/cli/fixtures/default-ignores-true/commitlint.config.js
+++ b/@commitlint/cli/fixtures/default-ignores-true/commitlint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	defaultIgnores: true,
+	rules: {
+		'subject-empty': [2, 'never']
+	}
+};

--- a/@commitlint/cli/fixtures/default-ignores-unset/commitlint.config.js
+++ b/@commitlint/cli/fixtures/default-ignores-unset/commitlint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	rules: {
+		'subject-empty': [2, 'never']
+	}
+};

--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -147,7 +147,8 @@ async function main(options) {
 	const opts = {
 		parserOpts: {},
 		plugins: {},
-		ignores: []
+		ignores: [],
+		defaultIgnores: false
 	};
 	if (parserOpts) {
 		opts.parserOpts = parserOpts;
@@ -157,6 +158,9 @@ async function main(options) {
 	}
 	if (loaded.ignores) {
 		opts.ignores = loaded.ignores;
+	}
+	if (loaded.defaultIgnores) {
+		opts.defaultIgnores = loaded.defaultIgnores;
 	}
 	const format = loadFormatter(loaded, flags);
 

--- a/@commitlint/cli/src/cli.js
+++ b/@commitlint/cli/src/cli.js
@@ -148,7 +148,7 @@ async function main(options) {
 		parserOpts: {},
 		plugins: {},
 		ignores: [],
-		defaultIgnores: false
+		defaultIgnores: true
 	};
 	if (parserOpts) {
 		opts.parserOpts = parserOpts;
@@ -159,8 +159,8 @@ async function main(options) {
 	if (loaded.ignores) {
 		opts.ignores = loaded.ignores;
 	}
-	if (loaded.defaultIgnores) {
-		opts.defaultIgnores = loaded.defaultIgnores;
+	if (loaded.defaultIgnores === false) {
+		opts.defaultIgnores = false;
 	}
 	const format = loadFormatter(loaded, flags);
 

--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -321,13 +321,19 @@ test('should not skip linting if message does not match ignores config', async t
 test('should not skip linting if defaultIgnores is false', async t => {
 	const cwd = await git.bootstrap('fixtures/default-ignores-false');
 	const actual = await cli([], {cwd})('fixup! foo: bar');
-	t.is(actual.code, 0);
+	t.is(actual.code, 1);
 });
 
 test('should skip linting if defaultIgnores is true', async t => {
-	const cwd = await git.bootstrap('fixtures/default-ignores-false');
+	const cwd = await git.bootstrap('fixtures/default-ignores-true');
 	const actual = await cli([], {cwd})('fixup! foo: bar');
-	t.is(actual.code, 1);
+	t.is(actual.code, 0);
+});
+
+test('should skip linting if defaultIgnores is unset', async t => {
+	const cwd = await git.bootstrap('fixtures/default-ignores-unset');
+	const actual = await cli([], {cwd})('fixup! foo: bar');
+	t.is(actual.code, 0);
 });
 
 test('should fail for invalid formatters from flags', async t => {

--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -318,6 +318,18 @@ test('should not skip linting if message does not match ignores config', async t
 	t.is(actual.code, 1);
 });
 
+test('should not skip linting if defaultIgnores is false', async t => {
+	const cwd = await git.bootstrap('fixtures/default-ignores-false');
+	const actual = await cli([], {cwd})('fixup! foo: bar');
+	t.is(actual.code, 0);
+});
+
+test('should skip linting if defaultIgnores is true', async t => {
+	const cwd = await git.bootstrap('fixtures/default-ignores-false');
+	const actual = await cli([], {cwd})('fixup! foo: bar');
+	t.is(actual.code, 1);
+});
+
 test('should fail for invalid formatters from flags', async t => {
 	const cwd = await git.bootstrap('fixtures/custom-formatter');
 	const actual = await cli(['--format', 'through-flag'], {cwd})('foo: bar');


### PR DESCRIPTION
pass defaultIgnores from configuration to the linter

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `defaultIgnores` to the opts that get passed in to the lint function in @commitlint/cli

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/conventional-changelog/commitlint/issues/769 - CLI users can't opt out of default ignore rules.

## Usage examples
<!--- Provide examples of intended usage -->
```js
// commitlint.config.js
module.exports = {
    defaultIgnores: false,
	rules: {
		'subject-empty': [2, 'never']
    }
};
```

```sh
echo "fixup!" | commitlint -V
⧗   input: fixup!
✖   subject may not be empty [subject-empty]

✖   found 1 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint

```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Wrote 2 tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
