### PR TITLE
feat(rules): add regex support for [subject|header]-full-stop rules

### DIFF
--- a/@commitlint/rules/src/header-full-stop.js
+++ b/@commitlint/rules/src/header-full-stop.js
@@ -3,7 +3,9 @@ import message from '@commitlint/message';
 export default (parsed, when, value) => {
 	const {header} = parsed;
 	const negated = when === 'never';
-	const hasStop = header[header.length - 1] === value;
+	const stop = header[header.length - 1];
+	const hasStop =
+		value.length > 1 ? new RegExp(value, 'u').test(stop) : stop === value;
 
 	return [
 		negated ? !hasStop : hasStop,

--- a/@commitlint/rules/src/header-full-stop.test.js
+++ b/@commitlint/rules/src/header-full-stop.test.js
@@ -35,3 +35,27 @@ test('without against "never ." should succeed', async t => {
 	const expected = true;
 	t.is(actual, expected);
 });
+
+test('with against "always [\\.0-9]" should succeed', async t => {
+	const [actual] = check(await parsed.with, 'always', '[\\.0-9]');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with against "never [\\.0-9]" should fail', async t => {
+	const [actual] = check(await parsed.with, 'never', '[\\.0-9]');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('without against "always [\\.0-9]" should fail', async t => {
+	const [actual] = check(await parsed.without, 'always', '[\\.0-9]');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('without against "never [\\.0-9]" should succeed', async t => {
+	const [actual] = check(await parsed.without, 'never', '[\\.0-9]');
+	const expected = true;
+	t.is(actual, expected);
+});

--- a/@commitlint/rules/src/subject-full-stop.js
+++ b/@commitlint/rules/src/subject-full-stop.js
@@ -8,7 +8,9 @@ export default (parsed, when, value) => {
 	}
 
 	const negated = when === 'never';
-	const hasStop = input[input.length - 1] === value;
+	const stop = input[input.length - 1];
+	const hasStop =
+		value.length > 1 ? new RegExp(value, 'u').test(stop) : stop === value;
 
 	return [
 		negated ? !hasStop : hasStop,

--- a/@commitlint/rules/src/subject-full-stop.test.js
+++ b/@commitlint/rules/src/subject-full-stop.test.js
@@ -49,3 +49,27 @@ test('without against "never ." should succeed', async t => {
 	const expected = true;
 	t.is(actual, expected);
 });
+
+test('with against "always [\\.0-9]" should succeed', async t => {
+	const [actual] = check(await parsed.with, 'always', '[\\.0-9]');
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('with against "never [\\.0-9]" should fail', async t => {
+	const [actual] = check(await parsed.with, 'never', '[\\.0-9]');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('without against "always [\\.0-9]" should fail', async t => {
+	const [actual] = check(await parsed.without, 'always', '[\\.0-9]');
+	const expected = false;
+	t.is(actual, expected);
+});
+
+test('without against "never [\\.0-9]" should succeed', async t => {
+	const [actual] = check(await parsed.without, 'never', '[\\.0-9]');
+	const expected = true;
+	t.is(actual, expected);
+});

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -111,11 +111,12 @@ Rule configurations are either of type `array` residing on a key with the rule's
 ```
 
 #### header-full-stop
-* **condition**: `header` ends with `value`
+* **condition**: `header` ends with `value` or `header`'s last character matches `value` string regexp
 * **rule**: `never`
-* **value**
+* **possible values**
 ```js
-  '.'
+  '.' // default
+  '[\\.0-9]' // any string regexp to match with last character
 ```
 
 #### header-max-length
@@ -211,11 +212,12 @@ Rule configurations are either of type `array` residing on a key with the rule's
 * **rule**: `never`
 
 #### subject-full-stop
-* **condition**: `subject` ends with `value`
+* **condition**: `subject` ends with `value` or `subject`'s last character matches `value` string regexp
 * **rule**: `never`
-* **value**
+* **possible values**
 ```js
-  '.'
+  '.' // default
+  '[\\.0-9]' // any string regexp to match with last character
 ```
 
 #### subject-max-length


### PR DESCRIPTION
## Description 

This allows usage of string regular expressions as `value` for `subject-full-stop` and `header-full-stop` rules. 

## Motivation and Context
We, internally, allow a range of stops. The current rule, however, allows providing one stop character which is restrictive, at least, in our use-case.

Yet, I'm not sure if it's a better fit for a plugin or the core. 

## Usage examples
```js
// commitlint.config.js
module.exports = {
  rules: {
    'subject-full-stop': [2, 'always', '[\\.0-9]'],
    'header-full-stop': [2, 'always', '[\\.0-9]']
  }
};
```

```sh
# subject
echo "test: subject" | commitlint # fails
echo "test: subject." | commitlint # passes
echo "test: subject #42" | commitlint # passes
echo "test: subject #420" | commitlint # passes

# header
echo "header" | commitlint # fails
echo "header." | commitlint # passes
echo "header #42" | commitlint # passes
echo "header #420" | commitlint # passes
```

## How Has This Been Tested?  
By adding new test cases.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.