### PR TITLE
feat(rules): add subject-matches & header-matches rules

### DIFF
--- a/@commitlint/rules/src/header-matches.js
+++ b/@commitlint/rules/src/header-matches.js
@@ -1,0 +1,16 @@
+import message from '@commitlint/message';
+
+export default (parsed, when, value) => {
+	const {header} = parsed;
+	const negated = when === 'never';
+	const matches = new RegExp(value, 'u').test(header);
+
+	return [
+		negated !== matches,
+		message([
+			'header',
+			negated ? 'may not' : 'must',
+			'match the given regex pattern'
+		])
+	];
+};

--- a/@commitlint/rules/src/header-matches.test.js
+++ b/@commitlint/rules/src/header-matches.test.js
@@ -1,0 +1,18 @@
+import test from 'ava';
+import parse from '@commitlint/parse';
+import check from './header-matches';
+
+const parsed = parse('Header. #42\n');
+const pattern = '^[A-Z]{1}.+\\.(\\s#\\d+)?$';
+
+test('checks header against "always match" rule', async t => {
+	const [actual] = check(await parsed, 'always', pattern);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('checks header against "never match" rule', async t => {
+	const [actual] = check(await parsed, 'never', pattern);
+	const expected = false;
+	t.is(actual, expected);
+});

--- a/@commitlint/rules/src/index.js
+++ b/@commitlint/rules/src/index.js
@@ -25,6 +25,7 @@ export default {
 	'subject-case': require('./subject-case'),
 	'subject-empty': require('./subject-empty'),
 	'subject-full-stop': require('./subject-full-stop'),
+	'subject-matches': require('./subject-matches'),
 	'subject-max-length': require('./subject-max-length'),
 	'subject-min-length': require('./subject-min-length'),
 	'type-case': require('./type-case'),

--- a/@commitlint/rules/src/index.js
+++ b/@commitlint/rules/src/index.js
@@ -12,6 +12,7 @@ export default {
 	'footer-min-length': require('./footer-min-length'),
 	'header-case': require('./header-case'),
 	'header-full-stop': require('./header-full-stop'),
+	'header-matches': require('./header-matches'),
 	'header-max-length': require('./header-max-length'),
 	'header-min-length': require('./header-min-length'),
 	'references-empty': require('./references-empty'),

--- a/@commitlint/rules/src/subject-matches.js
+++ b/@commitlint/rules/src/subject-matches.js
@@ -1,0 +1,16 @@
+import message from '@commitlint/message';
+
+export default (parsed, when, value) => {
+	const {subject} = parsed;
+	const negated = when === 'never';
+	const matches = new RegExp(value, 'u').test(subject);
+
+	return [
+		negated !== matches,
+		message([
+			'subject',
+			negated ? 'may not' : 'must',
+			'match the given regex pattern'
+		])
+	];
+};

--- a/@commitlint/rules/src/subject-matches.test.js
+++ b/@commitlint/rules/src/subject-matches.test.js
@@ -1,0 +1,18 @@
+import test from 'ava';
+import parse from '@commitlint/parse';
+import check from './subject-matches';
+
+const parsed = parse('feat(scope): Header. #42\n');
+const pattern = '^[A-Z]{1}.+\\.(\\s#\\d+)?$';
+
+test('checks subject against "always match" rule', async t => {
+	const [actual] = check(await parsed, 'always', pattern);
+	const expected = true;
+	t.is(actual, expected);
+});
+
+test('checks subject against "never match" rule', async t => {
+	const [actual] = check(await parsed, 'never', pattern);
+	const expected = false;
+	t.is(actual, expected);
+});

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -118,6 +118,14 @@ Rule configurations are either of type `array` residing on a key with the rule's
   '.'
 ```
 
+#### header-matches
+* **condition**: `header` matches the `value` string regexp
+* **rule**: `always`
+* **value**
+```js
+  '^(Feat|Bug):\\s[A-Z]{1}.+\\.(\\s#\\d+)?$'
+```
+
 #### header-max-length
 * **condition**: `header` has `value` or less characters
 * **rule**: `always`

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -226,6 +226,14 @@ Rule configurations are either of type `array` residing on a key with the rule's
   '.'
 ```
 
+#### subject-matches
+* **condition**: `subject` matches the `value` string regexp
+* **rule**: `always`
+* **value**
+```js
+  '^\\s[A-Z]{1}.+\\.(\\s#\\d+)?$'
+```
+
 #### subject-max-length
 * **condition**: `subject` has `value` or less characters
 * **rule**: `always`


### PR DESCRIPTION
## Description
This brings two additional rules to the table; `header-matches` and `subject-matches` which are given a string regex to match against the header and subject respectively.

## Motivation and Context
The motivation behind this is more about ease-of-use when granular customization is needed. While I'm sure, the same goal can be achieved using custom parsers, I found myself not wanting to redefine headers and subjects in parser presets. I just needed more customization power. 

While this might suit a plugin, I felt like it could also be a good fit for core rules as it opens up endless possibilities for customization. 

## Usage examples
```js
// commitlint.config.js
module.exports = {
 'subject-matches': [2, 'always', '^[A-Z]{1}.+\\.(\\s#\\d+)?$'],
 'header-matches': [2, 'always', '^(Feat|Bug):\\s[A-Z]{1}.+\\.(\\s#\\d+)?$']
};
```

```sh
echo "Header. #420" | commitlint # passes
echo "header #420" | commitlint # fails
echo "Feat: Add new rules. #819" | commitlint # passes
```

## How Has This Been Tested?
Added new test suites.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.