### PR TITLE
feat(config-conventional): use parser with short breaking change support

### DIFF
--- a/@commitlint/config-conventional/index.js
+++ b/@commitlint/config-conventional/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+	parserPreset: 'conventional-changelog-conventionalcommits',
 	rules: {
 		'body-leading-blank': [1, 'always'],
 		'footer-leading-blank': [1, 'always'],

--- a/@commitlint/config-conventional/package.json
+++ b/@commitlint/config-conventional/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "devDependencies": {
-    "@commitlint/utils": "^8.2.0"
+    "@commitlint/utils": "^8.2.0",
+    "conventional-changelog-conventionalcommits": "^4.1.0"
   }
 }

--- a/@commitlint/config-conventional/package.json
+++ b/@commitlint/config-conventional/package.json
@@ -32,7 +32,9 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "devDependencies": {
-    "@commitlint/utils": "^8.2.0",
+    "@commitlint/utils": "^8.2.0"
+  },
+  "dependencies": {
     "conventional-changelog-conventionalcommits": "^4.1.0"
   }
 }

--- a/@commitlint/load/fixtures/parser-preset-factory/commitlint.config.js
+++ b/@commitlint/load/fixtures/parser-preset-factory/commitlint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	parserOpts: {
+		parserPreset: './conventional-changelog-factory'
+	}
+};

--- a/@commitlint/load/fixtures/parser-preset-factory/conventional-changelog-factory.js
+++ b/@commitlint/load/fixtures/parser-preset-factory/conventional-changelog-factory.js
@@ -1,0 +1,10 @@
+module.exports = Promise.resolve().then(
+	() =>
+		function factory() {
+			return {
+				parserOpts: {
+					headerPattern: /^(\w*)(?:\((.*)\))?-(.*)$/
+				}
+			};
+		}
+);

--- a/@commitlint/load/src/index.js
+++ b/@commitlint/load/src/index.js
@@ -33,11 +33,17 @@ export default async (seed = {}, options = {cwd: process.cwd()}) => {
 	// Resolve parserPreset key
 	if (typeof config.parserPreset === 'string') {
 		const resolvedParserPreset = resolveFrom(base, config.parserPreset);
+		let resolvedParserConfig = await require(resolvedParserPreset);
+
+		// Resolve loaded parser preset if its a factory
+		if (typeof resolvedParserConfig === 'function') {
+			resolvedParserConfig = await resolvedParserConfig();
+		}
 
 		config.parserPreset = {
 			name: config.parserPreset,
 			path: resolvedParserPreset,
-			parserOpts: (await require(resolvedParserPreset)).parserOpts
+			parserOpts: resolvedParserConfig.parserOpts
 		};
 	}
 

--- a/@commitlint/load/src/index.test.js
+++ b/@commitlint/load/src/index.test.js
@@ -84,6 +84,20 @@ test('uses seed with parserPreset', async t => {
 	});
 });
 
+test('uses seed with parserPreset factory', async t => {
+	const cwd = await git.bootstrap('fixtures/parser-preset-factory');
+	const {parserPreset: actual} = await load(
+		{
+			parserPreset: './conventional-changelog-factory'
+		},
+		{cwd}
+	);
+	t.is(actual.name, './conventional-changelog-factory');
+	t.deepEqual(actual.parserOpts, {
+		headerPattern: /^(\w*)(?:\((.*)\))?-(.*)$/
+	});
+});
+
 test('invalid extend should throw', async t => {
 	const cwd = await git.bootstrap('fixtures/extends-invalid');
 	await t.throws(load({}, {cwd}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,6 +3707,14 @@ conventional-changelog-angular@^5.0.3:
     compare-func "^1.3.1"
     q "^1.5.1"
 
+conventional-changelog-conventionalcommits@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.1.0.tgz#eb7d47a9c5f1a6f9846a649482294e4ac50d7683"
+  integrity sha512-J3xolGrH8PTxpCqueHOuZtv3Cp73SQOWiBQzlsaugZAZ+hZgcJBonmC+1bQbfGs2neC2S18p2L1Gx+nTEglJTQ==
+  dependencies:
+    compare-func "^1.3.1"
+    q "^1.5.1"
+
 conventional-changelog-core@^3.1.6:
   version "3.1.6"
   resolved "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz#ac1731a461c50d150d29c1ad4f33143293bcd32f"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Related to PR #767 and discussion #658, but only includes the new parser. The configuration itself is not changed to avoid breaking changes.

## Motivation and Context
The new short breaking change (`!`) is part of the specification now and should be implemented by the conventional configuration. It's been a long-awaited feature but required additional changes because the parser is wrapped in another promise/factory.

We might consider setting this parser as a fallback parser in the configuration. But that also changes the other configuration. I'm not sure if they updated their specifications and include the short breaking change.

## Usage examples
<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
	parserPreset: 'conventional-changelog-conventionalcommits',
};
```

```sh
echo "fix!: this fix is a breaking change" | commitlint
```

## How Has This Been Tested?
Added an extra factory test in the `@commitlint/load`. This tests the new "factory"-preset.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
