### PR TITLE
feat(resolve-extends): accept absolute path in extends

### DIFF
--- a/@commitlint/resolve-extends/src/index.test.ts
+++ b/@commitlint/resolve-extends/src/index.test.ts
@@ -101,6 +101,22 @@ test('ignores prefix for relative extends', () => {
 	expect(ctx.require).toHaveBeenCalledWith('./extender');
 });
 
+test('ignores prefix for absolute extends', () => {
+	const absolutePath = require.resolve('@commitlint/config-angular');
+	const input = {extends: [absolutePath]};
+	const ctx = {
+		resolve: id,
+		require: jest.fn(() => ({}))
+	} as ResolveExtendsContext;
+
+	resolveExtends(input, {
+		...ctx,
+		prefix: 'prefix'
+	});
+
+	expect(ctx.require).toHaveBeenCalledWith(absolutePath);
+});
+
 test('propagates return value of require function', () => {
 	const input = {extends: ['extender-name']};
 	const propagated = {foo: 'bar'};

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -82,12 +82,13 @@ function getId(raw: string = '', prefix: string = ''): string {
 	const first = raw.charAt(0);
 	const scoped = first === '@';
 	const relative = first === '.';
+	const absolute = path.isAbsolute(raw);
 
 	if (scoped) {
 		return raw.includes('/') ? raw : [raw, prefix].filter(String).join('/');
 	}
 
-	return relative ? raw : [prefix, raw].filter(String).join('-');
+	return relative || absolute ? raw : [prefix, raw].filter(String).join('-');
 }
 
 function resolveConfig<T>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Extended `resolve-extends` to accept absolute file paths

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using Yarn PnP the items in the `extends` array is provided using `require.resolve`, which currently doesn't work as `resolve-extends` adds a preset to the path

## Usage examples
<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  extends: [require.resolve('@commitlint/config-conventional')],
};
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Copied the `ignores prefix for relative extends` test but using an absolute path instead

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] ~All new and existing tests passed.~ New test passes, master fails on existing test
