### PR TITLE
fix(load): add support for non-factory conventional parsers

### DIFF
--- a/@commitlint/load/fixtures/parser-preset-conventional-without-factory/commitlint.config.js
+++ b/@commitlint/load/fixtures/parser-preset-conventional-without-factory/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	parserPreset: 'conventional-changelog-conventionalcommits'
+};

--- a/@commitlint/load/fixtures/parser-preset-conventional-without-factory/package.json
+++ b/@commitlint/load/fixtures/parser-preset-conventional-without-factory/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "parser-preset-conventional-without-factory",
+    "version": "1.0.0",
+    "devDependencies": {
+        "conventional-changelog-conventionalcommits": "4.1.0"
+    }
+}

--- a/@commitlint/load/src/index.js
+++ b/@commitlint/load/src/index.js
@@ -137,9 +137,17 @@ async function loadParserOpts(parserName, pendingParser) {
 		startsWith(parserName, 'conventional-changelog-')
 	) {
 		return await new Promise(resolve => {
-			parser.parserOpts((_, opts) => {
+			const result = parser.parserOpts((_, opts) => {
 				resolve(opts.parserOpts);
 			});
+
+			// If result has data or a promise, the parser doesn't support factory-init
+			// due to https://github.com/nodejs/promises-debugging/issues/16 it just quits, so let's use this fallback
+			if (result) {
+				Promise.resolve(result).then(opts => {
+					resolve(opts.parserOpts);
+				});
+			}
 		});
 	}
 

--- a/@commitlint/load/src/index.test.js
+++ b/@commitlint/load/src/index.test.js
@@ -368,3 +368,17 @@ test('recursive resolves parser preset from conventional atom', async t => {
 	t.is(typeof actual.parserPreset.parserOpts, 'object');
 	t.deepEqual(actual.parserPreset.parserOpts.headerPattern, /^(:.*?:) (.*)$/);
 });
+
+test('resolves parser preset from conventional commits without factory support', async t => {
+	const cwd = await npm.bootstrap(
+		'fixtures/parser-preset-conventional-without-factory'
+	);
+	const actual = await load({}, {cwd});
+
+	t.is(actual.parserPreset.name, 'conventional-changelog-conventionalcommits');
+	t.is(typeof actual.parserPreset.parserOpts, 'object');
+	t.deepEqual(
+		actual.parserPreset.parserOpts.headerPattern,
+		/^(\w*)(?:\((.*)\))?!?: (.*)$/
+	);
+});


### PR DESCRIPTION
## Description
It's kind of weird how Node exits randomly, without proper warnings/errors, when a Promise is never resolved. This happened because the [older conventional-changelog-conventionalcommits](https://github.com/conventional-changelog/conventional-changelog/blob/dadbbf8b1acbe4b3a8f345633bde3f4a4ad0bea4/packages/conventional-changelog-conventionalcommits/index.js) is used. This adds a fallback-support for when this happens instead of just quitting.

## ~~Motivation and Context~~

## ~~Usage examples~~

## How Has This Been Tested?
Added a special test for older parser presets that do not support the callback-factory.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
