### PR TITLE
docs: add `ngx-semantic-version` to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ is room and need for improvement. The items on the roadmap should enhance `commi
 * [commitizen](https://git.io/vwTym) – Simple commit conventions for internet citizens
 * [create-semantic-module](https://git.io/vFjFg) – CLI for quickly integrating commitizen and commitlint in new or existing projects
 * [commitlint.io](https://github.com/tomasen/commitlintio) - helps your project to ensures nice and tidy commit messages without needing any download or installation
+* [ngx-semantic-version](https://github.com/d-koppenhagen/ngx-semantic-version) - Quickly integrate commitizen, commitlint, husky and standard-version in your Angular project
 
 ## License
 Copyright by @marionebl. All `commitlint` packages are released under the MIT license.


### PR DESCRIPTION
add `ngx-semantic-version` to the related projects section in `README.md`

## Description
The project `ngx-semantic-version` will add and configure commitlint, commitizen, husky and stanrd-version to an existing Angular project using the Angular Schematics.

## Motivation and Context
Quickly add commitlint, commitizen & Co. configs to an Angular project with minimum effort.

## Usage examples

```js
ng add ngx-semantic-version
```

## How Has This Been Tested?
just improves the docs, no tests needed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
