### PR TITLE
fix: #874 types node as dev dependency

### DIFF
--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -37,10 +37,10 @@
     "@commitlint/parse": "^8.3.2",
     "@commitlint/utils": "^8.3.0",
     "@types/lodash": "4.14.144",
+    "@types/node": "^12.12.22",
     "@types/resolve-from": "5.0.1"
   },
   "dependencies": {
-    "@types/node": "^12.0.2",
     "import-fresh": "^3.0.0",
     "lodash": "4.17.15",
     "resolve-from": "^5.0.0",


### PR DESCRIPTION
Fix #874 `@types/node` as dev dependency.

## Description
Move `@types/node` from dependency to dev dependency list with an update to the latest ^12 version.

## Motivation and Context
#874 as issue describes there is possibility to have colliding `@types/node` versions which cause an error in typescript build.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Created link to private repo and tested with typescript build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
