### PR TITLE
fix: read correct `package.json` with `read-pkg.sync`

### DIFF
--- a/@alias/commitlint/cli.js
+++ b/@alias/commitlint/cli.js
@@ -4,7 +4,7 @@ const resolvePkg = require('resolve-pkg');
 const readPkg = require('read-pkg');
 
 const pkgDir = resolvePkg('@commitlint/cli', {cwd: __dirname});
-const manifest = readPkg.sync(path.join(pkgDir, 'package.json'));
+const manifest = readPkg.sync({cwd: pkgDir});
 const bin = path.join(pkgDir, manifest.bin.commitlint);
 
 require(bin);

--- a/@packages/utils/pkg-check.js
+++ b/@packages/utils/pkg-check.js
@@ -43,7 +43,7 @@ function main(cli) {
 	const skipImport =
 		typeof cli.flags.skipImport === 'boolean' ? cli.flags.skipImport : false;
 
-	return readPkg(cwd).then(pkg => {
+	return readPkg({cwd: cwd}).then(pkg => {
 		return getTarballFiles(cwd, {write: !skipImport}).then(tarball => {
 			return getPackageFiles(cwd).then(pkgFiles => {
 				let problems = [];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This corrects the `read-pkg.sync()` usage, providing the current working directory in the argument format `read-pkg.sync()` expects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #887.

The `read-pkg` dependency upgrade (a876fb88) to `v5.2.0` introduced an issue because `read-pkg.sync`'s API introduced a breaking change.  In v3.0.0 `read-pkg.sync()` accepts the filepath as the first argument.  In v5.2.0, `read-pkg.sync()` accepts an object as its first argument, where the `cwd` key contains the filepath.  See [here](https://github.com/sindresorhus/read-pkg/compare/v3.0.0..v5.2.0#diff-168726dbe96b3ce427e7fedce31bb0bcL31-R31).

As `commitlint` did not provide a `cwd` key, the `read-pkg.sync()` defaults to reading `package.json` from the current working directory.

```sh
$ docker container run --rm -it --workdir /tmp node:lts /bin/bash
root@451ac1a044a3:/tmp# npm install -g @commitlint/config-conventional
+ @commitlint/config-conventional@8.3.3
added 8 packages from 9 contributors in 2.064s

root@451ac1a044a3:/tmp# echo "feat: example" | npx commitlint -x @commitlint/config-conventional
ENOENT: no such file or directory, open '/tmp/package.json'

root@451ac1a044a3:/tmp# echo "feat: example" | npx commitlint@8.2.0 -x @commitlint/config-conventional

root@451ac1a044a3:/tmp#
```

## Usage examples
<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  extends: ['@commitlint/config-conventional']
};
```

```sh
echo "FIX: some message" | commitlint # fails
echo "fix: some message" | commitlint # passes
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

After setting up the local development environment, I reproduced the issue against `master` in a temporary directory.  I then changed to the `fix-read-pkg-v5-usage` branch and re-ran the test case with success.

From within the git repository:

```sh
$ TMP_DIR="$(mktemp -d)"
$ git checkout master
$ (NODE_MODULES="$PWD"/node_modules; cd "$TMP_DIR"; echo "fix: some message" | "$NODE_MODULES"/.bin/commitlint -x "$NODE_MODULES"/@commitlint/config-conventional)
fs.js:125
    throw err;
    ^

Error: ENOENT: no such file or directory, open '/private/var/folders/hg/pn46533939vgwl3tc0ktm0vj8r095t/T/tmp.ZXkUozYH/package.json'
  ...
$ git checkout fix-read-pkg-v5-usage
$ (NODE_MODULES="$PWD"/node_modules; cd "$TMP_DIR"; echo "fix: some message" | "$NODE_MODULES"/.bin/commitlint -x "$NODE_MODULES"/@commitlint/config-conventional)
$
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
