### PR TITLE
config-conventional: drop support for 'improvement' type

### DIFF
--- a/@commitlint/config-conventional/index.js
+++ b/@commitlint/config-conventional/index.js
@@ -24,7 +24,6 @@ module.exports = {
 				'docs',
 				'feat',
 				'fix',
-				'improvement',
 				'perf',
 				'refactor',
 				'revert',


### PR DESCRIPTION
## Description
This removes the "improvement" type from the list of allowed types in `@commitlint/config-conventional`.

## Motivation and Context
Fixes https://github.com/conventional-changelog/commitlint/issues/898.

This reverts https://github.com/conventional-changelog/commitlint/pull/832.

## How Has This Been Tested?
Has not been tested (trivial change).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Tests and documentation were not changed in https://github.com/conventional-changelog/commitlint/pull/832.

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.