### PR TITLE
test(rules): migrate rules tests from ava to jest

### DIFF
--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -11,28 +11,7 @@
     "deps": "dep-check",
     "pkg": "pkg-check --skip-import",
     "start": "concurrently \"ava -c 4 --verbose --watch\" \"yarn run watch\"",
-    "test": "ava -c 4 --verbose",
     "watch": "babel src --out-dir lib --watch --source-maps"
-  },
-  "ava": {
-    "files": [
-      "src/**/*.test.js",
-      "!lib/**/*"
-    ],
-    "source": [
-      "src/**/*.js",
-      "!lib/**/*"
-    ],
-    "babel": {
-      "testOptions": {
-        "presets": [
-          "babel-preset-commitlint"
-        ]
-      }
-    },
-    "require": [
-      "@babel/register"
-    ]
   },
   "babel": {
     "presets": [
@@ -68,7 +47,6 @@
     "@commitlint/parse": "^8.3.4",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
-    "ava": "2.4.0",
     "babel-preset-commitlint": "^8.2.0",
     "concurrently": "3.6.1",
     "conventional-changelog-angular": "1.6.6",

--- a/@commitlint/rules/src/body-case.test.js
+++ b/@commitlint/rules/src/body-case.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import bodyCase from './body-case';
 
@@ -16,74 +15,74 @@ const parsed = {
 	uppercase: parse(messages.uppercase)
 };
 
-test('with empty body should succeed for "never lowercase"', async t => {
+test('with empty body should succeed for "never lowercase"', async () => {
 	const [actual] = bodyCase(await parsed.empty, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty body should succeed for "always lowercase"', async t => {
+test('with empty body should succeed for "always lowercase"', async () => {
 	const [actual] = bodyCase(await parsed.empty, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty body should succeed for "never uppercase"', async t => {
+test('with empty body should succeed for "never uppercase"', async () => {
 	const [actual] = bodyCase(await parsed.empty, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty body should succeed for "always uppercase"', async t => {
+test('with empty body should succeed for "always uppercase"', async () => {
 	const [actual] = bodyCase(await parsed.empty, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase body should fail for "never lowercase"', async t => {
+test('with lowercase body should fail for "never lowercase"', async () => {
 	const [actual] = bodyCase(await parsed.lowercase, 'never', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase body should succeed for "always lowercase"', async t => {
+test('with lowercase body should succeed for "always lowercase"', async () => {
 	const [actual] = bodyCase(await parsed.lowercase, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase body should succeed for "never lowercase"', async t => {
+test('with mixedcase body should succeed for "never lowercase"', async () => {
 	const [actual] = bodyCase(await parsed.mixedcase, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase body should fail for "always lowercase"', async t => {
+test('with mixedcase body should fail for "always lowercase"', async () => {
 	const [actual] = bodyCase(await parsed.mixedcase, 'always', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase body should succeed for "never uppercase"', async t => {
+test('with mixedcase body should succeed for "never uppercase"', async () => {
 	const [actual] = bodyCase(await parsed.mixedcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase body should fail for "always uppercase"', async t => {
+test('with mixedcase body should fail for "always uppercase"', async () => {
 	const [actual] = bodyCase(await parsed.mixedcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase body should fail for "never uppercase"', async t => {
+test('with uppercase body should fail for "never uppercase"', async () => {
 	const [actual] = bodyCase(await parsed.uppercase, 'never', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase body should succeed for "always uppercase"', async t => {
+test('with lowercase body should succeed for "always uppercase"', async () => {
 	const [actual] = bodyCase(await parsed.uppercase, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/body-empty.test.js
+++ b/@commitlint/rules/src/body-empty.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import bodyEmpty from './body-empty';
 
@@ -12,38 +11,38 @@ const parsed = {
 	filled: parse(messages.filled)
 };
 
-test('with empty body should succeed for empty keyword', async t => {
+test('with empty body should succeed for empty keyword', async () => {
 	const [actual] = bodyEmpty(await parsed.empty);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty body should fail for "never"', async t => {
+test('with empty body should fail for "never"', async () => {
 	const [actual] = bodyEmpty(await parsed.empty, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty body should succeed for "always"', async t => {
+test('with empty body should succeed for "always"', async () => {
 	const [actual] = bodyEmpty(await parsed.empty, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with body should fail for empty keyword', async t => {
+test('with body should fail for empty keyword', async () => {
 	const [actual] = bodyEmpty(await parsed.filled);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with body should succeed for "never"', async t => {
+test('with body should succeed for "never"', async () => {
 	const [actual] = bodyEmpty(await parsed.filled, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with body should fail for "always"', async t => {
+test('with body should fail for "always"', async () => {
 	const [actual] = bodyEmpty(await parsed.filled, 'always');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/body-leading-blank.test.js
+++ b/@commitlint/rules/src/body-leading-blank.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import bodyLeadingBlank from './body-leading-blank';
 
@@ -14,56 +13,56 @@ const parsed = {
 	with: parse(messages.with)
 };
 
-test('with simple message should succeed for empty keyword', async t => {
+test('with simple message should succeed for empty keyword', async () => {
 	const [actual] = bodyLeadingBlank(await parsed.simple);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with simple message should succeed for "never"', async t => {
+test('with simple message should succeed for "never"', async () => {
 	const [actual] = bodyLeadingBlank(await parsed.simple, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with simple message should succeed for "always"', async t => {
+test('with simple message should succeed for "always"', async () => {
 	const [actual] = bodyLeadingBlank(await parsed.simple, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without blank line before body should fail for empty keyword', async t => {
+test('without blank line before body should fail for empty keyword', async () => {
 	const [actual] = bodyLeadingBlank(await parsed.without);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without blank line before body should succeed for "never"', async t => {
+test('without blank line before body should succeed for "never"', async () => {
 	const [actual] = bodyLeadingBlank(await parsed.without, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without blank line before body should fail for "always"', async t => {
+test('without blank line before body should fail for "always"', async () => {
 	const [actual] = bodyLeadingBlank(await parsed.without, 'always');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with blank line before body should succeed for empty keyword', async t => {
+test('with blank line before body should succeed for empty keyword', async () => {
 	const [actual] = bodyLeadingBlank(await parsed.with);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with blank line before body should fail for "never"', async t => {
+test('with blank line before body should fail for "never"', async () => {
 	const [actual] = bodyLeadingBlank(await parsed.with, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with blank line before body should succeed for "always"', async t => {
+test('with blank line before body should succeed for "always"', async () => {
 	const [actual] = bodyLeadingBlank(await parsed.with, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/body-max-length.test.js
+++ b/@commitlint/rules/src/body-max-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './body-max-length';
 
@@ -19,20 +18,20 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should succeed', async t => {
+test('with short should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should fail', async t => {
+test('with long should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/body-max-line-length.test.js
+++ b/@commitlint/rules/src/body-max-line-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './body-max-line-length';
 
@@ -21,32 +20,32 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should succeed', async t => {
+test('with short should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should fail', async t => {
+test('with long should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short with multiple lines should succeed', async t => {
+test('with short with multiple lines should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long with multiple lines should fail', async t => {
+test('with long with multiple lines should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/body-min-length.test.js
+++ b/@commitlint/rules/src/body-min-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './body-min-length';
 
@@ -19,20 +18,20 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with simple should succeed', async t => {
+test('with simple should succeed', async () => {
 	const [actual] = check(await parsed.simple, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should fail', async t => {
+test('with short should fail', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should succeed', async t => {
+test('with long should succeed', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/footer-empty.test.js
+++ b/@commitlint/rules/src/footer-empty.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import footerEmpty from './footer-empty';
 
@@ -14,56 +13,56 @@ const parsed = {
 	filled: parse(messages.filled)
 };
 
-test('with simple message should succeed for empty keyword', async t => {
+test('with simple message should succeed for empty keyword', async () => {
 	const [actual] = footerEmpty(await parsed.simple);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with simple message should fail for "never"', async t => {
+test('with simple message should fail for "never"', async () => {
 	const [actual] = footerEmpty(await parsed.simple, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with simple message should succeed for "always"', async t => {
+test('with simple message should succeed for "always"', async () => {
 	const [actual] = footerEmpty(await parsed.simple, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty footer should succeed for empty keyword', async t => {
+test('with empty footer should succeed for empty keyword', async () => {
 	const [actual] = footerEmpty(await parsed.empty);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty footer should fail for "never"', async t => {
+test('with empty footer should fail for "never"', async () => {
 	const [actual] = footerEmpty(await parsed.empty, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty footer should succeed for "always"', async t => {
+test('with empty footer should succeed for "always"', async () => {
 	const [actual] = footerEmpty(await parsed.empty, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with footer should fail for empty keyword', async t => {
+test('with footer should fail for empty keyword', async () => {
 	const [actual] = footerEmpty(await parsed.filled);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with footer should succeed for "never"', async t => {
+test('with footer should succeed for "never"', async () => {
 	const [actual] = footerEmpty(await parsed.filled, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with footer should fail for "always"', async t => {
+test('with footer should fail for "always"', async () => {
 	const [actual] = footerEmpty(await parsed.filled, 'always');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/footer-leading-blank.test.js
+++ b/@commitlint/rules/src/footer-leading-blank.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import footerLeadingBlank from './footer-leading-blank';
 
@@ -26,134 +25,134 @@ const parsed = {
 	withDoubleNewLine: parse(messages.withDoubleNewLine)
 };
 
-test('with simple message should succeed for empty keyword', async t => {
+test('with simple message should succeed for empty keyword', async () => {
 	const [actual] = footerLeadingBlank(await parsed.simple);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with simple message should succeed for "never"', async t => {
+test('with simple message should succeed for "never"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.simple, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with simple message should succeed for "always"', async t => {
+test('with simple message should succeed for "always"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.simple, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with body message should succeed for empty keyword', async t => {
+test('with body message should succeed for empty keyword', async () => {
 	const [actual] = footerLeadingBlank(await parsed.body);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with body message should succeed for "never"', async t => {
+test('with body message should succeed for "never"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.body, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with body message should succeed for "always"', async t => {
+test('with body message should succeed for "always"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.body, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with trailing message should succeed for empty keyword', async t => {
+test('with trailing message should succeed for empty keyword', async () => {
 	const [actual] = footerLeadingBlank(await parsed.trailing);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with trailing message should succeed for "never"', async t => {
+test('with trailing message should succeed for "never"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.trailing, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with trailing message should succeed for "always"', async t => {
+test('with trailing message should succeed for "always"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.trailing, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without body should fail for "never"', async t => {
+test('without body should fail for "never"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.withoutBody, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without body should succeed for "always"', async t => {
+test('without body should succeed for "always"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.withoutBody, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without blank line before footer should fail for empty keyword', async t => {
+test('without blank line before footer should fail for empty keyword', async () => {
 	const [actual] = footerLeadingBlank(await parsed.without);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without blank line before footer should succeed for "never"', async t => {
+test('without blank line before footer should succeed for "never"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.without, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without blank line before footer should fail for "always"', async t => {
+test('without blank line before footer should fail for "always"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.without, 'always');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with blank line before footer should succeed for empty keyword', async t => {
+test('with blank line before footer should succeed for empty keyword', async () => {
 	const [actual] = footerLeadingBlank(await parsed.with);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with blank line before footer should fail for "never"', async t => {
+test('with blank line before footer should fail for "never"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.with, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with blank line before footer should succeed for "always"', async t => {
+test('with blank line before footer should succeed for "always"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.with, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with blank line before footer and multiline body should succeed for empty keyword', async t => {
+test('with blank line before footer and multiline body should succeed for empty keyword', async () => {
 	const [actual] = footerLeadingBlank(await parsed.withMulitLine);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with blank line before footer and multiline body should fail for "never"', async t => {
+test('with blank line before footer and multiline body should fail for "never"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.withMulitLine, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with blank line before footer and multiline body should succeed for "always"', async t => {
+test('with blank line before footer and multiline body should succeed for "always"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.withMulitLine, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with double blank line before footer and double line in body should fail for "never"', async t => {
+test('with double blank line before footer and double line in body should fail for "never"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.withDoubleNewLine, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with double blank line before footer and double line in body should succeed for "always"', async t => {
+test('with double blank line before footer and double line in body should succeed for "always"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.withDoubleNewLine, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/footer-max-length.test.js
+++ b/@commitlint/rules/src/footer-max-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './footer-max-length';
 
@@ -21,26 +20,26 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with simple should succeed', async t => {
+test('with simple should succeed', async () => {
 	const [actual] = check(await parsed.simple, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should succeed', async t => {
+test('with short should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should fail', async t => {
+test('with long should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/footer-max-line-length.test.js
+++ b/@commitlint/rules/src/footer-max-line-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './footer-max-line-length';
 
@@ -23,38 +22,38 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with simple should succeed', async t => {
+test('with simple should succeed', async () => {
 	const [actual] = check(await parsed.simple, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should succeed', async t => {
+test('with short should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should fail', async t => {
+test('with long should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short with multiple lines should succeed', async t => {
+test('with short with multiple lines should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long with multiple lines should fail', async t => {
+test('with long with multiple lines should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/footer-min-length.test.js
+++ b/@commitlint/rules/src/footer-min-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './footer-min-length';
 
@@ -21,26 +20,26 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with simple should succeed', async t => {
+test('with simple should succeed', async () => {
 	const [actual] = check(await parsed.simple, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should fail', async t => {
+test('with short should fail', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should succeed', async t => {
+test('with long should succeed', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/header-case.test.js
+++ b/@commitlint/rules/src/header-case.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import headerCase from './header-case';
 
@@ -26,293 +25,293 @@ const parsed = {
 	startcase: parse(messages.startcase)
 };
 
-test('with lowercase header should fail for "never lowercase"', async t => {
+test('with lowercase header should fail for "never lowercase"', async () => {
 	const [actual] = headerCase(await parsed.lowercase, 'never', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase header should succeed for "always lowercase"', async t => {
+test('with lowercase header should succeed for "always lowercase"', async () => {
 	const [actual] = headerCase(await parsed.lowercase, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase header should succeed for "never lowercase"', async t => {
+test('with mixedcase header should succeed for "never lowercase"', async () => {
 	const [actual] = headerCase(await parsed.mixedcase, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase header should fail for "always lowercase"', async t => {
+test('with mixedcase header should fail for "always lowercase"', async () => {
 	const [actual] = headerCase(await parsed.mixedcase, 'always', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase header should succeed for "never uppercase"', async t => {
+test('with mixedcase header should succeed for "never uppercase"', async () => {
 	const [actual] = headerCase(await parsed.mixedcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase header should fail for "always uppercase"', async t => {
+test('with mixedcase header should fail for "always uppercase"', async () => {
 	const [actual] = headerCase(await parsed.mixedcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase header should fail for "never uppercase"', async t => {
+test('with uppercase header should fail for "never uppercase"', async () => {
 	const [actual] = headerCase(await parsed.uppercase, 'never', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase header should succeed for "always uppercase"', async t => {
+test('with lowercase header should succeed for "always uppercase"', async () => {
 	const [actual] = headerCase(await parsed.uppercase, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase header should fail for "always uppercase"', async t => {
+test('with camelcase header should fail for "always uppercase"', async () => {
 	const [actual] = headerCase(await parsed.camelcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase header should succeed for "never uppercase"', async t => {
+test('with camelcase header should succeed for "never uppercase"', async () => {
 	const [actual] = headerCase(await parsed.camelcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase header should fail for "always pascalcase"', async t => {
+test('with camelcase header should fail for "always pascalcase"', async () => {
 	const [actual] = headerCase(await parsed.camelcase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase header should fail for "always kebabcase"', async t => {
+test('with camelcase header should fail for "always kebabcase"', async () => {
 	const [actual] = headerCase(await parsed.camelcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase header should fail for "always snakecase"', async t => {
+test('with camelcase header should fail for "always snakecase"', async () => {
 	const [actual] = headerCase(await parsed.camelcase, 'always', 'snake-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase header should succeed for "always camelcase"', async t => {
+test('with camelcase header should succeed for "always camelcase"', async () => {
 	const [actual] = headerCase(await parsed.camelcase, 'always', 'camel-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase header should fail for "always uppercase"', async t => {
+test('with pascalcase header should fail for "always uppercase"', async () => {
 	const [actual] = headerCase(await parsed.pascalcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase header should succeed for "never uppercase"', async t => {
+test('with pascalcase header should succeed for "never uppercase"', async () => {
 	const [actual] = headerCase(await parsed.pascalcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase header should succeed for "always pascalcase"', async t => {
+test('with pascalcase header should succeed for "always pascalcase"', async () => {
 	const [actual] = headerCase(await parsed.pascalcase, 'always', 'pascal-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase header should fail for "always kebabcase"', async t => {
+test('with pascalcase header should fail for "always kebabcase"', async () => {
 	const [actual] = headerCase(await parsed.pascalcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase header should fail for "always snakecase"', async t => {
+test('with pascalcase header should fail for "always snakecase"', async () => {
 	const [actual] = headerCase(await parsed.pascalcase, 'always', 'snake-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase header should fail for "always camelcase"', async t => {
+test('with pascalcase header should fail for "always camelcase"', async () => {
 	const [actual] = headerCase(await parsed.pascalcase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase header should fail for "always uppercase"', async t => {
+test('with snakecase header should fail for "always uppercase"', async () => {
 	const [actual] = headerCase(await parsed.snakecase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase header should succeed for "never uppercase"', async t => {
+test('with snakecase header should succeed for "never uppercase"', async () => {
 	const [actual] = headerCase(await parsed.snakecase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase header should fail for "always pascalcase"', async t => {
+test('with snakecase header should fail for "always pascalcase"', async () => {
 	const [actual] = headerCase(await parsed.snakecase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase header should fail for "always kebabcase"', async t => {
+test('with snakecase header should fail for "always kebabcase"', async () => {
 	const [actual] = headerCase(await parsed.snakecase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase header should succeed for "always snakecase"', async t => {
+test('with snakecase header should succeed for "always snakecase"', async () => {
 	const [actual] = headerCase(await parsed.snakecase, 'always', 'snake-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase header should fail for "always camelcase"', async t => {
+test('with snakecase header should fail for "always camelcase"', async () => {
 	const [actual] = headerCase(await parsed.snakecase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase header should fail for "always uppercase"', async t => {
+test('with startcase header should fail for "always uppercase"', async () => {
 	const [actual] = headerCase(await parsed.startcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase header should succeed for "never uppercase"', async t => {
+test('with startcase header should succeed for "never uppercase"', async () => {
 	const [actual] = headerCase(await parsed.startcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase header should fail for "always pascalcase"', async t => {
+test('with startcase header should fail for "always pascalcase"', async () => {
 	const [actual] = headerCase(await parsed.startcase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase header should fail for "always kebabcase"', async t => {
+test('with startcase header should fail for "always kebabcase"', async () => {
 	const [actual] = headerCase(await parsed.startcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase header should fail for "always snakecase"', async t => {
+test('with startcase header should fail for "always snakecase"', async () => {
 	const [actual] = headerCase(await parsed.startcase, 'always', 'snake-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase header should fail for "always camelcase"', async t => {
+test('with startcase header should fail for "always camelcase"', async () => {
 	const [actual] = headerCase(await parsed.startcase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase header should succeed for "always startcase"', async t => {
+test('with startcase header should succeed for "always startcase"', async () => {
 	const [actual] = headerCase(await parsed.startcase, 'always', 'start-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('should use expected message with "always"', async t => {
+test('should use expected message with "always"', async () => {
 	const [, message] = headerCase(
 		await parsed.uppercase,
 		'always',
 		'lower-case'
 	);
-	t.true(message.indexOf('must be lower-case') > -1);
+	expect(message).toContain('must be lower-case');
 });
 
-test('should use expected message with "never"', async t => {
+test('should use expected message with "never"', async () => {
 	const [, message] = headerCase(await parsed.uppercase, 'never', 'upper-case');
-	t.true(message.indexOf('must not be upper-case') > -1);
+	expect(message).toContain('must not be upper-case');
 });
 
-test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async t => {
+test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async () => {
 	const [actual] = headerCase(await parsed.uppercase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase header should succeed for "always [uppercase, lowercase]"', async t => {
+test('with lowercase header should succeed for "always [uppercase, lowercase]"', async () => {
 	const [actual] = headerCase(await parsed.lowercase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase header should fail for "always [uppercase, lowercase]"', async t => {
+test('with mixedcase header should fail for "always [uppercase, lowercase]"', async () => {
 	const [actual] = headerCase(await parsed.mixedcase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase header should pass for "always [uppercase, lowercase, camel-case]"', async t => {
+test('with mixedcase header should pass for "always [uppercase, lowercase, camel-case]"', async () => {
 	const [actual] = headerCase(await parsed.mixedcase, 'always', [
 		'uppercase',
 		'lowercase',
 		'camel-case'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async t => {
+test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async () => {
 	const [actual] = headerCase(await parsed.mixedcase, 'never', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase scope should fail for "never [uppercase, lowercase]"', async t => {
+test('with uppercase scope should fail for "never [uppercase, lowercase]"', async () => {
 	const [actual] = headerCase(await parsed.uppercase, 'never', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with numeric header should succeed for "never lowercase"', async t => {
+test('with numeric header should succeed for "never lowercase"', async () => {
 	const [actual] = headerCase(await parsed.numeric, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with numeric header should succeed for "always lowercase"', async t => {
+test('with numeric header should succeed for "always lowercase"', async () => {
 	const [actual] = headerCase(await parsed.numeric, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with numeric header should succeed for "never uppercase"', async t => {
+test('with numeric header should succeed for "never uppercase"', async () => {
 	const [actual] = headerCase(await parsed.numeric, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with numeric header should succeed for "always uppercase"', async t => {
+test('with numeric header should succeed for "always uppercase"', async () => {
 	const [actual] = headerCase(await parsed.numeric, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/header-full-stop.test.js
+++ b/@commitlint/rules/src/header-full-stop.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './header-full-stop';
 
@@ -12,26 +11,26 @@ const parsed = {
 	without: parse(messages.without)
 };
 
-test('with against "always ." should succeed', async t => {
+test('with against "always ." should succeed', async () => {
 	const [actual] = check(await parsed.with, 'always', '.');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with against "never ." should fail', async t => {
+test('with against "never ." should fail', async () => {
 	const [actual] = check(await parsed.with, 'never', '.');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without against "always ." should fail', async t => {
+test('without against "always ." should fail', async () => {
 	const [actual] = check(await parsed.without, 'always', '.');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without against "never ." should succeed', async t => {
+test('without against "never ." should succeed', async () => {
 	const [actual] = check(await parsed.without, 'never', '.');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/header-max-length.test.js
+++ b/@commitlint/rules/src/header-max-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './header-max-length';
 
@@ -17,14 +16,14 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with short should succeed', async t => {
+test('with short should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should fail', async t => {
+test('with long should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/header-min-length.test.js
+++ b/@commitlint/rules/src/header-min-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './header-min-length';
 
@@ -17,14 +16,14 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with short should fail', async t => {
+test('with short should fail', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should succeed', async t => {
+test('with long should succeed', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/index.test.js
+++ b/@commitlint/rules/src/index.test.js
@@ -1,18 +1,17 @@
 import path from 'path';
-import test from 'ava';
 import globby from 'globby';
-import {values} from 'lodash';
+import values from 'lodash/values';
 import rules from '.';
 
-test('exports all rules', async t => {
+test('exports all rules', async () => {
 	const expected = (await glob('*.js')).sort();
 	const actual = Object.keys(rules).sort();
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('rules export functions', t => {
+test('rules export functions', () => {
 	const actual = values(rules);
-	t.true(actual.every(rule => typeof rule === 'function'));
+	expect(actual.every(rule => typeof rule === 'function')).toBe(true);
 });
 
 async function glob(pattern) {

--- a/@commitlint/rules/src/references-empty.test.js
+++ b/@commitlint/rules/src/references-empty.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import preset from 'conventional-changelog-angular';
 import parse from '@commitlint/parse';
 import referencesEmpty from './references-empty';
@@ -31,56 +30,56 @@ const parsed = {
 	})
 };
 
-test('defaults to never and fails for plain', async t => {
+test('defaults to never and fails for plain', async () => {
 	const [actual] = referencesEmpty(await parsed.plain);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('defaults to never and succeeds for reference', async t => {
+test('defaults to never and succeeds for reference', async () => {
 	const [actual] = referencesEmpty(await parsed.reference);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('fails for comment with never', async t => {
+test('fails for comment with never', async () => {
 	const [actual] = referencesEmpty(await parsed.comment, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('succeeds for comment with always', async t => {
+test('succeeds for comment with always', async () => {
 	const [actual] = referencesEmpty(await parsed.comment, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('succeeds for reference with never', async t => {
+test('succeeds for reference with never', async () => {
 	const [actual] = referencesEmpty(await parsed.reference, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('fails for reference with always', async t => {
+test('fails for reference with always', async () => {
 	const [actual] = referencesEmpty(await parsed.reference, 'always');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('succeeds for references with never', async t => {
+test('succeeds for references with never', async () => {
 	const [actual] = referencesEmpty(await parsed.references, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('fails for references with always', async t => {
+test('fails for references with always', async () => {
 	const [actual] = referencesEmpty(await parsed.references, 'always');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('succeeds for custom references with always', async t => {
+test('succeeds for custom references with always', async () => {
 	const [actual] = referencesEmpty(await parsed.prefix, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/scope-case.test.js
+++ b/@commitlint/rules/src/scope-case.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import scopeCase from './scope-case';
 
@@ -26,299 +25,299 @@ const parsed = {
 	startcase: parse(messages.startcase)
 };
 
-test('with empty scope should succeed for "never lowercase"', async t => {
+test('with empty scope should succeed for "never lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "always lowercase"', async t => {
+test('with empty scope should succeed for "always lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "never uppercase"', async t => {
+test('with empty scope should succeed for "never uppercase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "always uppercase"', async t => {
+test('with empty scope should succeed for "always uppercase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "never camelcase"', async t => {
+test('with empty scope should succeed for "never camelcase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'camel-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "always camelcase"', async t => {
+test('with empty scope should succeed for "always camelcase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'camel-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "never kebabcase"', async t => {
+test('with empty scope should succeed for "never kebabcase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'kebab-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "always kebabcase"', async t => {
+test('with empty scope should succeed for "always kebabcase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'kebab-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "never pascalcase"', async t => {
+test('with empty scope should succeed for "never pascalcase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'pascal-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "always pascalcase"', async t => {
+test('with empty scope should succeed for "always pascalcase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'pascal-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "never snakecase"', async t => {
+test('with empty scope should succeed for "never snakecase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'snake-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "always snakecase"', async t => {
+test('with empty scope should succeed for "always snakecase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'snake-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "never startcase"', async t => {
+test('with empty scope should succeed for "never startcase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'start-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty scope should succeed for "always startcase"', async t => {
+test('with empty scope should succeed for "always startcase"', async () => {
 	const [actual] = scopeCase(await parsed.empty, 'never', 'start-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase scope should fail for "never lowercase"', async t => {
+test('with lowercase scope should fail for "never lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.lowercase, 'never', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase scope should succeed for "always lowercase"', async t => {
+test('with lowercase scope should succeed for "always lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.lowercase, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should succeed for "never lowercase"', async t => {
+test('with mixedcase scope should succeed for "never lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.mixedcase, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should fail for "always lowercase"', async t => {
+test('with mixedcase scope should fail for "always lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.mixedcase, 'always', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should succeed for "never uppercase"', async t => {
+test('with mixedcase scope should succeed for "never uppercase"', async () => {
 	const [actual] = scopeCase(await parsed.mixedcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with kebabcase scope should succeed for "always lowercase"', async t => {
+test('with kebabcase scope should succeed for "always lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.kebabcase, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with kebabcase scope should fail for "always camelcase"', async t => {
+test('with kebabcase scope should fail for "always camelcase"', async () => {
 	const [actual] = scopeCase(await parsed.kebabcase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with kebabcase scope should fail for "always pascalcase"', async t => {
+test('with kebabcase scope should fail for "always pascalcase"', async () => {
 	const [actual] = scopeCase(await parsed.kebabcase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with kebabcase scope should succeed for "always kebabcase"', async t => {
+test('with kebabcase scope should succeed for "always kebabcase"', async () => {
 	const [actual] = scopeCase(await parsed.kebabcase, 'always', 'kebab-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase scope should succeed for "always lowercase"', async t => {
+test('with snakecase scope should succeed for "always lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.snakecase, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase scope should fail for "always camelcase"', async t => {
+test('with snakecase scope should fail for "always camelcase"', async () => {
 	const [actual] = scopeCase(await parsed.snakecase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase scope should fail for "always pascalcase"', async t => {
+test('with snakecase scope should fail for "always pascalcase"', async () => {
 	const [actual] = scopeCase(await parsed.snakecase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase scope should succeed for "always snakecase"', async t => {
+test('with snakecase scope should succeed for "always snakecase"', async () => {
 	const [actual] = scopeCase(await parsed.snakecase, 'always', 'snake-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase scope should fail for "always lowercase"', async t => {
+test('with camelcase scope should fail for "always lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.camelcase, 'always', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase scope should succeed for "always camelcase"', async t => {
+test('with camelcase scope should succeed for "always camelcase"', async () => {
 	const [actual] = scopeCase(await parsed.camelcase, 'always', 'camel-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase scope should fail for "always kebabcase"', async t => {
+test('with camelcase scope should fail for "always kebabcase"', async () => {
 	const [actual] = scopeCase(await parsed.camelcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase scope should fail for "always pascalcase"', async t => {
+test('with camelcase scope should fail for "always pascalcase"', async () => {
 	const [actual] = scopeCase(await parsed.camelcase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase scope should fail for "always lowercase"', async t => {
+test('with pascalcase scope should fail for "always lowercase"', async () => {
 	const [actual] = scopeCase(await parsed.pascalcase, 'always', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase scope should fail for "always kebabcase"', async t => {
+test('with pascalcase scope should fail for "always kebabcase"', async () => {
 	const [actual] = scopeCase(await parsed.pascalcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase scope should fail for "always camelcase"', async t => {
+test('with pascalcase scope should fail for "always camelcase"', async () => {
 	const [actual] = scopeCase(await parsed.pascalcase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase scope should succeed for "always pascalcase"', async t => {
+test('with pascalcase scope should succeed for "always pascalcase"', async () => {
 	const [actual] = scopeCase(await parsed.pascalcase, 'always', 'pascal-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should fail for "always uppercase"', async t => {
+test('with mixedcase scope should fail for "always uppercase"', async () => {
 	const [actual] = scopeCase(await parsed.mixedcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase scope should fail for "never uppercase"', async t => {
+test('with uppercase scope should fail for "never uppercase"', async () => {
 	const [actual] = scopeCase(await parsed.uppercase, 'never', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase scope should succeed for "always uppercase"', async t => {
+test('with uppercase scope should succeed for "always uppercase"', async () => {
 	const [actual] = scopeCase(await parsed.uppercase, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async t => {
+test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async () => {
 	const [actual] = scopeCase(await parsed.uppercase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase scope should succeed for "always [uppercase, lowercase]"', async t => {
+test('with lowercase scope should succeed for "always [uppercase, lowercase]"', async () => {
 	const [actual] = scopeCase(await parsed.lowercase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should fail for "always [uppercase, lowercase]"', async t => {
+test('with mixedcase scope should fail for "always [uppercase, lowercase]"', async () => {
 	const [actual] = scopeCase(await parsed.mixedcase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should pass for "always [uppercase, lowercase, camel-case]"', async t => {
+test('with mixedcase scope should pass for "always [uppercase, lowercase, camel-case]"', async () => {
 	const [actual] = scopeCase(await parsed.mixedcase, 'always', [
 		'uppercase',
 		'lowercase',
 		'camel-case'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async t => {
+test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async () => {
 	const [actual] = scopeCase(await parsed.mixedcase, 'never', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase scope should fail for "never [uppercase, lowercase]"', async t => {
+test('with uppercase scope should fail for "never [uppercase, lowercase]"', async () => {
 	const [actual] = scopeCase(await parsed.uppercase, 'never', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with slash in scope should succeed for "always pascal-case"', async t => {
+test('with slash in scope should succeed for "always pascal-case"', async () => {
 	const commit = await parse('feat(Modules/Graph): add Pie Chart');
 	const [actual] = scopeCase(commit, 'always', 'pascal-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with slash in subject should succeed for "always sentence case"', async t => {
+test('with slash in subject should succeed for "always sentence case"', async () => {
 	const commit = await parse('chore: Update @angular/core');
 	const [actual] = scopeCase(commit, 'always', 'sentencecase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/scope-empty.test.js
+++ b/@commitlint/rules/src/scope-empty.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import scopeEmpty from './scope-empty';
 
@@ -14,56 +13,56 @@ const parsed = {
 	empty: parse(messages.empty)
 };
 
-test('with plain message it should succeed for empty keyword', async t => {
+test('with plain message it should succeed for empty keyword', async () => {
 	const [actual] = scopeEmpty(await parsed.plain);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with plain message it should succeed for "never"', async t => {
+test('with plain message it should succeed for "never"', async () => {
 	const [actual] = scopeEmpty(await parsed.plain, 'never');
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with plain message it should fail for "always"', async t => {
+test('with plain message it should fail for "always"', async () => {
 	const [actual] = scopeEmpty(await parsed.plain, 'always');
 	const expected = false;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with superfluous message it should fail for empty keyword', async t => {
+test('with superfluous message it should fail for empty keyword', async () => {
 	const [actual] = scopeEmpty(await parsed.superfluous);
 	const expected = false;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with superfluous message it should fail for "never"', async t => {
+test('with superfluous message it should fail for "never"', async () => {
 	const [actual] = scopeEmpty(await parsed.superfluous, 'never');
 	const expected = false;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with superfluous message it should fail for "always"', async t => {
+test('with superfluous message it should fail for "always"', async () => {
 	const [actual] = scopeEmpty(await parsed.superfluous, 'always');
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty message it should fail for empty keyword', async t => {
+test('with empty message it should fail for empty keyword', async () => {
 	const [actual] = scopeEmpty(await parsed.empty);
 	const expected = false;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty message it should fail for "never"', async t => {
+test('with empty message it should fail for "never"', async () => {
 	const [actual] = scopeEmpty(await parsed.empty, 'never');
 	const expected = false;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty message it should fail for "always"', async t => {
+test('with empty message it should fail for "always"', async () => {
 	const [actual] = scopeEmpty(await parsed.empty, 'always');
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/scope-enum.test.js
+++ b/@commitlint/rules/src/scope-enum.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import scopeEnum from './scope-enum';
 
@@ -14,80 +13,80 @@ const parsed = {
 	empty: parse(messages.empty)
 };
 
-test('scope-enum with plain message and always should succeed empty enum', async t => {
+test('scope-enum with plain message and always should succeed empty enum', async () => {
 	const [actual] = scopeEnum(await parsed.plain, 'always', []);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with plain message and never should error empty enum', async t => {
+test('scope-enum with plain message and never should error empty enum', async () => {
 	const [actual] = scopeEnum(await parsed.plain, 'never', []);
 	const expected = false;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with plain message should succeed correct enum', async t => {
+test('with plain message should succeed correct enum', async () => {
 	const [actual] = scopeEnum(await parsed.plain, 'always', ['bar']);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with plain message should error false enum', async t => {
+test('scope-enum with plain message should error false enum', async () => {
 	const [actual] = scopeEnum(await parsed.plain, 'always', ['foo']);
 	const expected = false;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with plain message should error forbidden enum', async t => {
+test('scope-enum with plain message should error forbidden enum', async () => {
 	const [actual] = scopeEnum(await parsed.plain, 'never', ['bar']);
 	const expected = false;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with plain message should succeed forbidden enum', async t => {
+test('scope-enum with plain message should succeed forbidden enum', async () => {
 	const [actual] = scopeEnum(await parsed.plain, 'never', ['foo']);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with superfluous scope should succeed enum', async t => {
+test('scope-enum with superfluous scope should succeed enum', async () => {
 	const [actual] = scopeEnum(await parsed.superfluous, 'always', ['bar']);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with superfluous scope and "never" should succeed', async t => {
+test('scope-enum with superfluous scope and "never" should succeed', async () => {
 	const [actual] = scopeEnum(await parsed.superfluous, 'never', ['bar']);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with superfluous scope and always should succeed empty enum', async t => {
+test('scope-enum with superfluous scope and always should succeed empty enum', async () => {
 	const [actual] = scopeEnum(await parsed.superfluous, 'always', []);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with superfluous scope and never should succeed empty enum', async t => {
+test('scope-enum with superfluous scope and never should succeed empty enum', async () => {
 	const [actual] = scopeEnum(await parsed.superfluous, 'never', []);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with empty scope and always should succeed empty enum', async t => {
+test('scope-enum with empty scope and always should succeed empty enum', async () => {
 	const [actual] = scopeEnum(await parsed.superfluous, 'always', []);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with empty scope and always should succeed filled enum', async t => {
+test('scope-enum with empty scope and always should succeed filled enum', async () => {
 	const [actual] = scopeEnum(await parsed.superfluous, 'always', ['foo']);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('scope-enum with empty scope and never should succeed empty enum', async t => {
+test('scope-enum with empty scope and never should succeed empty enum', async () => {
 	const [actual] = scopeEnum(await parsed.superfluous, 'never', []);
 	const expected = true;
-	t.deepEqual(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/scope-max-length.test.js
+++ b/@commitlint/rules/src/scope-max-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './scope-max-length';
 
@@ -19,20 +18,20 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should succeed', async t => {
+test('with short should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should fail', async t => {
+test('with long should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/scope-min-length.test.js
+++ b/@commitlint/rules/src/scope-min-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './scope-min-length';
 
@@ -19,20 +18,20 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should fail', async t => {
+test('with short should fail', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should succeed', async t => {
+test('with long should succeed', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/signed-off-by.test.js
+++ b/@commitlint/rules/src/signed-off-by.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './signed-off-by';
 
@@ -18,62 +17,62 @@ const parsed = {
 	inBody: parse(messages.inBody)
 };
 
-test('empty against "always signed-off-by" should fail', async t => {
+test('empty against "always signed-off-by" should fail', async () => {
 	const [actual] = check(await parsed.empty, 'always', 'Signed-off-by:');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('empty against "never signed-off-by" should succeed', async t => {
+test('empty against "never signed-off-by" should succeed', async () => {
 	const [actual] = check(await parsed.empty, 'never', 'Signed-off-by:');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with against "always signed-off-by" should succeed', async t => {
+test('with against "always signed-off-by" should succeed', async () => {
 	const [actual] = check(await parsed.with, 'always', 'Signed-off-by:');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with against "never signed-off-by" should fail', async t => {
+test('with against "never signed-off-by" should fail', async () => {
 	const [actual] = check(await parsed.with, 'never', 'Signed-off-by:');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without against "always signed-off-by" should fail', async t => {
+test('without against "always signed-off-by" should fail', async () => {
 	const [actual] = check(await parsed.without, 'always', 'Signed-off-by:');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without against "never signed-off-by" should succeed', async t => {
+test('without against "never signed-off-by" should succeed', async () => {
 	const [actual] = check(await parsed.without, 'never', 'Signed-off-by:');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('inSubject against "always signed-off-by" should fail', async t => {
+test('inSubject against "always signed-off-by" should fail', async () => {
 	const [actual] = check(await parsed.inSubject, 'always', 'Signed-off-by:');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('inSubject against "never signed-off-by" should succeed', async t => {
+test('inSubject against "never signed-off-by" should succeed', async () => {
 	const [actual] = check(await parsed.inSubject, 'never', 'Signed-off-by:');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('inBody against "always signed-off-by" should fail', async t => {
+test('inBody against "always signed-off-by" should fail', async () => {
 	const [actual] = check(await parsed.inBody, 'always', 'Signed-off-by:');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('inBody against "never signed-off-by" should succeed', async t => {
+test('inBody against "never signed-off-by" should succeed', async () => {
 	const [actual] = check(await parsed.inBody, 'never', 'Signed-off-by:');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/subject-case.test.js
+++ b/@commitlint/rules/src/subject-case.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import subjectCase from './subject-case';
 
@@ -28,325 +27,325 @@ const parsed = {
 	startcase: parse(messages.startcase)
 };
 
-test('with empty subject should succeed for "never lowercase"', async t => {
+test('with empty subject should succeed for "never lowercase"', async () => {
 	const [actual] = subjectCase(await parsed.empty, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty subject should succeed for "always lowercase"', async t => {
+test('with empty subject should succeed for "always lowercase"', async () => {
 	const [actual] = subjectCase(await parsed.empty, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty subject should succeed for "never uppercase"', async t => {
+test('with empty subject should succeed for "never uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.empty, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty subject should succeed for "always uppercase"', async t => {
+test('with empty subject should succeed for "always uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.empty, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase subject should fail for "never lowercase"', async t => {
+test('with lowercase subject should fail for "never lowercase"', async () => {
 	const [actual] = subjectCase(await parsed.lowercase, 'never', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase subject should succeed for "always lowercase"', async t => {
+test('with lowercase subject should succeed for "always lowercase"', async () => {
 	const [actual] = subjectCase(await parsed.lowercase, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase subject should succeed for "never lowercase"', async t => {
+test('with mixedcase subject should succeed for "never lowercase"', async () => {
 	const [actual] = subjectCase(await parsed.mixedcase, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase subject should fail for "always lowercase"', async t => {
+test('with mixedcase subject should fail for "always lowercase"', async () => {
 	const [actual] = subjectCase(await parsed.mixedcase, 'always', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase subject should succeed for "never uppercase"', async t => {
+test('with mixedcase subject should succeed for "never uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.mixedcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase subject should fail for "always uppercase"', async t => {
+test('with mixedcase subject should fail for "always uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.mixedcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase subject should fail for "never uppercase"', async t => {
+test('with uppercase subject should fail for "never uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.uppercase, 'never', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase subject should succeed for "always uppercase"', async t => {
+test('with lowercase subject should succeed for "always uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.uppercase, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase subject should fail for "always uppercase"', async t => {
+test('with camelcase subject should fail for "always uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.camelcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase subject should succeed for "never uppercase"', async t => {
+test('with camelcase subject should succeed for "never uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.camelcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase subject should fail for "always pascalcase"', async t => {
+test('with camelcase subject should fail for "always pascalcase"', async () => {
 	const [actual] = subjectCase(await parsed.camelcase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase subject should fail for "always kebabcase"', async t => {
+test('with camelcase subject should fail for "always kebabcase"', async () => {
 	const [actual] = subjectCase(await parsed.camelcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase subject should fail for "always snakecase"', async t => {
+test('with camelcase subject should fail for "always snakecase"', async () => {
 	const [actual] = subjectCase(await parsed.camelcase, 'always', 'snake-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase subject should succeed for "always camelcase"', async t => {
+test('with camelcase subject should succeed for "always camelcase"', async () => {
 	const [actual] = subjectCase(await parsed.camelcase, 'always', 'camel-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase subject should fail for "always uppercase"', async t => {
+test('with pascalcase subject should fail for "always uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.pascalcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase subject should succeed for "never uppercase"', async t => {
+test('with pascalcase subject should succeed for "never uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.pascalcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase subject should succeed for "always pascalcase"', async t => {
+test('with pascalcase subject should succeed for "always pascalcase"', async () => {
 	const [actual] = subjectCase(
 		await parsed.pascalcase,
 		'always',
 		'pascal-case'
 	);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase subject should fail for "always kebabcase"', async t => {
+test('with pascalcase subject should fail for "always kebabcase"', async () => {
 	const [actual] = subjectCase(await parsed.pascalcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase subject should fail for "always snakecase"', async t => {
+test('with pascalcase subject should fail for "always snakecase"', async () => {
 	const [actual] = subjectCase(await parsed.pascalcase, 'always', 'snake-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase subject should fail for "always camelcase"', async t => {
+test('with pascalcase subject should fail for "always camelcase"', async () => {
 	const [actual] = subjectCase(await parsed.pascalcase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase subject should fail for "always uppercase"', async t => {
+test('with snakecase subject should fail for "always uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.snakecase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase subject should succeed for "never uppercase"', async t => {
+test('with snakecase subject should succeed for "never uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.snakecase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase subject should fail for "always pascalcase"', async t => {
+test('with snakecase subject should fail for "always pascalcase"', async () => {
 	const [actual] = subjectCase(await parsed.snakecase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase subject should fail for "always kebabcase"', async t => {
+test('with snakecase subject should fail for "always kebabcase"', async () => {
 	const [actual] = subjectCase(await parsed.snakecase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase subject should succeed for "always snakecase"', async t => {
+test('with snakecase subject should succeed for "always snakecase"', async () => {
 	const [actual] = subjectCase(await parsed.snakecase, 'always', 'snake-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase subject should fail for "always camelcase"', async t => {
+test('with snakecase subject should fail for "always camelcase"', async () => {
 	const [actual] = subjectCase(await parsed.snakecase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase subject should fail for "always uppercase"', async t => {
+test('with startcase subject should fail for "always uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.startcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase subject should succeed for "never uppercase"', async t => {
+test('with startcase subject should succeed for "never uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.startcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase subject should fail for "always pascalcase"', async t => {
+test('with startcase subject should fail for "always pascalcase"', async () => {
 	const [actual] = subjectCase(await parsed.startcase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase subject should fail for "always kebabcase"', async t => {
+test('with startcase subject should fail for "always kebabcase"', async () => {
 	const [actual] = subjectCase(await parsed.startcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase subject should fail for "always snakecase"', async t => {
+test('with startcase subject should fail for "always snakecase"', async () => {
 	const [actual] = subjectCase(await parsed.startcase, 'always', 'snake-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase subject should fail for "always camelcase"', async t => {
+test('with startcase subject should fail for "always camelcase"', async () => {
 	const [actual] = subjectCase(await parsed.startcase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase subject should succeed for "always startcase"', async t => {
+test('with startcase subject should succeed for "always startcase"', async () => {
 	const [actual] = subjectCase(await parsed.startcase, 'always', 'start-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('should use expected message with "always"', async t => {
+test('should use expected message with "always"', async () => {
 	const [, message] = subjectCase(
 		await parsed.uppercase,
 		'always',
 		'lower-case'
 	);
-	t.true(message.indexOf('must be lower-case') > -1);
+	expect(message).toContain('must be lower-case');
 });
 
-test('should use expected message with "never"', async t => {
+test('should use expected message with "never"', async () => {
 	const [, message] = subjectCase(
 		await parsed.uppercase,
 		'never',
 		'upper-case'
 	);
-	t.true(message.indexOf('must not be upper-case') > -1);
+	expect(message).toContain('must not be upper-case');
 });
 
-test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async t => {
+test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async () => {
 	const [actual] = subjectCase(await parsed.uppercase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase subject should succeed for "always [uppercase, lowercase]"', async t => {
+test('with lowercase subject should succeed for "always [uppercase, lowercase]"', async () => {
 	const [actual] = subjectCase(await parsed.lowercase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase subject should fail for "always [uppercase, lowercase]"', async t => {
+test('with mixedcase subject should fail for "always [uppercase, lowercase]"', async () => {
 	const [actual] = subjectCase(await parsed.mixedcase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase subject should pass for "always [uppercase, lowercase, camel-case]"', async t => {
+test('with mixedcase subject should pass for "always [uppercase, lowercase, camel-case]"', async () => {
 	const [actual] = subjectCase(await parsed.mixedcase, 'always', [
 		'uppercase',
 		'lowercase',
 		'camel-case'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async t => {
+test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async () => {
 	const [actual] = subjectCase(await parsed.mixedcase, 'never', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase scope should fail for "never [uppercase, lowercase]"', async t => {
+test('with uppercase scope should fail for "never [uppercase, lowercase]"', async () => {
 	const [actual] = subjectCase(await parsed.uppercase, 'never', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with numeric subject should succeed for "never lowercase"', async t => {
+test('with numeric subject should succeed for "never lowercase"', async () => {
 	const [actual] = subjectCase(await parsed.numeric, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with numeric subject should succeed for "always lowercase"', async t => {
+test('with numeric subject should succeed for "always lowercase"', async () => {
 	const [actual] = subjectCase(await parsed.numeric, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with numeric subject should succeed for "never uppercase"', async t => {
+test('with numeric subject should succeed for "never uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.numeric, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with numeric subject should succeed for "always uppercase"', async t => {
+test('with numeric subject should succeed for "always uppercase"', async () => {
 	const [actual] = subjectCase(await parsed.numeric, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/subject-empty.test.js
+++ b/@commitlint/rules/src/subject-empty.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import subjectEmpty from './subject-empty';
 
@@ -12,38 +11,38 @@ const parsed = {
 	filled: parse(messages.filled)
 };
 
-test('without subject should succeed for empty keyword', async t => {
+test('without subject should succeed for empty keyword', async () => {
 	const [actual] = subjectEmpty(await parsed.empty);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without subject should fail for "never"', async t => {
+test('without subject should fail for "never"', async () => {
 	const [actual] = subjectEmpty(await parsed.empty, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without subject should succeed for "always"', async t => {
+test('without subject should succeed for "always"', async () => {
 	const [actual] = subjectEmpty(await parsed.empty, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with subject fail for empty keyword', async t => {
+test('with subject fail for empty keyword', async () => {
 	const [actual] = subjectEmpty(await parsed.filled);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with subject succeed for "never"', async t => {
+test('with subject succeed for "never"', async () => {
 	const [actual] = subjectEmpty(await parsed.filled, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with subject fail for "always"', async t => {
+test('with subject fail for "always"', async () => {
 	const [actual] = subjectEmpty(await parsed.filled, 'always');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/subject-full-stop.test.js
+++ b/@commitlint/rules/src/subject-full-stop.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './subject-full-stop';
 
@@ -14,38 +13,38 @@ const parsed = {
 	without: parse(messages.without)
 };
 
-test('empty against "always" should succeed', async t => {
+test('empty against "always" should succeed', async () => {
 	const [actual] = check(await parsed.empty, 'always', '.');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('empty against "never ." should succeed', async t => {
+test('empty against "never ." should succeed', async () => {
 	const [actual] = check(await parsed.empty, 'never', '.');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with against "always ." should succeed', async t => {
+test('with against "always ." should succeed', async () => {
 	const [actual] = check(await parsed.with, 'always', '.');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with against "never ." should fail', async t => {
+test('with against "never ." should fail', async () => {
 	const [actual] = check(await parsed.with, 'never', '.');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without against "always ." should fail', async t => {
+test('without against "always ." should fail', async () => {
 	const [actual] = check(await parsed.without, 'always', '.');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without against "never ." should succeed', async t => {
+test('without against "never ." should succeed', async () => {
 	const [actual] = check(await parsed.without, 'never', '.');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/subject-max-length.test.js
+++ b/@commitlint/rules/src/subject-max-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './subject-max-length';
 
@@ -19,20 +18,20 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should succeed', async t => {
+test('with short should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should fail', async t => {
+test('with long should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/subject-min-length.test.js
+++ b/@commitlint/rules/src/subject-min-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './subject-min-length';
 
@@ -19,20 +18,20 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should fail', async t => {
+test('with short should fail', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should succeed', async t => {
+test('with long should succeed', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/type-case.test.js
+++ b/@commitlint/rules/src/type-case.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import typeCase from './type-case';
 
@@ -29,297 +28,297 @@ const parsed = {
 	})
 };
 
-test('with empty type should succeed for "never lowercase"', async t => {
+test('with empty type should succeed for "never lowercase"', async () => {
 	const [actual] = typeCase(await parsed.empty, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty type should succeed for "always lowercase"', async t => {
+test('with empty type should succeed for "always lowercase"', async () => {
 	const [actual] = typeCase(await parsed.empty, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty type should succeed for "never uppercase"', async t => {
+test('with empty type should succeed for "never uppercase"', async () => {
 	const [actual] = typeCase(await parsed.empty, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with empty type should succeed for "always uppercase"', async t => {
+test('with empty type should succeed for "always uppercase"', async () => {
 	const [actual] = typeCase(await parsed.empty, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase type should fail for "never lowercase"', async t => {
+test('with lowercase type should fail for "never lowercase"', async () => {
 	const [actual] = typeCase(await parsed.lowercase, 'never', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase type should succeed for "always lowercase"', async t => {
+test('with lowercase type should succeed for "always lowercase"', async () => {
 	const [actual] = typeCase(await parsed.lowercase, 'always', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase type should succeed for "never lowercase"', async t => {
+test('with mixedcase type should succeed for "never lowercase"', async () => {
 	const [actual] = typeCase(await parsed.mixedcase, 'never', 'lowercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase type should fail for "always lowercase"', async t => {
+test('with mixedcase type should fail for "always lowercase"', async () => {
 	const [actual] = typeCase(await parsed.mixedcase, 'always', 'lowercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase type should succeed for "never uppercase"', async t => {
+test('with mixedcase type should succeed for "never uppercase"', async () => {
 	const [actual] = typeCase(await parsed.mixedcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase type should fail for "always uppercase"', async t => {
+test('with mixedcase type should fail for "always uppercase"', async () => {
 	const [actual] = typeCase(await parsed.mixedcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase type should fail for "never uppercase"', async t => {
+test('with uppercase type should fail for "never uppercase"', async () => {
 	const [actual] = typeCase(await parsed.uppercase, 'never', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase type should succeed for "always uppercase"', async t => {
+test('with lowercase type should succeed for "always uppercase"', async () => {
 	const [actual] = typeCase(await parsed.uppercase, 'always', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase type should fail for "always uppercase"', async t => {
+test('with camelcase type should fail for "always uppercase"', async () => {
 	const [actual] = typeCase(await parsed.camelcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase type should succeed for "never uppercase"', async t => {
+test('with camelcase type should succeed for "never uppercase"', async () => {
 	const [actual] = typeCase(await parsed.camelcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase type should fail for "always pascalcase"', async t => {
+test('with camelcase type should fail for "always pascalcase"', async () => {
 	const [actual] = typeCase(await parsed.camelcase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase type should fail for "always kebabcase"', async t => {
+test('with camelcase type should fail for "always kebabcase"', async () => {
 	const [actual] = typeCase(await parsed.camelcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase type should fail for "always snakecase"', async t => {
+test('with camelcase type should fail for "always snakecase"', async () => {
 	const [actual] = typeCase(await parsed.camelcase, 'always', 'snake-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase type should fail for "always startcase"', async t => {
+test('with camelcase type should fail for "always startcase"', async () => {
 	const [actual] = typeCase(await parsed.camelcase, 'always', 'start-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with camelcase type should succeed for "always camelcase"', async t => {
+test('with camelcase type should succeed for "always camelcase"', async () => {
 	const [actual] = typeCase(await parsed.camelcase, 'always', 'camel-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase type should fail for "always uppercase"', async t => {
+test('with pascalcase type should fail for "always uppercase"', async () => {
 	const [actual] = typeCase(await parsed.pascalcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase type should succeed for "never uppercase"', async t => {
+test('with pascalcase type should succeed for "never uppercase"', async () => {
 	const [actual] = typeCase(await parsed.pascalcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase type should fail for "always camelcase"', async t => {
+test('with pascalcase type should fail for "always camelcase"', async () => {
 	const [actual] = typeCase(await parsed.pascalcase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase type should fail for "always kebabcase"', async t => {
+test('with pascalcase type should fail for "always kebabcase"', async () => {
 	const [actual] = typeCase(await parsed.pascalcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase type should fail for "always snakecase"', async t => {
+test('with pascalcase type should fail for "always snakecase"', async () => {
 	const [actual] = typeCase(await parsed.pascalcase, 'always', 'snake-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase type should fail for "always startcase"', async t => {
+test('with pascalcase type should fail for "always startcase"', async () => {
 	const [actual] = typeCase(await parsed.pascalcase, 'always', 'start-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with pascalcase type should succeed for "always pascalcase"', async t => {
+test('with pascalcase type should succeed for "always pascalcase"', async () => {
 	const [actual] = typeCase(await parsed.pascalcase, 'always', 'pascal-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase type should fail for "always uppercase"', async t => {
+test('with snakecase type should fail for "always uppercase"', async () => {
 	const [actual] = typeCase(await parsed.snakecase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase type should succeed for "never uppercase"', async t => {
+test('with snakecase type should succeed for "never uppercase"', async () => {
 	const [actual] = typeCase(await parsed.snakecase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase type should fail for "always camelcase"', async t => {
+test('with snakecase type should fail for "always camelcase"', async () => {
 	const [actual] = typeCase(await parsed.snakecase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase type should fail for "always kebabcase"', async t => {
+test('with snakecase type should fail for "always kebabcase"', async () => {
 	const [actual] = typeCase(await parsed.snakecase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase type should succeed for "always snakecase"', async t => {
+test('with snakecase type should succeed for "always snakecase"', async () => {
 	const [actual] = typeCase(await parsed.snakecase, 'always', 'snake-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase type should fail for "always pascalcase"', async t => {
+test('with snakecase type should fail for "always pascalcase"', async () => {
 	const [actual] = typeCase(await parsed.snakecase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with snakecase type should fail for "always start case"', async t => {
+test('with snakecase type should fail for "always start case"', async () => {
 	const [actual] = typeCase(await parsed.snakecase, 'always', 'start-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase type should fail for "always uppercase"', async t => {
+test('with startcase type should fail for "always uppercase"', async () => {
 	const [actual] = typeCase(await parsed.startcase, 'always', 'uppercase');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase type should succeed for "never uppercase"', async t => {
+test('with startcase type should succeed for "never uppercase"', async () => {
 	const [actual] = typeCase(await parsed.startcase, 'never', 'uppercase');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase type should fail for "always camelcase"', async t => {
+test('with startcase type should fail for "always camelcase"', async () => {
 	const [actual] = typeCase(await parsed.startcase, 'always', 'camel-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase type should fail for "always kebabcase"', async t => {
+test('with startcase type should fail for "always kebabcase"', async () => {
 	const [actual] = typeCase(await parsed.startcase, 'always', 'kebab-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase type should fail for "always snakecase"', async t => {
+test('with startcase type should fail for "always snakecase"', async () => {
 	const [actual] = typeCase(await parsed.startcase, 'always', 'snake-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase type should fail for "always pascalcase"', async t => {
+test('with startcase type should fail for "always pascalcase"', async () => {
 	const [actual] = typeCase(await parsed.startcase, 'always', 'pascal-case');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with startcase type should succeed for "always startcase"', async t => {
+test('with startcase type should succeed for "always startcase"', async () => {
 	const [actual] = typeCase(await parsed.startcase, 'always', 'start-case');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async t => {
+test('with uppercase scope should succeed for "always [uppercase, lowercase]"', async () => {
 	const [actual] = typeCase(await parsed.uppercase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with lowercase subject should succeed for "always [uppercase, lowercase]"', async t => {
+test('with lowercase subject should succeed for "always [uppercase, lowercase]"', async () => {
 	const [actual] = typeCase(await parsed.lowercase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase subject should fail for "always [uppercase, lowercase]"', async t => {
+test('with mixedcase subject should fail for "always [uppercase, lowercase]"', async () => {
 	const [actual] = typeCase(await parsed.mixedcase, 'always', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase subject should pass for "always [uppercase, lowercase, camel-case]"', async t => {
+test('with mixedcase subject should pass for "always [uppercase, lowercase, camel-case]"', async () => {
 	const [actual] = typeCase(await parsed.mixedcase, 'always', [
 		'uppercase',
 		'lowercase',
 		'camel-case'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async t => {
+test('with mixedcase scope should pass for "never [uppercase, lowercase]"', async () => {
 	const [actual] = typeCase(await parsed.mixedcase, 'never', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with uppercase scope should fail for "never [uppercase, lowercase]"', async t => {
+test('with uppercase scope should fail for "never [uppercase, lowercase]"', async () => {
 	const [actual] = typeCase(await parsed.uppercase, 'never', [
 		'uppercase',
 		'lowercase'
 	]);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/type-empty.test.js
+++ b/@commitlint/rules/src/type-empty.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import typeEmpty from './type-empty';
 
@@ -12,38 +11,38 @@ const parsed = {
 	filled: parse(messages.filled)
 };
 
-test('without type should succeed for empty keyword', async t => {
+test('without type should succeed for empty keyword', async () => {
 	const [actual] = typeEmpty(await parsed.empty);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without type should fail for "never"', async t => {
+test('without type should fail for "never"', async () => {
 	const [actual] = typeEmpty(await parsed.empty, 'never');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('without type should succeed for "always"', async t => {
+test('without type should succeed for "always"', async () => {
 	const [actual] = typeEmpty(await parsed.empty, 'always');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with type fail for empty keyword', async t => {
+test('with type fail for empty keyword', async () => {
 	const [actual] = typeEmpty(await parsed.filled);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with type succeed for "never"', async t => {
+test('with type succeed for "never"', async () => {
 	const [actual] = typeEmpty(await parsed.filled, 'never');
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with type fail for "always"', async t => {
+test('with type fail for "always"', async () => {
 	const [actual] = typeEmpty(await parsed.filled, 'always');
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/type-enum.test.js
+++ b/@commitlint/rules/src/type-enum.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './type-enum';
 
@@ -14,110 +13,110 @@ const parsed = {
 	b: parse(messages.b)
 };
 
-test('empty succeeds', async t => {
+test('empty succeeds', async () => {
 	const [actual] = check(await parsed.empty);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('empty on "a" succeeds', async t => {
+test('empty on "a" succeeds', async () => {
 	const [actual] = check(await parsed.empty, '', ['a']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('empty on "always a" succeeds', async t => {
+test('empty on "always a" succeeds', async () => {
 	const [actual] = check(await parsed.empty, 'always', ['a']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('empty on "never a" succeeds', async t => {
+test('empty on "never a" succeeds', async () => {
 	const [actual] = check(await parsed.empty, 'never', ['a']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('empty on "always a, b" succeeds', async t => {
+test('empty on "always a, b" succeeds', async () => {
 	const [actual] = check(await parsed.empty, 'always', ['a', 'b']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('empty on "never a, b" succeeds', async t => {
+test('empty on "never a, b" succeeds', async () => {
 	const [actual] = check(await parsed.empty, 'neber', ['a', 'b']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('a on "a" succeeds', async t => {
+test('a on "a" succeeds', async () => {
 	const [actual] = check(await parsed.a, '', ['a']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('a on "always a" succeeds', async t => {
+test('a on "always a" succeeds', async () => {
 	const [actual] = check(await parsed.a, 'always', ['a']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('a on "never a" fails', async t => {
+test('a on "never a" fails', async () => {
 	const [actual] = check(await parsed.a, 'never', ['a']);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('b on "b" succeeds', async t => {
+test('b on "b" succeeds', async () => {
 	const [actual] = check(await parsed.b, '', ['b']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('b on "always b" succeeds', async t => {
+test('b on "always b" succeeds', async () => {
 	const [actual] = check(await parsed.b, 'always', ['b']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('b on "never b" fails', async t => {
+test('b on "never b" fails', async () => {
 	const [actual] = check(await parsed.b, 'never', ['b']);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('a on "a, b" succeeds', async t => {
+test('a on "a, b" succeeds', async () => {
 	const [actual] = check(await parsed.a, '', ['a', 'b']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('a on "always a, b" succeeds', async t => {
+test('a on "always a, b" succeeds', async () => {
 	const [actual] = check(await parsed.a, 'always', ['a', 'b']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('a on "never a, b" fails', async t => {
+test('a on "never a, b" fails', async () => {
 	const [actual] = check(await parsed.a, 'never', ['a', 'b']);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('b on "a, b" succeeds', async t => {
+test('b on "a, b" succeeds', async () => {
 	const [actual] = check(await parsed.b, '', ['a', 'b']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('b on "always a, b" succeeds', async t => {
+test('b on "always a, b" succeeds', async () => {
 	const [actual] = check(await parsed.b, 'always', ['a', 'b']);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('b on "never a, b" fails', async t => {
+test('b on "never a, b" fails', async () => {
 	const [actual] = check(await parsed.b, 'never', ['a', 'b']);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/type-max-length.test.js
+++ b/@commitlint/rules/src/type-max-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './type-max-length';
 
@@ -19,20 +18,20 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should succeed', async t => {
+test('with short should succeed', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should fail', async t => {
+test('with long should fail', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/type-min-length.test.js
+++ b/@commitlint/rules/src/type-min-length.test.js
@@ -1,4 +1,3 @@
-import test from 'ava';
 import parse from '@commitlint/parse';
 import check from './type-min-length';
 
@@ -19,20 +18,20 @@ const parsed = {
 	long: parse(messages.long)
 };
 
-test('with empty should succeed', async t => {
+test('with empty should succeed', async () => {
 	const [actual] = check(await parsed.empty, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with short should fail', async t => {
+test('with short should fail', async () => {
 	const [actual] = check(await parsed.short, '', value);
 	const expected = false;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });
 
-test('with long should succeed', async t => {
+test('with long should succeed', async () => {
 	const [actual] = check(await parsed.long, '', value);
 	const expected = true;
-	t.is(actual, expected);
+	expect(actual).toEqual(expected);
 });

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+// THis file is required by babel-jest
+module.exports = {
+	presets: ['babel-preset-commitlint']
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-	preset: 'ts-jest',
+	preset: 'ts-jest/presets/js-with-babel',
 	testEnvironment: 'node',
 	testRegex: undefined,
-	testMatch: ['**/*.test.ts?(x)']
+	testMatch: ['**/*.test.ts?(x)', '**/@commitlint/rules/src/*.test.js?(x)']
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,6 +1884,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz#6c3c8dc84988aff11fd2a63d7b5fbf39eaaab7b1"
   integrity sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==
 
+"@types/node@>= 8":
+  version "13.5.0"
+  resolved "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz#4e498dbf355795a611a87ae5ef811a8660d42662"
+  integrity sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==
+
 "@types/node@^12.12.22":
   version "12.12.24"
   resolved "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz#d4606afd8cf6c609036b854360367d1b2c78931f"
@@ -3617,7 +3622,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3793,11 +3798,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -5188,7 +5188,7 @@ husky@3.0.9:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -7253,15 +7253,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -7333,22 +7324,6 @@ node-notifier@^5.4.2:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 node-releases@^1.1.42:
   version "1.1.44"
@@ -7443,7 +7418,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.7"
   resolved "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
   integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
@@ -7483,7 +7458,7 @@ npm-which@^3.0.1:
     npm-path "^2.0.2"
     which "^1.2.10"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -8292,7 +8267,7 @@ range-parser@~1.2.1:
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -8819,7 +8794,7 @@ right-pad@^1.0.1:
   resolved "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
   integrity sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=
 
-rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -8947,7 +8922,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -9596,7 +9571,7 @@ tar-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
## Description
From what i understand code is being migrated to jest and typescript, this is middle step that should reduce amount of changes required to be reviewed while doing so.

I'm planning to upgrade tests from each package separately to reduce noise and made it easier to review.

## How Has This Been Tested?
Unrelated

## Types of changes
- [x] Tests refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
