### PR TITLE
feat: enable multiple scopes in scope-enum and scope-case rules

### DIFF
--- a/@commitlint/rules/src/scope-case.ts
+++ b/@commitlint/rules/src/scope-case.ts
@@ -25,9 +25,9 @@ export const scopeCase: SyncRule<TargetCaseType | TargetCaseType[]> = (
 		return check;
 	});
 
-	// Scopes may contain slash-delimiters to separate them and mark them as individual segments.
+	// Scopes may contain slash or comma delimiters to separate them and mark them as individual segments.
 	// This means that each of these segments should be tested separately with `ensure`.
-	const delimiters = /(\/|\\)/g;
+	const delimiters = /\/|\\|,/g;
 	const scopeSegments = scope.split(delimiters);
 
 	const result = checks.some(check => {

--- a/@commitlint/rules/src/scope-enum.test.ts
+++ b/@commitlint/rules/src/scope-enum.test.ts
@@ -4,13 +4,15 @@ import {scopeEnum} from './scope-enum';
 const messages = {
 	plain: 'foo(bar): baz',
 	superfluous: 'foo(): baz',
-	empty: 'foo: baz'
+	empty: 'foo: baz',
+	multiple: 'foo(bar,baz): qux'
 };
 
 const parsed = {
 	plain: parse(messages.plain),
 	superfluous: parse(messages.superfluous),
-	empty: parse(messages.empty)
+	empty: parse(messages.empty),
+	multiple: parse(messages.multiple)
 };
 
 test('scope-enum with plain message and always should succeed empty enum', async () => {
@@ -87,6 +89,24 @@ test('scope-enum with empty scope and always should succeed filled enum', async 
 
 test('scope-enum with empty scope and never should succeed empty enum', async () => {
 	const [actual] = scopeEnum(await parsed.superfluous, 'never', []);
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('scope-enum with multiple scope should succeed on message with multiple scope', async () => {
+	const [actual] = scopeEnum(await parsed.multiple, 'never', ['bar', 'baz']);
+	const expected = false;
+	expect(actual).toEqual(expected);
+});
+
+test('scope-enum with multiple scope should error on message with forbidden enum', async () => {
+	const [actual] = scopeEnum(await parsed.multiple, 'never', ['bar', 'qux']);
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('scope-enum with multiple scope should error on message with superfluous scope', async () => {
+	const [actual] = scopeEnum(await parsed.multiple, 'never', ['bar']);
 	const expected = true;
 	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/scope-enum.ts
+++ b/@commitlint/rules/src/scope-enum.ts
@@ -11,8 +11,15 @@ export const scopeEnum: SyncRule<string[]> = (
 		return [true, ''];
 	}
 
+	// Scopes may contain slash or comma delimiters to separate them and mark them as individual segments.
+	// This means that each of these segments should be tested separately with `ensure`.
+	const delimiters = /\/|\\|,/g;
+	const scopeSegments = parsed.scope.split(delimiters);
+
 	const negated = when === 'never';
-	const result = value.length === 0 || ensure.enum(parsed.scope, value);
+	const result =
+		value.length === 0 ||
+		scopeSegments.every(scope => ensure.enum(scope, value));
 
 	return [
 		negated ? !result : result,


### PR DESCRIPTION
## Description

Implement support for having multiple scopes, e.g. `chore(foo,bar): baz` in `scope-enum` and enable `,` as a default separator in `scope-case`

## Motivation and Context

`scope-case` already had support for using `/` and `\` and delimiters but this, and some issues have mentioned wanting it to be configurable or have it support `,`, ref #701.

This feature seems to have been wanted for a while, ref #75.

Other probably related issues: #318, #312, #307

## Usage examples
<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  extends: ["@commitlint/config-conventional"],
  rules: {
    "scope-enum": [2, "always", ["main", "api", "web"]],
    "scope-empty": [2, "never"]
  }
};

```

```sh
echo "chore(api,web)" | commitlint #passes
echo "chore(api)" | commitlint #passes
echo "chore(unknown)" | commitlint #fails
echo "chore(web,unknown)" | commitlint #fails
```

## How Has This Been Tested?

Extended the tests in scope-enum.test.js

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
