### PR TITLE
test(cli): force plain text when comparing output

### DIFF
--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -329,7 +329,8 @@ test('should handle linting with issue prefixes', async () => {
 test('should print full commit message when input from stdin fails', async () => {
 	const cwd = await gitBootstrap('fixtures/simple');
 	const input = 'foo: bar\n\nFoo bar bizz buzz.\n\nCloses #123.';
-	const actual = await cli([], {cwd})(input);
+	// output text in plain text so we can compare it
+	const actual = await cli(['--color=false'], {cwd})(input);
 
 	expect(actual.stdout).toContain(input);
 	expect(actual.code).toBe(1);
@@ -338,7 +339,8 @@ test('should print full commit message when input from stdin fails', async () =>
 test('should not print commit message fully or partially when input succeeds', async () => {
 	const cwd = await gitBootstrap('fixtures/default');
 	const message = 'type: bar\n\nFoo bar bizz buzz.\n\nCloses #123.';
-	const actual = await cli([], {cwd})(message);
+	// output text in plain text so we can compare it
+	const actual = await cli(['--color=false'], {cwd})(message);
 
 	expect(actual.stdout).not.toContain(message);
 	expect(actual.stdout).not.toContain(message.split('\n')[0]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Jest doesn't disable color outputs on some machines. That results in false positives in the CLI tests.

## ~~Motivation and Context~~

## ~~Usage examples~~

## ~~How Has This Been Tested?~~

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
