### PR TITLE
test(travis-cli): migrate tests from ava to jest

### DIFF
--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -5,7 +5,7 @@ import {merge} from 'lodash';
 import * as sander from 'sander';
 import stream from 'string-to-stream';
 
-const bin = path.normalize(path.join(__dirname, '../lib/cli.js'));
+const bin = require.resolve('../lib/cli.js');
 
 const cli = (args, options) => {
 	return (input = '') => {

--- a/@commitlint/travis-cli/fixtures/commitlint.js
+++ b/@commitlint/travis-cli/fixtures/commitlint.js
@@ -1,2 +1,9 @@
 #!/usr/bin/env node
-console.log(process.argv);
+
+const args = process.argv;
+args.shift(); // remove node
+console.log(
+	args.map((item, index) => {
+		return index === 0 ? 'commitlint' : item;
+	})
+);

--- a/@commitlint/travis-cli/fixtures/git.js
+++ b/@commitlint/travis-cli/fixtures/git.js
@@ -1,2 +1,9 @@
 #!/usr/bin/env node
-console.log(process.argv);
+
+const args = process.argv;
+args.shift(); // remove node
+console.log(
+	args.map((item, index) => {
+		return index === 0 ? 'git' : item;
+	})
+);

--- a/@commitlint/travis-cli/package.json
+++ b/@commitlint/travis-cli/package.json
@@ -42,14 +42,13 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "7.7.7",
     "@babel/cli": "7.7.7",
+    "@babel/core": "7.7.7",
     "@babel/register": "7.7.7",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
     "babel-preset-commitlint": "^8.2.0",
-    "cross-env": "6.0.3",
-    "which": "2.0.1"
+    "cross-env": "6.0.3"
   },
   "dependencies": {
     "@commitlint/cli": "^8.3.5",

--- a/@commitlint/travis-cli/package.json
+++ b/@commitlint/travis-cli/package.json
@@ -13,26 +13,7 @@
     "deps": "dep-check",
     "pkg": "pkg-check --skip-main",
     "start": "ava -c 4 --verbose --watch",
-    "test": "ava -c 4 --verbose",
     "watch": "babel src --out-dir lib --watch --source-maps"
-  },
-  "ava": {
-    "files": [
-      "src/**/*.test.js"
-    ],
-    "source": [
-      "lib/**/*.js"
-    ],
-    "babel": {
-      "testOptions": {
-        "presets": [
-          "babel-preset-commitlint"
-        ]
-      }
-    },
-    "require": [
-      "@babel/register"
-    ]
   },
   "babel": {
     "presets": [
@@ -66,7 +47,6 @@
     "@babel/register": "7.7.7",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
-    "ava": "2.4.0",
     "babel-preset-commitlint": "^8.2.0",
     "cross-env": "6.0.3",
     "which": "2.0.1"

--- a/@commitlint/travis-cli/src/cli.js
+++ b/@commitlint/travis-cli/src/cli.js
@@ -77,7 +77,7 @@ async function lint(args, options) {
 }
 
 async function log(hash) {
-	const result = await execa('git', [
+	const result = await execa(GIT, [
 		'log',
 		'-n',
 		'1',

--- a/@commitlint/travis-cli/src/cli.test.js
+++ b/@commitlint/travis-cli/src/cli.test.js
@@ -22,7 +22,7 @@ const cli = async (config = {}) => {
 	try {
 		return await execa(bin, [], config);
 	} catch (err) {
-		return Promise.reject([err.stdout, err.stderr].join('\n'));
+		throw new Error([err.stdout, err.stderr].join('\n'));
 	}
 };
 
@@ -32,7 +32,7 @@ test('should throw when not on travis ci', async () => {
 		TRAVIS: false
 	};
 
-	await expect(cli({env})).rejects.toContain(
+	await expect(cli({env})).rejects.toThrow(
 		'@commitlint/travis-cli is intended to be used on Travis CI'
 	);
 });
@@ -43,7 +43,7 @@ test('should throw when on travis ci, but env vars are missing', async () => {
 		CI: true
 	};
 
-	await expect(cli({env})).rejects.toContain(
+	await expect(cli({env})).rejects.toThrow(
 		'TRAVIS_COMMIT, TRAVIS_COMMIT_RANGE, TRAVIS_EVENT_TYPE, TRAVIS_REPO_SLUG, TRAVIS_PULL_REQUEST_SLUG'
 	);
 });

--- a/@commitlint/travis-cli/src/cli.test.js
+++ b/@commitlint/travis-cli/src/cli.test.js
@@ -43,24 +43,6 @@ test('should throw when on travis ci, but env vars are missing', async () => {
 	);
 });
 
-test('should throw when on travis ci, but TRAVIS_COMMIT is missing', async () => {
-	const env = {
-		TRAVIS: true,
-		CI: true
-	};
-
-	await expect(cli({env})).rejects.toContain('TRAVIS_COMMIT');
-});
-
-test('should throw when on travis ci, but TRAVIS_BRANCH is missing', async () => {
-	const env = {
-		TRAVIS: true,
-		CI: true
-	};
-
-	await expect(cli({env})).rejects.toContain('TRAVIS_BRANCH');
-});
-
 /*
 test('should call git with expected args on shallow repo', async () => {
 	const cwd = await git.clone(

--- a/@packages/test/src/git.ts
+++ b/@packages/test/src/git.ts
@@ -9,11 +9,16 @@ export async function bootstrap(fixture?: string, directory?: string) {
 	return cwd;
 }
 
-export async function clone(source: string, ...args: string[]) {
-	const cwd = await fix.bootstrap();
+export async function clone(
+	source: string,
+	args: string[],
+	directory?: string,
+	gitCommand = 'git'
+) {
+	const cwd = await fix.bootstrap(undefined, directory);
 
-	await execa('git', ['clone', ...args, source, cwd]);
-	await setup(cwd);
+	await execa(gitCommand, ['clone', ...args, source, cwd]);
+	await setup(cwd, gitCommand);
 	return cwd;
 }
 
@@ -23,11 +28,13 @@ export async function init(cwd: string) {
 	return cwd;
 }
 
-async function setup(cwd: string) {
+async function setup(cwd: string, gitCommand = 'git') {
 	try {
-		await execa('git', ['config', 'user.name', 'ava'], {cwd});
-		await execa('git', ['config', 'user.email', 'test@example.com'], {cwd});
-		await execa('git', ['config', 'commit.gpgsign', 'false'], {cwd});
+		await execa(gitCommand, ['config', 'user.name', 'ava'], {cwd});
+		await execa(gitCommand, ['config', 'user.email', 'test@example.com'], {
+			cwd
+		});
+		await execa(gitCommand, ['config', 'commit.gpgsign', 'false'], {cwd});
 	} catch (err) {
 		console.warn(`git config in ${cwd} failed`, err.message);
 	}

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	testMatch: [
 		'**/*.test.ts?(x)',
 		'**/@commitlint/read/src/*.test.js?(x)',
+		'**/@commitlint/travis-cli/src/*.test.js?(x)',
 		'**/@commitlint/cli/src/*.test.js?(x)'
 	]
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10172,13 +10172,6 @@ which-module@^2.0.0:
   resolved "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/which/-/which-2.0.1.tgz#f1cf94d07a8e571b6ff006aeb91d0300c47ef0a4"
-  integrity sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==
-  dependencies:
-    isexe "^2.0.0"
-
 which@^1.2.10, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"


### PR DESCRIPTION
migrate travis-cli tests from ava to jest

## Description
Most of travis-cli tests are commented out, i enabled / fixed some of them,

Should i update commented one to or should i remove it?
i will prefer that they can be enabled, but instead of cloning actual repo we could mock it up

## How Has This Been Tested?
Unrelated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
