### PR TITLE
test(prompt-cli): migrate ava tests to jest

### DIFF
--- a/@commitlint/prompt-cli/cli.test.js
+++ b/@commitlint/prompt-cli/cli.test.js
@@ -1,10 +1,8 @@
-import path from 'path';
 import {git} from '@commitlint/test';
-import test from 'ava';
 import execa from 'execa';
 import stream from 'string-to-stream';
 
-const bin = path.join(__dirname, './cli.js');
+const bin = require.resolve('./cli.js');
 
 const cli = (args, options) => {
 	return (input = '') => {
@@ -18,8 +16,9 @@ const cli = (args, options) => {
 	};
 };
 
-test('should print warning if stage is empty', async t => {
+test('should print warning if stage is empty', async () => {
 	const cwd = await git.bootstrap();
 	const actual = await cli([], {cwd})('foo: bar');
-	t.true(actual.stdout.includes('Nothing to commit.'));
+	expect(actual.stdout).toContain('Nothing to commit.');
+	expect(actual.stderr).toBe('');
 });

--- a/@commitlint/prompt-cli/package.json
+++ b/@commitlint/prompt-cli/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "commit": "$npm_package_bin_commit",
     "deps": "dep-check",
-    "pkg": "pkg-check --skip-main",
-    "test": "ava -c 4 --verbose"
+    "pkg": "pkg-check --skip-main"
   },
   "repository": {
     "type": "git",
@@ -31,11 +30,10 @@
   "devDependencies": {
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
-    "ava": "2.4.0"
+    "string-to-stream": "3.0.1"
   },
   "dependencies": {
     "@commitlint/prompt": "^8.3.5",
-    "execa": "0.11.0",
-    "string-to-stream": "3.0.1"
+    "execa": "0.11.0"
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	testMatch: [
 		'**/*.test.ts?(x)',
 		'**/@commitlint/read/src/*.test.js?(x)',
-		'**/@commitlint/cli/src/*.test.js?(x)'
+		'**/@commitlint/cli/src/*.test.js?(x)',
+		'**/@commitlint/prompt-cli/*.test.js?(x)'
 	]
 };


### PR DESCRIPTION
migrate prompt-cli tests from ava to jest

## Description
`string-to-stream` is used only in tests, i moved it to dev dependencies

## How Has This Been Tested?
Unrelated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
