### PR TITLE
chore: cleanup no longer used dev dependencies

### DIFF
--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -46,16 +46,11 @@
   "devDependencies": {
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
-    "@babel/register": "^7.7.7",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
     "babel-preset-commitlint": "^8.2.0",
-    "concurrently": "3.6.1",
     "cross-env": "6.0.3",
     "execa": "0.11.0",
-    "mkdirp": "0.5.1",
-    "pkg-dir": "4.2.0",
-    "resolve-bin": "0.4.0",
     "sander": "0.6.0",
     "string-to-stream": "3.0.1"
   },

--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
-    "@babel/register": "^7.7.7",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
     "babel-preset-commitlint": "^8.2.0",

--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -10,7 +10,7 @@
     "build": "cross-env NODE_ENV=production babel src --out-dir lib  --source-maps",
     "deps": "dep-check",
     "pkg": "pkg-check --skip-import",
-    "start": "concurrently \"ava -c 4 --verbose --watch\" \"yarn run watch\"",
+    "start": "yarn run watch",
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "babel": {
@@ -43,11 +43,9 @@
   "devDependencies": {
     "@babel/core": "7.7.7",
     "@babel/cli": "7.7.7",
-    "@babel/register": "7.7.7",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
     "babel-preset-commitlint": "^8.2.0",
-    "concurrently": "3.6.1",
     "cross-env": "6.0.3",
     "execa": "0.11.0"
   },

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -34,16 +34,10 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "7.7.7",
-    "@babel/cli": "7.7.7",
-    "@babel/register": "7.7.7",
     "@commitlint/parse": "^8.3.4",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
-    "babel-preset-commitlint": "^8.2.0",
-    "concurrently": "3.6.1",
     "conventional-changelog-angular": "1.6.6",
-    "cross-env": "6.0.3",
     "globby": "10.0.1",
     "lodash": "4.17.15"
   },

--- a/@commitlint/top-level/package.json
+++ b/@commitlint/top-level/package.json
@@ -11,11 +11,6 @@
     "deps": "dep-check",
     "pkg": "pkg-check"
   },
-  "babel": {
-    "presets": [
-      "babel-preset-commitlint"
-    ]
-  },
   "engines": {
     "node": ">=4"
   },

--- a/@commitlint/travis-cli/package.json
+++ b/@commitlint/travis-cli/package.json
@@ -12,7 +12,7 @@
     "build": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps",
     "deps": "dep-check",
     "pkg": "pkg-check --skip-main",
-    "start": "ava -c 4 --verbose --watch",
+    "start": "yarn run watch",
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "babel": {
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@babel/cli": "7.7.7",
     "@babel/core": "7.7.7",
-    "@babel/register": "7.7.7",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
     "babel-preset-commitlint": "^8.2.0",

--- a/@packages/babel-preset-commitlint/package.json
+++ b/@packages/babel-preset-commitlint/package.json
@@ -43,8 +43,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.7.7",
-    "ava": "2.4.0"
+    "@babel/core": "^7.7.7"
   },
   "dependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.7.5",

--- a/@packages/utils/package.json
+++ b/@packages/utils/package.json
@@ -18,11 +18,6 @@
     "deps": "node dep-check.js",
     "pkg": "node pkg-check.js --skip-main"
   },
-  "ava": {
-    "files": [
-      "cli.test.js"
-    ]
-  },
   "engines": {
     "node": ">=4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4425,11 +4425,6 @@ find-node-modules@2.0.0:
     findup-sync "^3.0.0"
     merge "^1.2.1"
 
-find-parent-dir@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
-  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
-
 find-root@1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
@@ -7112,7 +7107,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@0.5.1, mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@*, mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -8631,13 +8626,6 @@ require-precompiled@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz#5a1b52eb70ebed43eb982e974c85ab59571e56fa"
   integrity sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=
-
-resolve-bin@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/resolve-bin/-/resolve-bin-0.4.0.tgz#47132249891101afb19991fe937cb0a5f072e5d9"
-  integrity sha1-RxMiSYkRAa+xmZH+k3ywpfBy5dk=
-  dependencies:
-    find-parent-dir "~0.3.0"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Cleanup of no longer used dev dependencies and remove some invalid configurations for packages that are already ported to typescript

## Description
<!--- Describe your changes in detail -->

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
