### PR TITLE
chore: use frozen lockfile to fail build if an update is needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,10 @@ commands:
     steps:
       - run:
           name: Install dependencies
-          command: yarn install --ignore-engines
+          command: yarn install --ignore-engines --frozen-lockfile
+      - run:
+          name: Verify if lockfile is up to date
+          command: git diff --quiet --exit-code
   audit:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ commands:
       - run:
           name: Install dependencies
           command: yarn install --ignore-engines --frozen-lockfile
-      - run:
-          name: Verify if lockfile is up to date
-          command: git diff --quiet --exit-code
   audit:
     steps:
       - run:


### PR DESCRIPTION
This change ensures that yarn.lock and other lock files are valid and do not change after install

## Motivation and Context


## How Has This Been Tested?
Ci has to pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
