### PR TITLE
test: add simple tests for configs

### DIFF
--- a/@commitlint/config-angular-type-enum/__snapshots__/index.test.js.snap
+++ b/@commitlint/config-angular-type-enum/__snapshots__/index.test.js.snap
@@ -2,21 +2,21 @@
 
 exports[`rules type-enum empty 1`] = `
 Array [
-  false,
-  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+  true,
+  "type must be one of [build, ci, docs, feat, fix, perf, refactor, revert, style, test]",
 ]
 `;
 
 exports[`rules type-enum filled 1`] = `
 Array [
-  false,
-  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+  true,
+  "type must be one of [build, ci, docs, feat, fix, perf, refactor, revert, style, test]",
 ]
 `;
 
 exports[`rules type-enum simple 1`] = `
 Array [
-  false,
-  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+  true,
+  "type must be one of [build, ci, docs, feat, fix, perf, refactor, revert, style, test]",
 ]
 `;

--- a/@commitlint/config-angular-type-enum/__snapshots__/index.test.js.snap
+++ b/@commitlint/config-angular-type-enum/__snapshots__/index.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rules type-enum empty 1`] = `
+Array [
+  false,
+  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+]
+`;
+
+exports[`rules type-enum filled 1`] = `
+Array [
+  false,
+  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+]
+`;
+
+exports[`rules type-enum simple 1`] = `
+Array [
+  false,
+  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+]
+`;

--- a/@commitlint/config-angular-type-enum/index.test.js
+++ b/@commitlint/config-angular-type-enum/index.test.js
@@ -17,10 +17,9 @@ it('should have correct structure', () => {
 
 describe('rules', () => {
 	describe.each(configRules)('%s', (name, options) => {
-		const severity = options.unshift();
 		it.each(messages)('%s', async (type, message) => {
 			expect(
-				rules[name](await parse(message), severity, options)
+				rules[name](await parse(message), ...options.slice(1))
 			).toMatchSnapshot();
 		});
 	});

--- a/@commitlint/config-angular-type-enum/index.test.js
+++ b/@commitlint/config-angular-type-enum/index.test.js
@@ -1,0 +1,27 @@
+import config from '.';
+import rules from '@commitlint/rules';
+import parse from '@commitlint/parse';
+
+const messages = Object.entries({
+	simple: 'test: subject',
+	empty: 'test: subject\nbody',
+	filled: 'test: subject\nBREAKING CHANGE: something important'
+});
+const configRules = Object.entries(config.rules);
+
+it('should have correct structure', () => {
+	expect(config).toMatchObject({
+		rules: expect.any(Object)
+	});
+});
+
+describe('rules', () => {
+	describe.each(configRules)('%s', (name, options) => {
+		const severity = options.unshift();
+		it.each(messages)('%s', async (type, message) => {
+			expect(
+				rules[name](await parse(message), severity, options)
+			).toMatchSnapshot();
+		});
+	});
+});

--- a/@commitlint/config-angular-type-enum/package.json
+++ b/@commitlint/config-angular-type-enum/package.json
@@ -28,7 +28,14 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "babel": {
+    "presets": [
+      "babel-preset-commitlint"
+    ]
+  },
   "devDependencies": {
-    "@commitlint/utils": "^8.3.4"
+    "@commitlint/utils": "^8.3.4",
+    "@commitlint/rules": "^8.3.4",
+    "@commitlint/parse": "^8.3.4"
   }
 }

--- a/@commitlint/config-angular/__snapshots__/index.test.js.snap
+++ b/@commitlint/config-angular/__snapshots__/index.test.js.snap
@@ -1,0 +1,204 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rules body-leading-blank empty 1`] = `
+Array [
+  false,
+  "body must have leading blank line",
+]
+`;
+
+exports[`rules body-leading-blank filled 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules body-leading-blank simple 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules footer-leading-blank empty 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules footer-leading-blank filled 1`] = `
+Array [
+  false,
+  "footer must have leading blank line",
+]
+`;
+
+exports[`rules footer-leading-blank simple 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules header-max-length empty 1`] = `
+Array [
+  false,
+  "header must not be longer than 2,always,72 characters, current length is 13",
+]
+`;
+
+exports[`rules header-max-length filled 1`] = `
+Array [
+  false,
+  "header must not be longer than 2,always,72 characters, current length is 13",
+]
+`;
+
+exports[`rules header-max-length simple 1`] = `
+Array [
+  false,
+  "header must not be longer than 2,always,72 characters, current length is 13",
+]
+`;
+
+exports[`rules scope-case empty 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules scope-case filled 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules scope-case simple 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules subject-case empty 1`] = `
+Array [
+  true,
+  "subject must be , never, ",
+]
+`;
+
+exports[`rules subject-case filled 1`] = `
+Array [
+  true,
+  "subject must be , never, ",
+]
+`;
+
+exports[`rules subject-case simple 1`] = `
+Array [
+  true,
+  "subject must be , never, ",
+]
+`;
+
+exports[`rules subject-empty empty 1`] = `
+Array [
+  false,
+  "subject must be empty",
+]
+`;
+
+exports[`rules subject-empty filled 1`] = `
+Array [
+  false,
+  "subject must be empty",
+]
+`;
+
+exports[`rules subject-empty simple 1`] = `
+Array [
+  false,
+  "subject must be empty",
+]
+`;
+
+exports[`rules subject-full-stop empty 1`] = `
+Array [
+  false,
+  "subject must end with full stop",
+]
+`;
+
+exports[`rules subject-full-stop filled 1`] = `
+Array [
+  false,
+  "subject must end with full stop",
+]
+`;
+
+exports[`rules subject-full-stop simple 1`] = `
+Array [
+  false,
+  "subject must end with full stop",
+]
+`;
+
+exports[`rules type-case empty 1`] = `
+Array [
+  true,
+  "type must be , always, lower-case",
+]
+`;
+
+exports[`rules type-case filled 1`] = `
+Array [
+  true,
+  "type must be , always, lower-case",
+]
+`;
+
+exports[`rules type-case simple 1`] = `
+Array [
+  true,
+  "type must be , always, lower-case",
+]
+`;
+
+exports[`rules type-empty empty 1`] = `
+Array [
+  false,
+  "type must be empty",
+]
+`;
+
+exports[`rules type-empty filled 1`] = `
+Array [
+  false,
+  "type must be empty",
+]
+`;
+
+exports[`rules type-empty simple 1`] = `
+Array [
+  false,
+  "type must be empty",
+]
+`;
+
+exports[`rules type-enum empty 1`] = `
+Array [
+  false,
+  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+]
+`;
+
+exports[`rules type-enum filled 1`] = `
+Array [
+  false,
+  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+]
+`;
+
+exports[`rules type-enum simple 1`] = `
+Array [
+  false,
+  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+]
+`;

--- a/@commitlint/config-angular/__snapshots__/index.test.js.snap
+++ b/@commitlint/config-angular/__snapshots__/index.test.js.snap
@@ -40,22 +40,22 @@ Array [
 
 exports[`rules header-max-length empty 1`] = `
 Array [
-  false,
-  "header must not be longer than 2,always,72 characters, current length is 13",
+  true,
+  "header must not be longer than 72 characters, current length is 13",
 ]
 `;
 
 exports[`rules header-max-length filled 1`] = `
 Array [
-  false,
-  "header must not be longer than 2,always,72 characters, current length is 13",
+  true,
+  "header must not be longer than 72 characters, current length is 13",
 ]
 `;
 
 exports[`rules header-max-length simple 1`] = `
 Array [
-  false,
-  "header must not be longer than 2,always,72 characters, current length is 13",
+  true,
+  "header must not be longer than 72 characters, current length is 13",
 ]
 `;
 
@@ -80,125 +80,125 @@ Array [
 exports[`rules subject-case empty 1`] = `
 Array [
   true,
-  "subject must be , never, ",
+  "subject must not be sentence-case, start-case, pascal-case, upper-case",
 ]
 `;
 
 exports[`rules subject-case filled 1`] = `
 Array [
   true,
-  "subject must be , never, ",
+  "subject must not be sentence-case, start-case, pascal-case, upper-case",
 ]
 `;
 
 exports[`rules subject-case simple 1`] = `
 Array [
   true,
-  "subject must be , never, ",
+  "subject must not be sentence-case, start-case, pascal-case, upper-case",
 ]
 `;
 
 exports[`rules subject-empty empty 1`] = `
 Array [
-  false,
-  "subject must be empty",
+  true,
+  "subject may not be empty",
 ]
 `;
 
 exports[`rules subject-empty filled 1`] = `
 Array [
-  false,
-  "subject must be empty",
+  true,
+  "subject may not be empty",
 ]
 `;
 
 exports[`rules subject-empty simple 1`] = `
 Array [
-  false,
-  "subject must be empty",
+  true,
+  "subject may not be empty",
 ]
 `;
 
 exports[`rules subject-full-stop empty 1`] = `
 Array [
-  false,
-  "subject must end with full stop",
+  true,
+  "subject may not end with full stop",
 ]
 `;
 
 exports[`rules subject-full-stop filled 1`] = `
 Array [
-  false,
-  "subject must end with full stop",
+  true,
+  "subject may not end with full stop",
 ]
 `;
 
 exports[`rules subject-full-stop simple 1`] = `
 Array [
-  false,
-  "subject must end with full stop",
+  true,
+  "subject may not end with full stop",
 ]
 `;
 
 exports[`rules type-case empty 1`] = `
 Array [
   true,
-  "type must be , always, lower-case",
+  "type must be lower-case",
 ]
 `;
 
 exports[`rules type-case filled 1`] = `
 Array [
   true,
-  "type must be , always, lower-case",
+  "type must be lower-case",
 ]
 `;
 
 exports[`rules type-case simple 1`] = `
 Array [
   true,
-  "type must be , always, lower-case",
+  "type must be lower-case",
 ]
 `;
 
 exports[`rules type-empty empty 1`] = `
 Array [
-  false,
-  "type must be empty",
+  true,
+  "type may not be empty",
 ]
 `;
 
 exports[`rules type-empty filled 1`] = `
 Array [
-  false,
-  "type must be empty",
+  true,
+  "type may not be empty",
 ]
 `;
 
 exports[`rules type-empty simple 1`] = `
 Array [
-  false,
-  "type must be empty",
+  true,
+  "type may not be empty",
 ]
 `;
 
 exports[`rules type-enum empty 1`] = `
 Array [
-  false,
-  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+  true,
+  "type must be one of [build, ci, docs, feat, fix, perf, refactor, revert, style, test]",
 ]
 `;
 
 exports[`rules type-enum filled 1`] = `
 Array [
-  false,
-  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+  true,
+  "type must be one of [build, ci, docs, feat, fix, perf, refactor, revert, style, test]",
 ]
 `;
 
 exports[`rules type-enum simple 1`] = `
 Array [
-  false,
-  "type must be one of [2, always, build,ci,docs,feat,fix,perf,refactor,revert,style,test]",
+  true,
+  "type must be one of [build, ci, docs, feat, fix, perf, refactor, revert, style, test]",
 ]
 `;

--- a/@commitlint/config-angular/index.test.js
+++ b/@commitlint/config-angular/index.test.js
@@ -17,10 +17,9 @@ it('should have correct structure', () => {
 
 describe('rules', () => {
 	describe.each(configRules)('%s', (name, options) => {
-		const severity = options.unshift();
 		it.each(messages)('%s', async (type, message) => {
 			expect(
-				rules[name](await parse(message), severity, options)
+				rules[name](await parse(message), ...options.slice(1))
 			).toMatchSnapshot();
 		});
 	});

--- a/@commitlint/config-angular/index.test.js
+++ b/@commitlint/config-angular/index.test.js
@@ -1,0 +1,27 @@
+import config from '.';
+import rules from '@commitlint/rules';
+import parse from '@commitlint/parse';
+
+const messages = Object.entries({
+	simple: 'test: subject',
+	empty: 'test: subject\nbody',
+	filled: 'test: subject\nBREAKING CHANGE: something important'
+});
+const configRules = Object.entries(config.rules);
+
+it('should have correct structure', () => {
+	expect(config).toMatchObject({
+		rules: expect.any(Object)
+	});
+});
+
+describe('rules', () => {
+	describe.each(configRules)('%s', (name, options) => {
+		const severity = options.unshift();
+		it.each(messages)('%s', async (type, message) => {
+			expect(
+				rules[name](await parse(message), severity, options)
+			).toMatchSnapshot();
+		});
+	});
+});

--- a/@commitlint/config-angular/package.json
+++ b/@commitlint/config-angular/package.json
@@ -28,8 +28,15 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "babel": {
+    "presets": [
+      "babel-preset-commitlint"
+    ]
+  },
   "devDependencies": {
-    "@commitlint/utils": "^8.3.4"
+    "@commitlint/utils": "^8.3.4",
+    "@commitlint/rules": "^8.3.4",
+    "@commitlint/parse": "^8.3.4"
   },
   "dependencies": {
     "@commitlint/config-angular-type-enum": "^8.3.4"

--- a/@commitlint/config-conventional/__snapshots__/index.test.js.snap
+++ b/@commitlint/config-conventional/__snapshots__/index.test.js.snap
@@ -1,0 +1,204 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rules body-leading-blank empty 1`] = `
+Array [
+  false,
+  "body must have leading blank line",
+]
+`;
+
+exports[`rules body-leading-blank filled 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules body-leading-blank simple 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules footer-leading-blank empty 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules footer-leading-blank filled 1`] = `
+Array [
+  false,
+  "footer must have leading blank line",
+]
+`;
+
+exports[`rules footer-leading-blank simple 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules header-max-length empty 1`] = `
+Array [
+  false,
+  "header must not be longer than 2,always,72 characters, current length is 13",
+]
+`;
+
+exports[`rules header-max-length filled 1`] = `
+Array [
+  false,
+  "header must not be longer than 2,always,72 characters, current length is 13",
+]
+`;
+
+exports[`rules header-max-length simple 1`] = `
+Array [
+  false,
+  "header must not be longer than 2,always,72 characters, current length is 13",
+]
+`;
+
+exports[`rules scope-case empty 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules scope-case filled 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules scope-case simple 1`] = `
+Array [
+  true,
+]
+`;
+
+exports[`rules subject-case empty 1`] = `
+Array [
+  true,
+  "subject must be , never, ",
+]
+`;
+
+exports[`rules subject-case filled 1`] = `
+Array [
+  true,
+  "subject must be , never, ",
+]
+`;
+
+exports[`rules subject-case simple 1`] = `
+Array [
+  true,
+  "subject must be , never, ",
+]
+`;
+
+exports[`rules subject-empty empty 1`] = `
+Array [
+  false,
+  "subject must be empty",
+]
+`;
+
+exports[`rules subject-empty filled 1`] = `
+Array [
+  false,
+  "subject must be empty",
+]
+`;
+
+exports[`rules subject-empty simple 1`] = `
+Array [
+  false,
+  "subject must be empty",
+]
+`;
+
+exports[`rules subject-full-stop empty 1`] = `
+Array [
+  false,
+  "subject must end with full stop",
+]
+`;
+
+exports[`rules subject-full-stop filled 1`] = `
+Array [
+  false,
+  "subject must end with full stop",
+]
+`;
+
+exports[`rules subject-full-stop simple 1`] = `
+Array [
+  false,
+  "subject must end with full stop",
+]
+`;
+
+exports[`rules type-case empty 1`] = `
+Array [
+  true,
+  "type must be , always, lower-case",
+]
+`;
+
+exports[`rules type-case filled 1`] = `
+Array [
+  true,
+  "type must be , always, lower-case",
+]
+`;
+
+exports[`rules type-case simple 1`] = `
+Array [
+  true,
+  "type must be , always, lower-case",
+]
+`;
+
+exports[`rules type-empty empty 1`] = `
+Array [
+  false,
+  "type must be empty",
+]
+`;
+
+exports[`rules type-empty filled 1`] = `
+Array [
+  false,
+  "type must be empty",
+]
+`;
+
+exports[`rules type-empty simple 1`] = `
+Array [
+  false,
+  "type must be empty",
+]
+`;
+
+exports[`rules type-enum empty 1`] = `
+Array [
+  false,
+  "type must be one of [2, always, build,chore,ci,docs,feat,fix,improvement,perf,refactor,revert,style,test]",
+]
+`;
+
+exports[`rules type-enum filled 1`] = `
+Array [
+  false,
+  "type must be one of [2, always, build,chore,ci,docs,feat,fix,improvement,perf,refactor,revert,style,test]",
+]
+`;
+
+exports[`rules type-enum simple 1`] = `
+Array [
+  false,
+  "type must be one of [2, always, build,chore,ci,docs,feat,fix,improvement,perf,refactor,revert,style,test]",
+]
+`;

--- a/@commitlint/config-conventional/__snapshots__/index.test.js.snap
+++ b/@commitlint/config-conventional/__snapshots__/index.test.js.snap
@@ -40,22 +40,22 @@ Array [
 
 exports[`rules header-max-length empty 1`] = `
 Array [
-  false,
-  "header must not be longer than 2,always,72 characters, current length is 13",
+  true,
+  "header must not be longer than 72 characters, current length is 13",
 ]
 `;
 
 exports[`rules header-max-length filled 1`] = `
 Array [
-  false,
-  "header must not be longer than 2,always,72 characters, current length is 13",
+  true,
+  "header must not be longer than 72 characters, current length is 13",
 ]
 `;
 
 exports[`rules header-max-length simple 1`] = `
 Array [
-  false,
-  "header must not be longer than 2,always,72 characters, current length is 13",
+  true,
+  "header must not be longer than 72 characters, current length is 13",
 ]
 `;
 
@@ -80,125 +80,125 @@ Array [
 exports[`rules subject-case empty 1`] = `
 Array [
   true,
-  "subject must be , never, ",
+  "subject must not be sentence-case, start-case, pascal-case, upper-case",
 ]
 `;
 
 exports[`rules subject-case filled 1`] = `
 Array [
   true,
-  "subject must be , never, ",
+  "subject must not be sentence-case, start-case, pascal-case, upper-case",
 ]
 `;
 
 exports[`rules subject-case simple 1`] = `
 Array [
   true,
-  "subject must be , never, ",
+  "subject must not be sentence-case, start-case, pascal-case, upper-case",
 ]
 `;
 
 exports[`rules subject-empty empty 1`] = `
 Array [
-  false,
-  "subject must be empty",
+  true,
+  "subject may not be empty",
 ]
 `;
 
 exports[`rules subject-empty filled 1`] = `
 Array [
-  false,
-  "subject must be empty",
+  true,
+  "subject may not be empty",
 ]
 `;
 
 exports[`rules subject-empty simple 1`] = `
 Array [
-  false,
-  "subject must be empty",
+  true,
+  "subject may not be empty",
 ]
 `;
 
 exports[`rules subject-full-stop empty 1`] = `
 Array [
-  false,
-  "subject must end with full stop",
+  true,
+  "subject may not end with full stop",
 ]
 `;
 
 exports[`rules subject-full-stop filled 1`] = `
 Array [
-  false,
-  "subject must end with full stop",
+  true,
+  "subject may not end with full stop",
 ]
 `;
 
 exports[`rules subject-full-stop simple 1`] = `
 Array [
-  false,
-  "subject must end with full stop",
+  true,
+  "subject may not end with full stop",
 ]
 `;
 
 exports[`rules type-case empty 1`] = `
 Array [
   true,
-  "type must be , always, lower-case",
+  "type must be lower-case",
 ]
 `;
 
 exports[`rules type-case filled 1`] = `
 Array [
   true,
-  "type must be , always, lower-case",
+  "type must be lower-case",
 ]
 `;
 
 exports[`rules type-case simple 1`] = `
 Array [
   true,
-  "type must be , always, lower-case",
+  "type must be lower-case",
 ]
 `;
 
 exports[`rules type-empty empty 1`] = `
 Array [
-  false,
-  "type must be empty",
+  true,
+  "type may not be empty",
 ]
 `;
 
 exports[`rules type-empty filled 1`] = `
 Array [
-  false,
-  "type must be empty",
+  true,
+  "type may not be empty",
 ]
 `;
 
 exports[`rules type-empty simple 1`] = `
 Array [
-  false,
-  "type must be empty",
+  true,
+  "type may not be empty",
 ]
 `;
 
 exports[`rules type-enum empty 1`] = `
 Array [
-  false,
-  "type must be one of [2, always, build,chore,ci,docs,feat,fix,improvement,perf,refactor,revert,style,test]",
+  true,
+  "type must be one of [build, chore, ci, docs, feat, fix, improvement, perf, refactor, revert, style, test]",
 ]
 `;
 
 exports[`rules type-enum filled 1`] = `
 Array [
-  false,
-  "type must be one of [2, always, build,chore,ci,docs,feat,fix,improvement,perf,refactor,revert,style,test]",
+  true,
+  "type must be one of [build, chore, ci, docs, feat, fix, improvement, perf, refactor, revert, style, test]",
 ]
 `;
 
 exports[`rules type-enum simple 1`] = `
 Array [
-  false,
-  "type must be one of [2, always, build,chore,ci,docs,feat,fix,improvement,perf,refactor,revert,style,test]",
+  true,
+  "type must be one of [build, chore, ci, docs, feat, fix, improvement, perf, refactor, revert, style, test]",
 ]
 `;

--- a/@commitlint/config-conventional/index.test.js
+++ b/@commitlint/config-conventional/index.test.js
@@ -17,10 +17,9 @@ it('should have correct structure', () => {
 
 describe('rules', () => {
 	describe.each(configRules)('%s', (name, options) => {
-		const severity = options.unshift();
 		it.each(messages)('%s', async (type, message) => {
 			expect(
-				rules[name](await parse(message), severity, options)
+				rules[name](await parse(message), ...options.slice(1))
 			).toMatchSnapshot();
 		});
 	});

--- a/@commitlint/config-conventional/index.test.js
+++ b/@commitlint/config-conventional/index.test.js
@@ -1,0 +1,27 @@
+import config from '.';
+import rules from '@commitlint/rules';
+import parse from '@commitlint/parse';
+
+const messages = Object.entries({
+	simple: 'test: subject',
+	empty: 'test: subject\nbody',
+	filled: 'test: subject\nBREAKING CHANGE: something important'
+});
+const configRules = Object.entries(config.rules);
+
+it('should have correct structure', () => {
+	expect(config).toMatchObject({
+		rules: expect.any(Object)
+	});
+});
+
+describe('rules', () => {
+	describe.each(configRules)('%s', (name, options) => {
+		const severity = options.unshift();
+		it.each(messages)('%s', async (type, message) => {
+			expect(
+				rules[name](await parse(message), severity, options)
+			).toMatchSnapshot();
+		});
+	});
+});

--- a/@commitlint/config-conventional/package.json
+++ b/@commitlint/config-conventional/package.json
@@ -31,8 +31,15 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "babel": {
+    "presets": [
+      "babel-preset-commitlint"
+    ]
+  },
   "devDependencies": {
-    "@commitlint/utils": "^8.3.4"
+    "@commitlint/utils": "^8.3.4",
+    "@commitlint/rules": "^8.3.4",
+    "@commitlint/parse": "^8.3.4"
   },
   "dependencies": {
     "conventional-changelog-conventionalcommits": "4.2.1"

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,9 @@ module.exports = {
 		'**/@commitlint/read/src/*.test.js?(x)',
 		'**/@commitlint/travis-cli/src/*.test.js?(x)',
 		'**/@commitlint/cli/src/*.test.js?(x)',
-		'**/@commitlint/prompt-cli/*.test.js?(x)'
+		'**/@commitlint/prompt-cli/*.test.js?(x)',
+		'**/@commitlint/config-angular/*.test.js?(x)',
+		'**/@commitlint/config-angular-type-enum/*.test.js?(x)',
+		'**/@commitlint/config-conventional/*.test.js?(x)'
 	]
 };


### PR DESCRIPTION
Add simple generic tests for configs

## Description
As for testing to make them generic i used jest snapshots

new tests cover configs:
- @commitlint/config-angular
- @commitlint/config-angular-type-enum
- @commitlint/config-conventional

## Motivation and Context
#889

## Usage examples
```bash
$ jest
```

## How Has This Been Tested?
This is adding new tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New test cases
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
