### PR TITLE
test: execute tests from all packages

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
 	testRegex: undefined,
 	testMatch: [
 		'**/*.test.ts?(x)',
-		'**/@commitlint/{lint,read,travis-cli,cli,load,prompt}/src/*.test.js?(x)',
+		'**/@commitlint/{lint,read,travis-cli,cli,load,prompt}/src/**/*.test.js?(x)',
 		'**/@commitlint/prompt-cli/*.test.js?(x)'
 	]
 };


### PR DESCRIPTION
Make sure that tests from deep folders are executed,

## Description
Currently test file located in `@commitlint\prompt\src\library\get-prompt.test.js` is not executed

![image](https://user-images.githubusercontent.com/625469/73681918-91fa0180-46bf-11ea-9e7a-129fcc24d30d.png)

## Motivation and Context
Fix issue introduced in #786

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Configuration

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
