### PR TITLE
chore: remove obsolete git add

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   },
   "lint-staged": {
     "*.{ts,js}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "renovate": {


### PR DESCRIPTION
`lint-staged` does add changes automatically now. Printed this warning 

```
⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
```