### PR TITLE
chore: import only required lodash functions

### DIFF
--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import {fix, git} from '@commitlint/test';
 import execa from 'execa';
-import {merge} from 'lodash';
+import merge from 'lodash/merge';
 import * as sander from 'sander';
 import stream from 'string-to-stream';
 

--- a/@commitlint/config-patternplate/index.js
+++ b/@commitlint/config-patternplate/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const globby = require('globby');
-const {merge} = require('lodash');
+const merge = require('lodash/merge');
 
 function pathToId(root, filePath) {
 	const relativePath = path.relative(root, filePath);

--- a/@commitlint/ensure/src/case.ts
+++ b/@commitlint/ensure/src/case.ts
@@ -1,4 +1,8 @@
-import * as _ from 'lodash';
+import camelCase from 'lodash/camelCase';
+import kebabCase from 'lodash/kebabCase';
+import snakeCase from 'lodash/snakeCase';
+import upperFirst from 'lodash/upperFirst';
+import startCase from 'lodash/startCase';
 
 export default ensureCase;
 
@@ -38,15 +42,15 @@ function ensureCase(
 function toCase(input: string, target: TargetCaseType): string {
 	switch (target) {
 		case 'camel-case':
-			return _.camelCase(input);
+			return camelCase(input);
 		case 'kebab-case':
-			return _.kebabCase(input);
+			return kebabCase(input);
 		case 'snake-case':
-			return _.snakeCase(input);
+			return snakeCase(input);
 		case 'pascal-case':
-			return _.upperFirst(_.camelCase(input));
+			return upperFirst(camelCase(input));
 		case 'start-case':
-			return _.startCase(input);
+			return startCase(input);
 		case 'upper-case':
 		case 'uppercase':
 			return input.toUpperCase();

--- a/@commitlint/ensure/src/index.test.ts
+++ b/@commitlint/ensure/src/index.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import globby from 'globby';
-import {camelCase, values} from 'lodash';
+import values from 'lodash/values';
+import camelCase from 'lodash/camelCase';
 import * as ensure from '.';
 
 test('exports all checkers', async () => {

--- a/@commitlint/lint/src/index.js
+++ b/@commitlint/lint/src/index.js
@@ -2,7 +2,8 @@ import util from 'util';
 import isIgnored from '@commitlint/is-ignored';
 import parse from '@commitlint/parse';
 import implementations from '@commitlint/rules';
-import {toPairs, values} from 'lodash';
+import toPairs from 'lodash/toPairs';
+import values from 'lodash/values';
 
 const buildCommitMesage = ({header, body, footer}) => {
 	let message = header;

--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -1,6 +1,9 @@
 import Path from 'path';
 
-import {toPairs, merge, mergeWith, pick} from 'lodash';
+import toPairs from 'lodash/toPairs';
+import merge from 'lodash/merge';
+import mergeWith from 'lodash/mergeWith';
+import pick from 'lodash/pick';
 import resolveFrom from 'resolve-from';
 
 import executeRule from '@commitlint/execute-rule';

--- a/@commitlint/load/src/utils/load-parser-opts.ts
+++ b/@commitlint/load/src/utils/load-parser-opts.ts
@@ -1,4 +1,4 @@
-import {startsWith} from 'lodash';
+import startsWith from 'lodash/startsWith';
 
 export async function loadParserOpts(
 	parserName: string,

--- a/@commitlint/load/src/utils/pick-config.ts
+++ b/@commitlint/load/src/utils/pick-config.ts
@@ -1,5 +1,5 @@
 import {UserConfig} from '../types';
-import {pick} from 'lodash';
+import pick from 'lodash/pick';
 
 export const pickConfig = (input: unknown): UserConfig =>
 	pick(

--- a/@commitlint/parse/src/index.ts
+++ b/@commitlint/parse/src/index.ts
@@ -1,4 +1,5 @@
-import {isArray, mergeWith} from 'lodash';
+import mergeWith from 'lodash/mergeWith';
+import isArray from 'lodash/isArray';
 import {Commit, Parser, ParserOptions} from './types';
 
 const {sync} = require('conventional-commits-parser');

--- a/@commitlint/prompt/src/library/format.js
+++ b/@commitlint/prompt/src/library/format.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import {toPairs} from 'lodash';
+import toPairs from 'lodash/toPairs';
 
 export default format;
 

--- a/@commitlint/prompt/src/library/get-forced-case-fn.js
+++ b/@commitlint/prompt/src/library/get-forced-case-fn.js
@@ -1,4 +1,8 @@
-import * as _ from 'lodash';
+import camelCase from 'lodash/camelCase';
+import kebabCase from 'lodash/kebabCase';
+import snakeCase from 'lodash/snakeCase';
+import upperFirst from 'lodash/upperFirst';
+import startCase from 'lodash/startCase';
 
 /**
  * Get forced case for rule
@@ -38,15 +42,15 @@ export default function getForcedCaseFn(rule) {
 
 	switch (target) {
 		case 'camel-case':
-			return input => _.camelCase(input);
+			return input => camelCase(input);
 		case 'kebab-case':
-			return input => _.kebabCase(input);
+			return input => kebabCase(input);
 		case 'snake-case':
-			return input => _.snakeCase(input);
+			return input => snakeCase(input);
 		case 'pascal-case':
-			return input => _.upperFirst(_.camelCase(input));
+			return input => upperFirst(camelCase(input));
 		case 'start-case':
-			return input => _.startCase(input);
+			return input => startCase(input);
 		case 'upper-case':
 		case 'uppercase':
 			return input => input.toUpperCase();

--- a/@commitlint/prompt/src/library/meta.js
+++ b/@commitlint/prompt/src/library/meta.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import {toPairs} from 'lodash';
+import toPairs from 'lodash/toPairs';
 
 /**
  * Get formatted meta hints for configuration

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -2,7 +2,10 @@ import path from 'path';
 
 import 'resolve-global';
 import resolveFrom from 'resolve-from';
-import {isArray, merge, mergeWith, omit} from 'lodash';
+import isArray from 'lodash/isArray';
+import merge from 'lodash/merge';
+import mergeWith from 'lodash/mergeWith';
+import omit from 'lodash/omit';
 
 const importFresh = require('import-fresh');
 

--- a/@packages/utils/pkg-check.js
+++ b/@packages/utils/pkg-check.js
@@ -8,7 +8,7 @@ const meow = require('meow');
 const readPkg = require('read-pkg');
 const requireFromString = require('require-from-string');
 const tar = require('tar-fs');
-const {values} = require('lodash');
+const values = require('lodash/values');
 const {fix} = require('@commitlint/test');
 
 const builtin = require.resolve('is-builtin-module');


### PR DESCRIPTION
Import only required lodash functions, this format is recommended to reduce size of bundled package (in case if someone will use it in tooling)

## Description

## Motivation and Context

## Usage examples

## How Has This Been Tested?
Manual tests + unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
