### PR TITLE
refactor: replace unmaintained sander package with fs-extra

### DIFF
--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -51,7 +51,7 @@
     "babel-preset-commitlint": "^8.2.0",
     "cross-env": "7.0.0",
     "execa": "0.11.0",
-    "sander": "0.6.0",
+    "fs-extra": "^8.1.0",
     "string-to-stream": "3.0.1"
   },
   "dependencies": {

--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -2,7 +2,7 @@ import path from 'path';
 import {fix, git} from '@commitlint/test';
 import execa from 'execa';
 import {merge} from 'lodash';
-import * as sander from 'sander';
+import fs from 'fs-extra';
 import stream from 'string-to-stream';
 
 const bin = require.resolve('../lib/cli.js');
@@ -233,7 +233,7 @@ test('should work with husky via commitlint -e %HUSKY_GIT_PARAMS%', async () => 
 
 test('should allow reading of environment variables for edit file, succeeding if valid', async () => {
 	const cwd = await gitBootstrap('fixtures/simple');
-	await sander.writeFile(cwd, 'commit-msg-file', 'foo');
+	await fs.writeFile(path.join(cwd, 'commit-msg-file'), 'foo');
 	const actual = await cli(['--env', 'variable'], {
 		cwd,
 		env: {variable: 'commit-msg-file'}
@@ -243,9 +243,8 @@ test('should allow reading of environment variables for edit file, succeeding if
 
 test('should allow reading of environment variables for edit file, failing if invalid', async () => {
 	const cwd = await gitBootstrap('fixtures/simple');
-	await sander.writeFile(
-		cwd,
-		'commit-msg-file',
+	await fs.writeFile(
+		path.join(cwd, 'commit-msg-file'),
 		'foo: bar\n\nFoo bar bizz buzz.\n\nCloses #123.'
 	);
 	const actual = await cli(['--env', 'variable'], {
@@ -428,7 +427,7 @@ test('should work with relative formatter path', async () => {
 
 async function writePkg(payload, options) {
 	const pkgPath = path.join(options.cwd, 'package.json');
-	const pkg = JSON.parse(await sander.readFile(pkgPath));
+	const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf-8'));
 	const result = merge(pkg, payload);
-	await sander.writeFile(pkgPath, JSON.stringify(result, null, '  '));
+	await fs.writeFile(pkgPath, JSON.stringify(result, null, '  '));
 }

--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@commitlint/top-level": "^8.3.4",
-    "@marionebl/sander": "^0.6.0",
+    "fs-extra": "^8.1.0",
     "git-raw-commits": "^2.0.0"
   }
 }

--- a/@commitlint/read/src/get-edit-commit.ts
+++ b/@commitlint/read/src/get-edit-commit.ts
@@ -1,7 +1,6 @@
 import toplevel from '@commitlint/top-level';
+import fs from 'fs-extra';
 import {getEditFilePath} from './get-edit-file-path';
-
-const sander = require('@marionebl/sander');
 
 // Get recently edited commit message
 export async function getEditCommit(
@@ -15,7 +14,7 @@ export async function getEditCommit(
 	}
 
 	const editFilePath = await getEditFilePath(top, edit);
+	const editFile: Buffer = await fs.readFile(editFilePath);
 
-	const editFile: Buffer = await sander.readFile(editFilePath);
 	return [`${editFile.toString('utf-8')}\n`];
 }

--- a/@commitlint/read/src/get-edit-file-path.ts
+++ b/@commitlint/read/src/get-edit-file-path.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import {Stats} from 'fs';
-
-const sander = require('@marionebl/sander');
+import fs from 'fs-extra';
 
 // Get path to recently edited commit message file
 export async function getEditFilePath(
@@ -13,13 +12,13 @@ export async function getEditFilePath(
 	}
 
 	const dotgitPath = path.join(top, '.git');
-	const dotgitStats: Stats = sander.lstatSync(dotgitPath);
+	const dotgitStats: Stats = await fs.lstat(dotgitPath);
 
 	if (dotgitStats.isDirectory()) {
 		return path.join(top, '.git/COMMIT_EDITMSG');
 	}
 
-	const gitFile: string = await sander.readFile(dotgitPath, {
+	const gitFile: string = await fs.readFile(dotgitPath, {
 		encoding: 'utf-8'
 	});
 	const relativeGitPath = gitFile.replace('gitdir: ', '').replace('\n', '');

--- a/@commitlint/read/src/read.test.ts
+++ b/@commitlint/read/src/read.test.ts
@@ -1,14 +1,14 @@
+import path from 'path';
 import {git} from '@commitlint/test';
 import execa from 'execa';
-
-const sander = require('@marionebl/sander');
+import fs from 'fs-extra';
 
 import read from './read';
 
 test('get edit commit message specified by the `edit` flag', async () => {
 	const cwd: string = await git.bootstrap();
 
-	await sander.writeFile(cwd, 'commit-msg-file', 'foo');
+	await fs.writeFile(cwd, 'commit-msg-file', 'foo');
 
 	const expected = ['foo\n'];
 	const actual = await read({edit: 'commit-msg-file', cwd});
@@ -18,7 +18,7 @@ test('get edit commit message specified by the `edit` flag', async () => {
 test('get edit commit message from git root', async () => {
 	const cwd: string = await git.bootstrap();
 
-	await sander.writeFile(cwd, 'alpha.txt', 'alpha');
+	await fs.writeFile(path.join(cwd, 'alpha.txt'), 'alpha');
 	await execa('git', ['add', '.'], {cwd});
 	await execa('git', ['commit', '-m', 'alpha'], {cwd});
 	const expected = ['alpha\n\n'];
@@ -28,7 +28,7 @@ test('get edit commit message from git root', async () => {
 
 test('get history commit messages', async () => {
 	const cwd: string = await git.bootstrap();
-	await sander.writeFile(cwd, 'alpha.txt', 'alpha');
+	await fs.writeFile(path.join(cwd, 'alpha.txt'), 'alpha');
 	await execa('git', ['add', 'alpha.txt'], {cwd});
 	await execa('git', ['commit', '-m', 'alpha'], {cwd});
 	await execa('git', ['rm', 'alpha.txt'], {cwd});
@@ -41,8 +41,8 @@ test('get history commit messages', async () => {
 
 test('get edit commit message from git subdirectory', async () => {
 	const cwd: string = await git.bootstrap();
-	await sander.mkdir(cwd, 'beta');
-	await sander.writeFile(cwd, 'beta/beta.txt', 'beta');
+	await fs.mkdir(path.join(cwd, 'beta'));
+	await fs.writeFile(cwd, 'beta/beta.txt', 'beta');
 
 	await execa('git', ['add', '.'], {cwd});
 	await execa('git', ['commit', '-m', 'beta'], {cwd});

--- a/@commitlint/read/src/read.test.ts
+++ b/@commitlint/read/src/read.test.ts
@@ -8,7 +8,7 @@ import read from './read';
 test('get edit commit message specified by the `edit` flag', async () => {
 	const cwd: string = await git.bootstrap();
 
-	await fs.writeFile(cwd, 'commit-msg-file', 'foo');
+	await fs.writeFile(path.join(cwd, 'commit-msg-file'), 'foo');
 
 	const expected = ['foo\n'];
 	const actual = await read({edit: 'commit-msg-file', cwd});
@@ -42,7 +42,7 @@ test('get history commit messages', async () => {
 test('get edit commit message from git subdirectory', async () => {
 	const cwd: string = await git.bootstrap();
 	await fs.mkdir(path.join(cwd, 'beta'));
-	await fs.writeFile(cwd, 'beta/beta.txt', 'beta');
+	await fs.writeFile(path.join(cwd, 'beta/beta.txt'), 'beta');
 
 	await execa('git', ['add', '.'], {cwd});
 	await execa('git', ['commit', '-m', 'beta'], {cwd});

--- a/@packages/utils/package.json
+++ b/@packages/utils/package.json
@@ -41,7 +41,6 @@
   "license": "MIT",
   "dependencies": {
     "@commitlint/test": "8.2.0",
-    "@marionebl/sander": "0.6.1",
     "execa": "0.11.0",
     "is-builtin-module": "3.0.0",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -71,9 +71,6 @@
     "name": "Mario Nebl",
     "email": "hello@herebecode.com"
   },
-  "dependencies": {
-    "@marionebl/sander": "0.6.1"
-  },
   "devDependencies": {
     "@lerna/project": "3.18.0",
     "@types/jest": "25.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,15 +1798,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@marionebl/sander@0.6.1", "@marionebl/sander@^0.6.0":
-  version "0.6.1"
-  resolved "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz#1958965874f24bc51be48875feb50d642fc41f7b"
-  integrity sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=
-  dependencies:
-    graceful-fs "^4.1.3"
-    mkdirp "^0.5.1"
-    rimraf "^2.5.2"
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -4577,7 +4568,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -7910,7 +7901,7 @@ right-pad@^1.0.1:
   resolved "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
   integrity sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=
 
-rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7989,15 +7989,6 @@ safe-regex@^1.1.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sander@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.npmjs.org/sander/-/sander-0.6.0.tgz#af1624cd7fb6dfad98ebef565319f920078da925"
-  integrity sha1-rxYkzX+2362Y6+9WUxn5IAeNqSU=
-  dependencies:
-    graceful-fs "^4.1.3"
-    mkdirp "^0.5.1"
-    rimraf "^2.5.2"
-
 sane@^4.0.3:
   version "4.1.0"
   resolved "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
replace unmaintained [`sander`](https://github.com/Rich-Harris/sander) package with [`fs-extra`](https://github.com/jprichardson/node-fs-extra) #918

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
`sander` package seems unmaintained (not updated for 4 years) and `cli` is only place where is used.
`sander` has no type definition

`fs` promisify and utils.promisify is not supported in targeted node versions (this should be replaced if/when node 8 / 10 will is going to be targeted)

## Usage examples

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
