### PR TITLE
chore: align all packages

### DIFF
--- a/@alias/commitlint-config-angular/package.json
+++ b/@alias/commitlint-config-angular/package.json
@@ -6,8 +6,6 @@
     "index.js"
   ],
   "scripts": {
-    "test": "exit 0",
-    "clean": "exit 0",
     "deps": "dep-check",
     "pkg": "pkg-check"
   },

--- a/@alias/commitlint-config-angular/package.json
+++ b/@alias/commitlint-config-angular/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "conventional-changelog",

--- a/@alias/commitlint-config-lerna-scopes/package.json
+++ b/@alias/commitlint-config-lerna-scopes/package.json
@@ -6,8 +6,6 @@
     "index.js"
   ],
   "scripts": {
-    "test": "exit 0",
-    "clean": "exit 0",
     "deps": "dep-check",
     "pkg": "pkg-check"
   },

--- a/@alias/commitlint-config-lerna-scopes/package.json
+++ b/@alias/commitlint-config-lerna-scopes/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "conventional-changelog",

--- a/@alias/commitlint-config-patternplate/package.json
+++ b/@alias/commitlint-config-patternplate/package.json
@@ -6,8 +6,6 @@
     "index.js"
   ],
   "scripts": {
-    "test": "exit 0",
-    "clean": "exit 0",
     "deps": "dep-check",
     "pkg": "pkg-check"
   },

--- a/@alias/commitlint-config-patternplate/package.json
+++ b/@alias/commitlint-config-patternplate/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "conventional-changelog",

--- a/@commitlint/config-angular-type-enum/package.json
+++ b/@commitlint/config-angular-type-enum/package.json
@@ -6,11 +6,8 @@
     "index.js"
   ],
   "scripts": {
-    "clean": "exit 0",
     "deps": "dep-check",
-    "pkg": "pkg-check",
-    "start": "exit 0",
-    "test": "exit 0"
+    "pkg": "pkg-check"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/config-angular-type-enum/package.json
+++ b/@commitlint/config-angular-type-enum/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "conventional-changelog",

--- a/@commitlint/config-angular/package.json
+++ b/@commitlint/config-angular/package.json
@@ -6,11 +6,8 @@
     "index.js"
   ],
   "scripts": {
-    "clean": "exit 0",
     "deps": "dep-check",
-    "pkg": "pkg-check --skip-import",
-    "start": "exit 0",
-    "test": "exit 0"
+    "pkg": "pkg-check --skip-import"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/config-angular/package.json
+++ b/@commitlint/config-angular/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "conventional-changelog",

--- a/@commitlint/config-conventional/package.json
+++ b/@commitlint/config-conventional/package.json
@@ -6,11 +6,8 @@
     "index.js"
   ],
   "scripts": {
-    "clean": "exit 0",
     "deps": "dep-check",
-    "pkg": "pkg-check",
-    "start": "exit 0",
-    "test": "exit 0"
+    "pkg": "pkg-check"
   },
   "publishConfig": {
     "access": "public"

--- a/@commitlint/config-conventional/package.json
+++ b/@commitlint/config-conventional/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "conventional-changelog",

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -35,8 +35,6 @@
   },
   "devDependencies": {
     "@commitlint/test": "8.2.0",
-    "@commitlint/utils": "^8.3.4",
-    "@lerna/project": "3.18.0",
-    "lerna": "3.20.2"
+    "@commitlint/utils": "^8.3.4"
   }
 }

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "conventional-changelog",

--- a/@commitlint/config-patternplate/package.json
+++ b/@commitlint/config-patternplate/package.json
@@ -6,11 +6,8 @@
     "index.js"
   ],
   "scripts": {
-    "clean": "exit 0",
     "deps": "dep-check",
-    "pkg": "pkg-check --skip-import",
-    "start": "exit 0",
-    "test": "exit 0"
+    "pkg": "pkg-check --skip-import"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/config-patternplate/package.json
+++ b/@commitlint/config-patternplate/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "conventional-changelog",

--- a/@commitlint/core/package.json
+++ b/@commitlint/core/package.json
@@ -36,5 +36,8 @@
     "@commitlint/lint": "^8.3.5",
     "@commitlint/load": "^8.3.5",
     "@commitlint/read": "^8.3.4"
+  },
+  "devDependencies": {
+    "@commitlint/utils": "^8.3.4"
   }
 }

--- a/@commitlint/ensure/package.json
+++ b/@commitlint/ensure/package.json
@@ -35,6 +35,7 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/utils": "^8.3.4",
+    "@types/lodash": "4.14.149",
     "globby": "11.0.0"
   },
   "dependencies": {

--- a/@commitlint/execute-rule/package.json
+++ b/@commitlint/execute-rule/package.json
@@ -34,7 +34,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@commitlint/parse": "^8.3.4",
     "@commitlint/utils": "^8.3.4"
   }
 }

--- a/@commitlint/execute-rule/package.json
+++ b/@commitlint/execute-rule/package.json
@@ -35,10 +35,6 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/parse": "^8.3.4",
-    "@commitlint/utils": "^8.3.4",
-    "@types/jest": "25.1.1",
-    "@types/lodash": "4.14.149",
-    "jest": "25.1.0",
-    "ts-jest": "25.2.0"
+    "@commitlint/utils": "^8.3.4"
   }
 }

--- a/@commitlint/format/package.json
+++ b/@commitlint/format/package.json
@@ -34,10 +34,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@commitlint/utils": "^8.3.4",
-    "@types/lodash": "4.14.149",
-    "lodash": "4.17.15",
-    "typescript": "3.7.5"
+    "@commitlint/utils": "^8.3.4"
   },
   "dependencies": {
     "chalk": "^3.0.0"

--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -46,8 +46,7 @@
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
     "babel-preset-commitlint": "^8.2.0",
-    "cross-env": "7.0.0",
-    "execa": "0.11.0"
+    "cross-env": "7.0.0"
   },
   "dependencies": {
     "@commitlint/is-ignored": "^8.3.5",

--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
+    "@types/lodash": "4.14.149",
     "execa": "0.11.0"
   },
   "dependencies": {

--- a/@commitlint/message/package.json
+++ b/@commitlint/message/package.json
@@ -35,7 +35,6 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/test": "8.2.0",
-    "@commitlint/utils": "^8.3.4",
-    "typescript": "3.7.5"
+    "@commitlint/utils": "^8.3.4"
   }
 }

--- a/@commitlint/parse/package.json
+++ b/@commitlint/parse/package.json
@@ -37,8 +37,7 @@
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
     "@types/lodash": "4.14.149",
-    "import-from": "3.0.0",
-    "typescript": "3.7.5"
+    "import-from": "3.0.0"
   },
   "dependencies": {
     "conventional-changelog-angular": "^5.0.0",

--- a/@commitlint/prompt-cli/package.json
+++ b/@commitlint/prompt-cli/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "commitlint",

--- a/@commitlint/prompt/package.json
+++ b/@commitlint/prompt/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/conventional-changelog/commitlint.git"
+    "url": "https://github.com/conventional-changelog/commitlint.git"
   },
   "keywords": [
     "conventional-changelog",

--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
+    "@types/fs-extra": "^8.0.1",
     "@types/git-raw-commits": "^2.0.0"
   },
   "dependencies": {

--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -36,9 +36,7 @@
   "devDependencies": {
     "@commitlint/parse": "^8.3.4",
     "@commitlint/utils": "^8.3.4",
-    "@types/lodash": "4.14.149",
-    "@types/node": "12.12.26",
-    "@types/resolve-from": "5.0.1"
+    "@types/lodash": "4.14.149"
   },
   "dependencies": {
     "import-fresh": "^3.0.0",

--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -34,7 +34,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@commitlint/parse": "^8.3.4",
     "@commitlint/utils": "^8.3.4",
     "@types/lodash": "4.14.149"
   },

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -37,6 +37,7 @@
     "@commitlint/parse": "^8.3.4",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
+    "@types/lodash": "4.14.149",
     "conventional-changelog-angular": "5.0.6",
     "globby": "^11.0.0",
     "lodash": "^4.17.15"

--- a/@commitlint/to-lines/package.json
+++ b/@commitlint/to-lines/package.json
@@ -34,7 +34,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@commitlint/parse": "^8.3.4",
     "@commitlint/utils": "^8.3.4"
   }
 }

--- a/@commitlint/top-level/package.json
+++ b/@commitlint/top-level/package.json
@@ -35,8 +35,7 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/utils": "^8.3.4",
-    "@types/find-up": "2.1.1",
-    "@types/node": "12.12.26"
+    "@types/find-up": "2.1.1"
   },
   "dependencies": {
     "find-up": "^4.0.0"

--- a/@packages/utils/package.json
+++ b/@packages/utils/package.json
@@ -11,10 +11,6 @@
     "pkg-check": "./pkg-check.js"
   },
   "scripts": {
-    "build": "exit 0",
-    "clean": "exit 0",
-    "start": "exit 0",
-    "test": "exit 0",
     "deps": "node dep-check.js",
     "pkg": "node pkg-check.js --skip-main"
   },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@lerna/project": "3.18.0",
+    "@types/node": "12.12.26",
     "@types/jest": "25.1.1",
     "docsify-cli": "^4.4.0",
     "husky": "4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,13 +2066,6 @@
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/resolve-from@5.0.1":
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/@types/resolve-from/-/resolve-from-5.0.1.tgz#2714eaa840c0472dcfa96ec3fb9d170dbf0b677d"
-  integrity sha512-1G7n5Jtr5inoS1Ez2Y9Efedk9/wH6uGQslbfhGTOw9J42PCAwuyaDgQHW7fIq02+shwB02kM/w31W8gMxI8ORg==
-  dependencies:
-    resolve-from "*"
-
 "@types/semver@7.1.0":
   version "7.1.0"
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz#c8c630d4c18cd326beff77404887596f96408408"
@@ -8328,7 +8321,7 @@ resolve-dir@^1.0.0, resolve-dir@^1.0.1:
     expand-tilde "^2.0.0"
     global-modules "^1.0.0"
 
-resolve-from@*, resolve-from@5.0.0, resolve-from@^5.0.0:
+resolve-from@5.0.0, resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==


### PR DESCRIPTION
align `package.json` across all packages

## Description

- remove all `exit 0` scripts, lerna no longer requires it
- remove lerna from devDependencies in `config-lerna-scopes` (follow up #950)
- align `repository.url` across packages (`git+`)
- add/remove type packages from packages (when used in context of package)
- remove `typescript`, `jest`, `ts-jest`, `@types/jest` from some packages as its inherited from root
- move `@types/node` to root as it was imported in some (not all packages) and should be available to all
- remove `@commitlint/parse` from some devDependencies as its not used in context of package
- `@types/resolve-from` is a stub and its not required as resolve-from has type definition

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

## How Has This Been Tested?
Manual validation and `eslint` with `eslint-plugin-import` executed locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
