### PR TITLE
test: speed up npm bootstrap

### DIFF
--- a/@packages/test/src/npm.ts
+++ b/@packages/test/src/npm.ts
@@ -1,15 +1,62 @@
-import execa from 'execa';
 import path from 'path';
 import fs from 'fs-extra';
+import resolvePkg from 'resolve-pkg';
 
 import * as git from './git';
 
 export async function bootstrap(fixture: string, directory?: string) {
 	const cwd = await git.bootstrap(fixture, directory);
+	const manifestPath = path.join(cwd, 'package.json');
+	const targetModulesPath = path.join(cwd, 'node_modules');
 
-	if (await fs.pathExists(path.join(cwd, 'package.json'))) {
-		await execa('npm', ['install'], {cwd});
+	if (await fs.pathExists(manifestPath)) {
+		const {dependencies = {}, devDependencies = {}} = await fs.readJson(
+			manifestPath
+		);
+		const deps = Object.keys({...dependencies, ...devDependencies});
+		await Promise.all(
+			deps.map(async (dependency: any) => {
+				const sourcePath = resolvePkg(dependency);
+
+				if (!sourcePath) {
+					throw new Error(`Could not resolve dependency ${dependency}`);
+				}
+
+				const sourceModulesPath = findParentPath(sourcePath, 'node_modules');
+
+				if (!sourceModulesPath) {
+					throw new Error(`Could not determine node_modules for ${sourcePath}`);
+				}
+
+				const relativePath = path.relative(sourceModulesPath, sourcePath);
+				const targetPath = path.join(targetModulesPath, relativePath);
+
+				await fs.mkdirp(path.join(targetPath, '..'));
+				await fs.symlink(sourcePath, targetPath);
+			})
+		);
 	}
 
 	return cwd;
+}
+
+function findParentPath(path: string, dirname: string): string | undefined {
+	const rawFragments = path.split('/');
+
+	const {matched, fragments} = rawFragments.reduceRight(
+		({fragments, matched}, item) => {
+			if (item === dirname && !matched) {
+				return {fragments, matched: true};
+			}
+
+			if (!matched && fragments.length > 0) {
+				fragments.pop();
+			}
+
+			return {fragments, matched};
+		},
+		{fragments: rawFragments, matched: false}
+	);
+
+	return matched ? fragments.join('/') : undefined;
 }


### PR DESCRIPTION
This refactors the npm bootstrap utility to symlink dependencies installed into the mono repository instead of running a dedicated `npm install`. 

By doing so we should be able to keep test runtimes inside jest timeouts.