### PR TITLE
chore: clarify lowest supported Node.js version

### DIFF
--- a/@alias/commitlint-config-angular/package.json
+++ b/@alias/commitlint-config-angular/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "engines": {
+    "node": ">=8"
+  },
   "dependencies": {
     "@commitlint/config-angular": "^8.3.4"
   },

--- a/@alias/commitlint-config-lerna-scopes/package.json
+++ b/@alias/commitlint-config-lerna-scopes/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "engines": {
+    "node": ">=8"
+  },
   "dependencies": {
     "@commitlint/config-lerna-scopes": "^8.3.4"
   },

--- a/@alias/commitlint-config-patternplate/package.json
+++ b/@alias/commitlint-config-patternplate/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "engines": {
+    "node": ">=8"
+  },
   "dependencies": {
     "@commitlint/config-patternplate": "^8.3.4",
     "@commitlint/utils": "^8.3.4"

--- a/@alias/commitlint/package.json
+++ b/@alias/commitlint/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check --skip-main"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -23,7 +23,7 @@
     ]
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/config-angular-type-enum/package.json
+++ b/@commitlint/config-angular-type-enum/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "engines": {
+    "node": ">=8"
+  },
   "devDependencies": {
     "@commitlint/utils": "^8.3.4"
   }

--- a/@commitlint/config-angular/package.json
+++ b/@commitlint/config-angular/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "engines": {
+    "node": ">=8"
+  },
   "devDependencies": {
     "@commitlint/utils": "^8.3.4"
   },

--- a/@commitlint/config-conventional/package.json
+++ b/@commitlint/config-conventional/package.json
@@ -28,6 +28,9 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "engines": {
+    "node": ">=8"
+  },
   "devDependencies": {
     "@commitlint/utils": "^8.3.4"
   },

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -28,6 +28,9 @@
   "peerDependencies": {
     "lerna": "^3.20.2"
   },
+  "engines": {
+    "node": ">=8"
+  },
   "dependencies": {
     "import-from": "3.0.0",
     "resolve-pkg": "2.0.0",

--- a/@commitlint/config-patternplate/package.json
+++ b/@commitlint/config-patternplate/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "engines": {
+    "node": ">=8"
+  },
   "dependencies": {
     "@commitlint/config-angular": "^8.3.4",
     "globby": "^11.0.0",

--- a/@commitlint/core/package.json
+++ b/@commitlint/core/package.json
@@ -10,7 +10,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/ensure/package.json
+++ b/@commitlint/ensure/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/execute-rule/package.json
+++ b/@commitlint/execute-rule/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/format/package.json
+++ b/@commitlint/format/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/is-ignored/package.json
+++ b/@commitlint/is-ignored/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/message/package.json
+++ b/@commitlint/message/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/parse/package.json
+++ b/@commitlint/parse/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/prompt-cli/package.json
+++ b/@commitlint/prompt-cli/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "engines": {
+    "node": ">=8"
+  },
   "devDependencies": {
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",

--- a/@commitlint/prompt/package.json
+++ b/@commitlint/prompt/package.json
@@ -41,6 +41,9 @@
     "url": "https://github.com/conventional-changelog/commitlint/issues"
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
+  "engines": {
+    "node": ">=8"
+  },
   "devDependencies": {
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",

--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/to-lines/package.json
+++ b/@commitlint/to-lines/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/top-level/package.json
+++ b/@commitlint/top-level/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/travis-cli/package.json
+++ b/@commitlint/travis-cli/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/types/package.json
+++ b/@commitlint/types/package.json
@@ -11,7 +11,7 @@
         "pkg": "pkg-check"
     },
     "engines": {
-        "node": ">=4"
+        "node": ">=8"
     },
     "repository": {
         "type": "git",

--- a/@packages/babel-preset-commitlint/package.json
+++ b/@packages/babel-preset-commitlint/package.json
@@ -7,7 +7,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@packages/test/package.json
+++ b/@packages/test/package.json
@@ -8,7 +8,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/@packages/utils/package.json
+++ b/@packages/utils/package.json
@@ -15,7 +15,7 @@
     "pkg": "node pkg-check.js --skip-main"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@packages/*"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,8 +1,7 @@
 {
     "compilerOptions": {
-        "lib": [
-            "es2015"
-        ],
+        "target": "ES2017",
+        "lib": ["es2017"],
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,


### PR DESCRIPTION
This resyncs all pages to specify Node.js >= 8 as lowest supported version.

This also lifts the target output to ES2017 and pulls in the ES2017 lib as those correspond to the feature set of Node.js 8.

Reference: #918 
