### PR TITLE
test: update execa cli calls and remove string-to-stream

### DIFF
--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -51,8 +51,7 @@
     "babel-preset-commitlint": "^8.2.0",
     "cross-env": "7.0.0",
     "execa": "0.11.0",
-    "fs-extra": "^8.1.0",
-    "string-to-stream": "3.0.1"
+    "fs-extra": "^8.1.0"
   },
   "dependencies": {
     "@commitlint/format": "^8.3.4",

--- a/@commitlint/cli/src/cli.test.js
+++ b/@commitlint/cli/src/cli.test.js
@@ -3,18 +3,16 @@ import {fix, git} from '@commitlint/test';
 import execa from 'execa';
 import merge from 'lodash/merge';
 import fs from 'fs-extra';
-import stream from 'string-to-stream';
 
 const bin = require.resolve('../lib/cli.js');
 
 const cli = (args, options) => {
 	return (input = '') => {
 		const c = execa(bin, args, {
-			capture: ['stdout'],
 			cwd: options.cwd,
-			env: options.env
+			env: options.env,
+			input: input
 		});
-		stream(input).pipe(c.stdin);
 		return c.catch(err => err);
 	};
 };

--- a/@commitlint/prompt-cli/cli.test.js
+++ b/@commitlint/prompt-cli/cli.test.js
@@ -1,17 +1,15 @@
 import {git} from '@commitlint/test';
 import execa from 'execa';
-import stream from 'string-to-stream';
 
 const bin = require.resolve('./cli.js');
 
 const cli = (args, options) => {
 	return (input = '') => {
 		const c = execa(bin, args, {
-			capture: ['stdout'],
 			cwd: options.cwd,
-			env: options.env
+			env: options.env,
+			input: input
 		});
-		stream(input).pipe(c.stdin);
 		return c.catch(err => err);
 	};
 };

--- a/@commitlint/prompt-cli/package.json
+++ b/@commitlint/prompt-cli/package.json
@@ -32,8 +32,7 @@
   },
   "devDependencies": {
     "@commitlint/test": "8.2.0",
-    "@commitlint/utils": "^8.3.4",
-    "string-to-stream": "3.0.1"
+    "@commitlint/utils": "^8.3.4"
   },
   "dependencies": {
     "@commitlint/prompt": "^8.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8038,7 +8038,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@^3.0.1, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0:
+"readable-stream@2 || 3", readable-stream@^3.0.1, readable-stream@^3.0.2, readable-stream@^3.1.1:
   version "3.4.0"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
@@ -8903,13 +8903,6 @@ string-length@^3.1.0:
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^5.2.0"
-
-string-to-stream@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/string-to-stream/-/string-to-stream-3.0.1.tgz#480e6fb4d5476d31cb2221f75307a5dcb6638a42"
-  integrity sha512-Hl092MV3USJuUCC6mfl9sPzGloA3K5VwdIeJjYIkXY/8K+mUvaeEabWJgArp+xXrsWxCajeT2pc4axbVhIZJyg==
-  dependencies:
-    readable-stream "^3.4.0"
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Drop `string-to-stream` package in favor of execa input option.

## Description

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
