### PR TITLE
chore: rename lerna run include option

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "tsc -b && lerna run build --stream --parallel --include-filtered-dependencies",
-    "watch": "lerna run watch --stream --parallel --include-filtered-dependencies",
+    "build": "tsc -b && lerna run build --stream --parallel --include-dependencies",
+    "watch": "lerna run watch --stream --parallel --include-dependencies",
     "clean": "tsc -b --clean && lerna clean --yes && lerna exec 'git clean -xdf lib' && git clean -xdf node_modules",
     "commit": "node @commitlint/prompt-cli/cli.js",
     "deps": "lerna run deps",
@@ -15,9 +15,9 @@
     "lint": "prettier **/*.{ts,js,json,yml,md} -l",
     "publish": "lerna publish --conventional-commits",
     "reinstall": "yarn clean && yarn install",
-    "start": "lerna run start --stream --parallel --include-filtered-dependencies",
-    "test": "jest && lerna run test --stream --parallel --include-filtered-dependencies",
-    "test-ci": "jest --runInBand && lerna run test --stream --parallel --include-filtered-dependencies"
+    "start": "lerna run start --stream --parallel --include-dependencies",
+    "test": "jest && lerna run test --stream --parallel --include-dependencies",
+    "test-ci": "jest --runInBand && lerna run test --stream --parallel --include-dependencies"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
Update lerna filter argument to reflect changes in api


## Description
In `lerna@v3.18.0`  filter `--include-filtered-dependencies` was renamed to `--include-dependencies` and currently it showing deprecation warning.

https://github.com/lerna/lerna/commit/f2c3a92fe41b6fdc5d11269f0f2c3e27761b4c85

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
