### PR TITLE
test(parse): remove import-from package from tests

### DIFF
--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -34,12 +34,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@babel/cli": "^7.7.7",
-    "@babel/core": "^7.7.7",
     "@commitlint/test": "8.2.0",
-    "@commitlint/utils": "^8.3.4",
-    "babel-preset-commitlint": "^8.2.0",
-    "cross-env": "7.0.0"
+    "@commitlint/utils": "^8.3.4"
   },
   "dependencies": {
     "@commitlint/is-ignored": "^8.3.5",

--- a/@commitlint/parse/fixtures/parser-preset/commitlint.config.js
+++ b/@commitlint/parse/fixtures/parser-preset/commitlint.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-	parserOpts: {
-		parserPreset: './conventional-changelog-custom'
-	}
-};

--- a/@commitlint/parse/fixtures/parser-preset/conventional-changelog-custom.js
+++ b/@commitlint/parse/fixtures/parser-preset/conventional-changelog-custom.js
@@ -1,5 +1,0 @@
-module.exports = Promise.resolve().then(() => ({
-	parserOpts: {
-		headerPattern: /^(\w*)(?:\((.*)\))?-(.*)$/
-	}
-}));

--- a/@commitlint/parse/package.json
+++ b/@commitlint/parse/package.json
@@ -36,8 +36,7 @@
   "devDependencies": {
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
-    "@types/lodash": "4.14.149",
-    "import-from": "3.0.0"
+    "@types/lodash": "4.14.149"
   },
   "dependencies": {
     "conventional-changelog-angular": "^5.0.0",

--- a/@commitlint/parse/src/index.test.ts
+++ b/@commitlint/parse/src/index.test.ts
@@ -1,4 +1,3 @@
-import importFrom from 'import-from';
 import parse from '.';
 
 test('throws when called without params', () => {
@@ -81,10 +80,11 @@ test('uses angular grammar', async () => {
 
 test('uses custom opts parser', async () => {
 	const message = 'type(scope)-subject';
-	const changelogOpts: any = await importFrom(
-		__dirname,
-		'../fixtures/parser-preset/conventional-changelog-custom.js'
-	);
+	const changelogOpts = {
+		parserOpts: {
+			headerPattern: /^(\w*)(?:\((.*)\))?-(.*)$/
+		}
+	};
 	const actual = await parse(message, undefined, changelogOpts.parserOpts);
 	const expected = {
 		body: null,
@@ -145,13 +145,11 @@ test('supports scopes with / and empty parserOpts', async () => {
 
 test('ignores comments', async () => {
 	const message = 'type(some/scope): subject\n# some comment';
-	const changelogOpts: any = await importFrom(
-		process.cwd(),
-		'conventional-changelog-angular'
-	);
-	const opts = Object.assign({}, changelogOpts.parserOpts, {
+	const changelogOpts = await require('conventional-changelog-angular');
+	const opts = {
+		...changelogOpts.parserOpts,
 		commentChar: '#'
-	});
+	};
 	const actual = await parse(message, undefined, opts);
 
 	expect(actual.body).toBe(null);
@@ -162,13 +160,11 @@ test('ignores comments', async () => {
 test('registers inline #', async () => {
 	const message =
 		'type(some/scope): subject #reference\n# some comment\nthings #reference';
-	const changelogOpts: any = await importFrom(
-		process.cwd(),
-		'conventional-changelog-angular'
-	);
-	const opts = Object.assign({}, changelogOpts.parserOpts, {
+	const changelogOpts = await require('conventional-changelog-angular');
+	const opts = {
+		...changelogOpts.parserOpts,
 		commentChar: '#'
-	});
+	};
 	const actual = await parse(message, undefined, opts);
 
 	expect(actual.subject).toBe('subject #reference');
@@ -177,13 +173,10 @@ test('registers inline #', async () => {
 
 test('parses references leading subject', async () => {
 	const message = '#1 some subject';
-	const opts = await importFrom(
-		process.cwd(),
-		'conventional-changelog-angular'
-	);
+	const opts = await require('conventional-changelog-angular');
 	const {
 		references: [actual]
-	} = await parse(message, undefined, opts as any);
+	} = await parse(message, undefined, opts);
 
 	expect(actual.issue).toBe('1');
 });


### PR DESCRIPTION
Remove unnecessary `import-from` package from parse tests

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
