### PR TITLE
refactor: use builtin Object.values instead of lodash/values

### DIFF
--- a/@commitlint/ensure/src/index.test.ts
+++ b/@commitlint/ensure/src/index.test.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import globby from 'globby';
-import values from 'lodash/values';
 import camelCase from 'lodash/camelCase';
 import * as ensure from '.';
 
@@ -15,7 +14,7 @@ test('exports all checkers', async () => {
 });
 
 test('rules export functions', () => {
-	const actual = values(ensure);
+	const actual = Object.values(ensure);
 	expect(actual.every(rule => typeof rule === 'function')).toBe(true);
 });
 

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -9,7 +9,6 @@ import {
 	LintOptions,
 	LintRuleOutcome,
 	Rule,
-	Plugin,
 	RuleSeverity
 } from '@commitlint/types';
 
@@ -42,7 +41,7 @@ export default async function lint(
 	);
 
 	if (opts.plugins) {
-		Object.values(opts.plugins).forEach((plugin: Plugin) => {
+		Object.values(opts.plugins).forEach(plugin => {
 			if (plugin.rules) {
 				Object.keys(plugin.rules).forEach(ruleKey =>
 					allRules.set(ruleKey, plugin.rules[ruleKey])

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -3,7 +3,6 @@ import isIgnored from '@commitlint/is-ignored';
 import parse from '@commitlint/parse';
 import defaultRules from '@commitlint/rules';
 import toPairs from 'lodash/toPairs';
-import values from 'lodash/values';
 import {buildCommitMesage} from './commit-message';
 import {
 	LintRuleConfig,
@@ -43,7 +42,7 @@ export default async function lint(
 	);
 
 	if (opts.plugins) {
-		values(opts.plugins).forEach((plugin: Plugin) => {
+		Object.values(opts.plugins).forEach((plugin: Plugin) => {
 			if (plugin.rules) {
 				Object.keys(plugin.rules).forEach(ruleKey =>
 					allRules.set(ruleKey, plugin.rules[ruleKey])

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -37,10 +37,8 @@
     "@commitlint/parse": "^8.3.4",
     "@commitlint/test": "8.2.0",
     "@commitlint/utils": "^8.3.4",
-    "@types/lodash": "4.14.149",
     "conventional-changelog-angular": "5.0.6",
-    "globby": "^11.0.0",
-    "lodash": "^4.17.15"
+    "globby": "^11.0.0"
   },
   "dependencies": {
     "@commitlint/ensure": "^8.3.4",

--- a/@commitlint/rules/src/index.test.ts
+++ b/@commitlint/rules/src/index.test.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import globby from 'globby';
-import values from 'lodash/values';
 import rules from '.';
 
 test('exports all rules', async () => {
@@ -10,7 +9,7 @@ test('exports all rules', async () => {
 });
 
 test('rules export functions', () => {
-	const actual = values(rules);
+	const actual = Object.values(rules);
 	expect(actual.every(rule => typeof rule === 'function')).toBe(true);
 });
 

--- a/@packages/utils/package.json
+++ b/@packages/utils/package.json
@@ -39,7 +39,6 @@
     "@commitlint/test": "8.2.0",
     "execa": "0.11.0",
     "is-builtin-module": "3.0.0",
-    "lodash": "^4.17.15",
     "meow": "4.0.1",
     "read-pkg": "5.2.0",
     "require-from-string": "2.0.2",

--- a/@packages/utils/pkg-check.js
+++ b/@packages/utils/pkg-check.js
@@ -8,7 +8,6 @@ const meow = require('meow');
 const readPkg = require('read-pkg');
 const requireFromString = require('require-from-string');
 const tar = require('tar-fs');
-const values = require('lodash/values');
 const {fix} = require('@commitlint/test');
 
 const builtin = require.resolve('is-builtin-module');
@@ -198,7 +197,7 @@ function getPkgBinFiles(bin) {
 	}
 
 	if (typeof bin === 'object') {
-		return values(bin).map(b => path.normalize(b));
+		return Object.values(bin).map(b => path.normalize(b));
 	}
 }
 


### PR DESCRIPTION
use builtin Object.values instead of lodash/values

## Description

https://node.green/#ES2017-features-Object-static-methods-Object-values

## Motivation and Context

## Usage examples

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
