### PR TITLE
refactor: use native Object.entries instead of lodash/toPairs

### DIFF
--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -45,7 +45,6 @@
     "@commitlint/is-ignored": "^8.3.5",
     "@commitlint/parse": "^8.3.4",
     "@commitlint/rules": "^8.3.4",
-    "@commitlint/types": "^8.3.4",
-    "lodash": "^4.17.15"
+    "@commitlint/types": "^8.3.4"
   }
 }

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -2,7 +2,6 @@ import util from 'util';
 import isIgnored from '@commitlint/is-ignored';
 import parse from '@commitlint/parse';
 import defaultRules from '@commitlint/rules';
-import toPairs from 'lodash/toPairs';
 import {buildCommitMesage} from './commit-message';
 import {
 	LintRuleConfig,
@@ -64,7 +63,7 @@ export default async function lint(
 		);
 	}
 
-	const invalid = toPairs(rulesConfig)
+	const invalid = Object.entries(rulesConfig)
 		.map(([name, config]) => {
 			if (!Array.isArray(config)) {
 				return new Error(
@@ -131,7 +130,7 @@ export default async function lint(
 	}
 
 	// Validate against all rules
-	const results = toPairs(rulesConfig)
+	const results = Object.entries(rulesConfig)
 		.filter(([, [level]]) => level > 0)
 		.map(entry => {
 			const [name, config] = entry;

--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -1,6 +1,5 @@
 import Path from 'path';
 
-import toPairs from 'lodash/toPairs';
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
 import pick from 'lodash/pick';
@@ -94,7 +93,7 @@ export default async function load(
 
 	const rules = preset.rules ? preset.rules : {};
 	const qualifiedRules = (await Promise.all(
-		toPairs(rules || {}).map(entry => executeRule<any>(entry))
+		Object.entries(rules || {}).map(entry => executeRule<any>(entry))
 	)).reduce<QualifiedRules>((registry, item) => {
 		const [key, value] = item as any;
 		(registry as any)[key] = value;

--- a/@commitlint/prompt/src/library/format.js
+++ b/@commitlint/prompt/src/library/format.js
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import toPairs from 'lodash/toPairs';
 
 export default format;
 
@@ -11,7 +10,7 @@ export default format;
  */
 function format(input, debug = false) {
 	const results = debug
-		? toPairs(input).reduce((registry, item) => {
+		? Object.entries(input || {}).reduce((registry, item) => {
 				const [name, value] = item;
 				registry[name] =
 					value === null ? chalk.grey(`<${name}>`) : chalk.bold(value);

--- a/@commitlint/prompt/src/library/meta.js
+++ b/@commitlint/prompt/src/library/meta.js
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import toPairs from 'lodash/toPairs';
 
 /**
  * Get formatted meta hints for configuration
@@ -8,7 +7,7 @@ import toPairs from 'lodash/toPairs';
  */
 export default function meta(settings) {
 	return chalk.grey(
-		toPairs(settings)
+		Object.entries(settings || {})
 			.filter(item => item[1])
 			.map(item => {
 				const [name, value] = item;


### PR DESCRIPTION
use native Object.entries instead of lodash/toPairs

## Description

https://node.green/#ES2017-features-Object-static-methods-Object-entries

## Motivation and Context


## Usage examples

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
