### PR TITLE
refactor: use native Array.isArray instead of lodash/isArray

### DIFF
--- a/@commitlint/parse/src/index.ts
+++ b/@commitlint/parse/src/index.ts
@@ -1,5 +1,4 @@
 import mergeWith from 'lodash/mergeWith';
-import isArray from 'lodash/isArray';
 import {Commit, Parser, ParserOptions} from '@commitlint/types';
 
 const {sync} = require('conventional-commits-parser');
@@ -14,7 +13,7 @@ async function parse(
 ): Promise<Commit> {
 	const defaultOpts = (await defaultChangelogOpts).parserOpts;
 	const opts = mergeWith({}, defaultOpts, parserOpts, (objValue, srcValue) => {
-		if (isArray(objValue)) return srcValue;
+		if (Array.isArray(objValue)) return srcValue;
 	});
 	const parsed = parser(message, opts) as Commit;
 	parsed.raw = message;

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -2,7 +2,6 @@ import path from 'path';
 
 import 'resolve-global';
 import resolveFrom from 'resolve-from';
-import isArray from 'lodash/isArray';
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
 import omit from 'lodash/omit';
@@ -37,7 +36,7 @@ export default function resolveExtends(
 	const extended = loadExtends(config, context).reduceRight(
 		(r, c) =>
 			mergeWith(r, omit(c, 'extends'), (objValue, srcValue) => {
-				if (isArray(objValue)) {
+				if (Array.isArray(objValue)) {
 					return srcValue;
 				}
 			}),


### PR DESCRIPTION
use native Array.isArray instead of lodash/isArray

## Description
in most places this got already migrated

https://node.green/#ES2015-built-ins-Proxy-Array-isArray-support

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
