### PR TITLE
refactor: use native String.startsWith instead of lodash/startsWith

### DIFF
--- a/@commitlint/load/src/utils/load-parser-opts.ts
+++ b/@commitlint/load/src/utils/load-parser-opts.ts
@@ -1,5 +1,3 @@
-import startsWith from 'lodash/startsWith';
-
 export async function loadParserOpts(
 	parserName: string,
 	pendingParser: Promise<any>
@@ -20,7 +18,7 @@ export async function loadParserOpts(
 	if (
 		typeof parser === 'object' &&
 		typeof parser.parserOpts === 'function' &&
-		startsWith(parserName, 'conventional-changelog-')
+		parserName.startsWith('conventional-changelog-')
 	) {
 		return await new Promise(resolve => {
 			const result = parser.parserOpts((_: never, opts: {parserOpts: any}) => {


### PR DESCRIPTION
use native String.startsWith instead of lodash/startsWith

## Description

https://node.green/#ES2015-built-ins-well-known-symbols-Symbol-match--String-prototype-startsWith

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
