### PR TITLE
refactor(parse): refactor parse to use object spread

### DIFF
--- a/@commitlint/parse/package.json
+++ b/@commitlint/parse/package.json
@@ -35,12 +35,10 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/test": "8.2.0",
-    "@commitlint/utils": "^8.3.4",
-    "@types/lodash": "4.14.149"
+    "@commitlint/utils": "^8.3.4"
   },
   "dependencies": {
     "conventional-changelog-angular": "^5.0.0",
-    "conventional-commits-parser": "^3.0.0",
-    "lodash": "^4.17.15"
+    "conventional-commits-parser": "^3.0.0"
   }
 }

--- a/@commitlint/parse/src/index.ts
+++ b/@commitlint/parse/src/index.ts
@@ -1,20 +1,18 @@
-import mergeWith from 'lodash/mergeWith';
 import {Commit, Parser, ParserOptions} from '@commitlint/types';
 
 const {sync} = require('conventional-commits-parser');
 const defaultChangelogOpts = require('conventional-changelog-angular');
 
-export default parse;
-
-async function parse(
+export default async function parse(
 	message: string,
 	parser: Parser = sync,
 	parserOpts?: ParserOptions
 ): Promise<Commit> {
 	const defaultOpts = (await defaultChangelogOpts).parserOpts;
-	const opts = mergeWith({}, defaultOpts, parserOpts, (objValue, srcValue) => {
-		if (Array.isArray(objValue)) return srcValue;
-	});
+	const opts = {
+		...defaultOpts,
+		...(parserOpts || {})
+	};
 	const parsed = parser(message, opts) as Commit;
 	parsed.raw = message;
 	return parsed;


### PR DESCRIPTION
refactor parse to use object spread instead of `lodash/mergeWith`

## Description

defaultOpts and parserOpts must be object that contains array of string or literal values

```ts
export interface ParserOptions {
	commentChar?: string;
	headerCorrespondence?: string[];
	headerPattern?: RegExp;
	issuePrefixes?: string[];
	mergeCorrespondence?: string[];
	mergePattern?: RegExp;
	noteKeywords?: string[];
	revertCorrespondence?: string[];
	revertPattern?: RegExp;
}
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
