### PR TITLE
fix(config-lerna-scopes): version range of lerna in peerDependencies

### DIFF
--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "peerDependencies": {
-    "lerna": "^3.20.2"
+    "lerna": "^2.0.0 || ^3.0.0"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
Fixes regression introduced by #936 and #406 

## Description

This rule supports both lerna@2 and lerna@3 versions and both cases are tested.
We should allow to use it with both of them and not warn users about missing `peerDependencies`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
