### PR TITLE
refactor(resolve-extends): replace lodash/omit with spread

### DIFF
--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -4,7 +4,6 @@ import 'resolve-global';
 import resolveFrom from 'resolve-from';
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
-import omit from 'lodash/omit';
 
 const importFresh = require('import-fresh');
 
@@ -34,8 +33,8 @@ export default function resolveExtends(
 ) {
 	const {extends: e} = config;
 	const extended = loadExtends(config, context).reduceRight(
-		(r, c) =>
-			mergeWith(r, omit(c, 'extends'), (objValue, srcValue) => {
+		(r, {extends: _, ...c}) =>
+			mergeWith(r, c, (objValue, srcValue) => {
 				if (Array.isArray(objValue)) {
 					return srcValue;
 				}


### PR DESCRIPTION
replace lodash/omit with spread

## Description

This syntax is not supported in targeted version of node but typescript does transpile it in ~same way as babel does

## Motivation and Context

`lodash/omit` has huge performance impact on code and new syntax (transpiled) is up to 10 times faster
`omit` is also on roadmap to be removed from `lodash`

https://github.com/lodash/lodash/issues/2930
https://github.com/lodash/lodash/wiki/Roadmap

## Usage examples

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
