### PR TITLE
fix(prompt): incorrect use of when in getForcedCaseFn

### DIFF
--- a/@commitlint/prompt/src/library/get-forced-case-fn.js
+++ b/@commitlint/prompt/src/library/get-forced-case-fn.js
@@ -30,7 +30,7 @@ export default function getForcedCaseFn(rule) {
 
 	const [, when] = config;
 
-	if (when === 'neve') {
+	if (when === 'never') {
 		return;
 	}
 


### PR DESCRIPTION
Fix incorrect use of `when` in `getForcedCaseFn`

## Description

This package has no tests, and this issue was introduced while fixing #145 in 3a569a744a5d2af6a324f5b65adce6a346cd6073

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

## How Has This Been Tested?

manual test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
