### PR TITLE
docs: update README.md

### DIFF
--- a/@commitlint/prompt/README.md
+++ b/@commitlint/prompt/README.md
@@ -9,7 +9,7 @@ Learn how to use it at [docs/prompt](https://conventional-changelog.github.io/co
 ## Getting started
 
 ```bash
-npm install --save-dev @commitlint/prompt @commitlint/config-angular commitizen
+npm install --save-dev @commitlint/prompt @commitlint/config-conventional commitizen
 echo "module.exports = {extends: ['@commitlint/config-conventional']};" > commitlint.config.js
 ```
 


### PR DESCRIPTION
Correct extend's name.

## Motivation and Context

The installed extend is `@commitlint/angular` while the required extend is `@commitlint/conventional`.

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
