### PR TITLE
feat: add local plugins support

### DIFF
--- a/@commitlint/load/src/load.test.ts
+++ b/@commitlint/load/src/load.test.ts
@@ -63,6 +63,28 @@ test('plugins should be loaded from seed', async () => {
 	});
 });
 
+test('plugins should be loaded from local', async () => {
+	const actual = await load({
+		plugins: [
+			{
+				rules: {
+					test: () => [true, 'asd']
+				}
+			}
+		]
+	});
+
+	expect(actual.plugins).toEqual(
+		expect.objectContaining({
+			local: {
+				rules: {
+					test: expect.any(Function)
+				}
+			}
+		})
+	);
+});
+
 test('plugins should be loaded from config', async () => {
 	const cwd = await gitBootstrap('fixtures/extends-plugins');
 	const actual = await load({}, {cwd});

--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -86,8 +86,12 @@ export default async function load(
 
 	// resolve plugins
 	if (Array.isArray(config.plugins)) {
-		config.plugins.forEach((pluginKey: string) => {
-			loadPlugin(preset.plugins, pluginKey, process.env.DEBUG === 'true');
+		config.plugins.forEach(plugin => {
+			if (typeof plugin === 'string') {
+				loadPlugin(preset.plugins, plugin, process.env.DEBUG === 'true');
+			} else {
+				preset.plugins.local = plugin;
+			}
 		});
 	}
 

--- a/@commitlint/types/src/load.ts
+++ b/@commitlint/types/src/load.ts
@@ -96,7 +96,7 @@ export interface UserConfig {
 	parserPreset?: string | ParserPreset;
 	ignores?: ((commit: string) => boolean)[];
 	defaultIgnores?: boolean;
-	plugins?: string[];
+	plugins?: (string | Plugin)[];
 }
 
 export interface UserPreset {

--- a/docs/reference-plugins.md
+++ b/docs/reference-plugins.md
@@ -43,6 +43,41 @@ Recommended keywords:
 
 Add these keywords into your `package.json` file to make it easy for others to find.
 
+## Local Plugins
+
+In case you want to develop your plugins locally without the need to publish to `npm`, you can send declare your plugins inside your project locally. Please be aware that you can declare **only one** local plugin.
+
+### Usage Example
+
+```js
+// commitlint.config.js
+module.exports = {
+  rules: {
+    'hello-world-rule': [2, 'always']
+  },
+  plugins: [
+    {
+      rules: {
+        'hello-world-rule': ({subject}) => {
+          const HELLO_WORLD = 'Hello World';
+          return [
+            subject.includes(HELLO_WORLD),
+            `Your subject should contain ${HELLO_WORLD} message`
+          ];
+        }
+      }
+    }
+  ]
+};
+```
+
+### Usage Example
+
+```bash
+> echo "feat: random subject" | commitlint # fails
+> echo "feat: Hello World" | commitlint # passes
+```
+
 ## Further Reading
 
 - [npm Developer Guide](https://docs.npmjs.com/misc/developers)


### PR DESCRIPTION
## Description

Add support for local plugins inside `commitlint.config.js`

## Motivation and Context

Sometimes you want to just add one custom rule without going throw the whole process of publishing an npm package. With this change, the developers can now send an object inside the `plugins` object, with the structure of a Plugin. Which I find super helpful because all the validations are inside only one place.

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  rules: {
    'hello-world-rule': [2, 'always'],
  },
  plugins: [
    {
      rules: {
        'hello-world-rule': ({ subject }) => {
          return [
            subject.includes('Hello World'),
            'Your subject should contain "Hello World" message',
          ];
        },
      },
    },
  ],
};
```

```sh
echo "feat: random subject" | commitlint # fails
echo "feat: Hello World" | commitlint # passes
```

## How Has This Been Tested?

I tested locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
