### PR TITLE
docs(readme): add install husky example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ npm install --save-dev @commitlint/config-conventional @commitlint/cli
 echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 ```
 
-To lint commits before they are created you can use Husky's 'commit-msg' hook:
+To lint commits before they are created you can use Husky's 'commit-msg' hook.
+
+Install in your project `npm install husky --save-dev` or `yarn add -D husky`.
+
+After that, you can create a `.huskyrc` file or add to your `package.json` the following code:
 
 ```json
 {


### PR DESCRIPTION
## Description

Add line of code how to install husky before usage them.

## Motivation and Context

Better explain how to lint before commit and the required package to do this.

## Usage examples

You can see the example usage in the `Getting Started` section of `README.md`.

## How Has This Been Tested?

It's just new text to the docs about the requirement of `Husky` to lint before commit.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
