### PR TITLE
chore: add node 13/14 to circle-ci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,16 @@ jobs:
       - image: node:12
     steps:
       - run-all
+  v13:
+    docker:
+      - image: node:13
+    steps:
+      - run-all
+  v14:
+    docker:
+      - image: node:14
+    steps:
+      - run-all
   windows-v12:
     executor: win/default
     steps:
@@ -102,4 +112,6 @@ workflows:
       - v8
       - v10
       - v12
+      - v13
+      - v14
       - windows-v12


### PR DESCRIPTION
## Description

Add node 13/14 as new testing jobs for circle-ci.

## Motivation and Context

https://github.com/conventional-changelog/commitlint/pull/1936  
execa supports nodejs >=10, we should start moving our minimum version up.  
This is only a start to make this happen if wanted.

## How Has This Been Tested?

via circle-ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
