### PR TITLE
feat: allow multiple local plugins

### DIFF
--- a/@commitlint/load/src/load.test.ts
+++ b/@commitlint/load/src/load.test.ts
@@ -85,6 +85,34 @@ test('plugins should be loaded from local', async () => {
 	);
 });
 
+test('multiple local plugins should be supported', async () => {
+	const actual = await load({
+		plugins: [
+			{
+				rules: {
+					test1: () => [true, 'asd']
+				}
+			},
+			{
+				rules: {
+					test2: () => [true, 'fgh']
+				}
+			}
+		]
+	});
+
+	expect(actual.plugins).toEqual(
+		expect.objectContaining({
+			local: {
+				rules: {
+					test1: expect.any(Function),
+					test2: expect.any(Function)
+				}
+			}
+		})
+	);
+});
+
 test('plugins should be loaded from config', async () => {
 	const cwd = await gitBootstrap('fixtures/extends-plugins');
 	const actual = await load({}, {cwd});

--- a/@commitlint/load/src/load.test.ts
+++ b/@commitlint/load/src/load.test.ts
@@ -76,7 +76,7 @@ test('plugins should be loaded from local', async () => {
 
 	expect(actual.plugins).toEqual(
 		expect.objectContaining({
-			local: {
+			'local-0': {
 				rules: {
 					test: expect.any(Function)
 				}
@@ -103,9 +103,13 @@ test('multiple local plugins should be supported', async () => {
 
 	expect(actual.plugins).toEqual(
 		expect.objectContaining({
-			local: {
+			'local-0': {
 				rules: {
-					test1: expect.any(Function),
+					test1: expect.any(Function)
+				}
+			},
+			'local-1': {
+				rules: {
 					test2: expect.any(Function)
 				}
 			}

--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -24,6 +24,12 @@ import {pickConfig} from './utils/pick-config';
 const w = <T>(_: unknown, b: ArrayLike<T> | null | undefined | false) =>
 	Array.isArray(b) ? b : undefined;
 
+const generateLocalId = () => {
+	let id = 0;
+
+	return () => `local-${id++}`;
+};
+
 export default async function load(
 	seed: UserConfig = {},
 	options: LoadOptions = {}
@@ -86,11 +92,13 @@ export default async function load(
 
 	// resolve plugins
 	if (Array.isArray(config.plugins)) {
+		const localIdGenerator = generateLocalId();
+
 		config.plugins.forEach(plugin => {
 			if (typeof plugin === 'string') {
 				loadPlugin(preset.plugins, plugin, process.env.DEBUG === 'true');
 			} else {
-				preset.plugins.local = plugin;
+				preset.plugins[localIdGenerator()] = plugin;
 			}
 		});
 	}

--- a/docs/reference-plugins.md
+++ b/docs/reference-plugins.md
@@ -45,7 +45,7 @@ Add these keywords into your `package.json` file to make it easy for others to f
 
 ## Local Plugins
 
-In case you want to develop your plugins locally without the need to publish to `npm`, you can send declare your plugins inside your project locally. Please be aware that you can declare **only one** local plugin.
+In case you want to develop your plugins locally without the need to publish to `npm`, you can send declare your plugins inside your project locally. This is also a great way to include specific rules in a [shareable configuration](https://commitlint.js.org/#/reference-configuration?id=shareable-configuration).
 
 ### Usage Example
 


### PR DESCRIPTION
This PR allows for multiple local plugins to be loaded.

## Description

The plugins are usually loaded by their name and added to an object, with their name as key. Local plugins do not have a name so they were previously saved as 'local' in the same object. If you loaded multiple local plugins the value was overwritten.

This PR saves all local plugins on a unique key. They are called `local-0`, `local-1`, etc.

## Motivation and Context

First of all you can have multiple local plugins. This means that you can export and import them without having to merge them. This also means that you can include multiple shareable plugins that include local plugins, without them overwriting each other. 

## Usage examples

Self-explanatory.

## How Has This Been Tested?

I have added a test for multiple plugins, and they are correctly loaded.

I have _not_ tested how it works when you include multiple shared configurations with plugins or a mix of local plugins in your config and from a shared config. This is because currently, the master branch does not support plugins from shared configs in any way. When that is fixed we can add tests for this.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
