### PR TITLE
refactor!: drop support for node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,6 @@ commands:
       - build
       - test
 jobs:
-  v8:
-    docker:
-      - image: node:8
-    steps:
-      - run-tests
   v10:
     docker:
       - image: node:10
@@ -89,11 +84,6 @@ jobs:
   v12:
     docker:
       - image: node:12
-    steps:
-      - run-all
-  v13:
-    docker:
-      - image: node:13
     steps:
       - run-all
   v14:
@@ -109,9 +99,7 @@ jobs:
 workflows:
   node:
     jobs:
-      - v8
       - v10
       - v12
-      - v13
       - v14
       - windows-v12

--- a/@alias/commitlint-config-angular/package.json
+++ b/@alias/commitlint-config-angular/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "dependencies": {
     "@commitlint/config-angular": "^9.1.2"

--- a/@alias/commitlint-config-lerna-scopes/package.json
+++ b/@alias/commitlint-config-lerna-scopes/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "dependencies": {
     "@commitlint/config-lerna-scopes": "^9.1.2"

--- a/@alias/commitlint-config-patternplate/package.json
+++ b/@alias/commitlint-config-patternplate/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "dependencies": {
     "@commitlint/config-patternplate": "^9.1.2"

--- a/@alias/commitlint/package.json
+++ b/@alias/commitlint/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check --skip-main"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -15,7 +15,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/config-angular-type-enum/package.json
+++ b/@commitlint/config-angular-type-enum/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "devDependencies": {
     "@commitlint/utils": "^9.1.2"

--- a/@commitlint/config-angular/package.json
+++ b/@commitlint/config-angular/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "devDependencies": {
     "@commitlint/utils": "^9.1.2"

--- a/@commitlint/config-conventional/package.json
+++ b/@commitlint/config-conventional/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "devDependencies": {
     "@commitlint/lint": "^9.1.2",

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -29,7 +29,7 @@
     "lerna": "^2.0.0 || ^3.0.0"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "dependencies": {
     "import-from": "3.0.0",

--- a/@commitlint/config-patternplate/package.json
+++ b/@commitlint/config-patternplate/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "dependencies": {
     "@commitlint/config-angular": "^9.1.2",

--- a/@commitlint/core/package.json
+++ b/@commitlint/core/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/ensure/package.json
+++ b/@commitlint/ensure/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/execute-rule/package.json
+++ b/@commitlint/execute-rule/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/format/package.json
+++ b/@commitlint/format/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/is-ignored/package.json
+++ b/@commitlint/is-ignored/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/message/package.json
+++ b/@commitlint/message/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/parse/package.json
+++ b/@commitlint/parse/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/prompt-cli/package.json
+++ b/@commitlint/prompt-cli/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "devDependencies": {
     "@commitlint/test": "^9.1.2",

--- a/@commitlint/prompt/package.json
+++ b/@commitlint/prompt/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/conventional-changelog/commitlint#readme",
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.7",

--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/to-lines/package.json
+++ b/@commitlint/to-lines/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/top-level/package.json
+++ b/@commitlint/top-level/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/travis-cli/package.json
+++ b/@commitlint/travis-cli/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/types/package.json
+++ b/@commitlint/types/package.json
@@ -11,7 +11,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@packages/babel-preset-commitlint/package.json
+++ b/@packages/babel-preset-commitlint/package.json
@@ -8,7 +8,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@packages/test-environment/package.json
+++ b/@packages/test-environment/package.json
@@ -9,7 +9,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@packages/test/package.json
+++ b/@packages/test/package.json
@@ -9,7 +9,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/@packages/utils/package.json
+++ b/@packages/utils/package.json
@@ -16,7 +16,7 @@
     "pkg": "node pkg-check.js --skip-main"
   },
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ is room and need for improvement. The items on the roadmap should enhance `commi
 
 ## Version Support
 
-- Node.js [LTS](https://github.com/nodejs/LTS#lts-schedule) `>= 10`
+- Node.js [LTS](https://github.com/nodejs/LTS#lts-schedule) `>= 10.21.0`
 - git `>= 2.13.2`
 
 ## Related projects

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ is room and need for improvement. The items on the roadmap should enhance `commi
 
 ## Version Support
 
-- Node.js [LTS](https://github.com/nodejs/LTS#lts-schedule) `>= 8`
+- Node.js [LTS](https://github.com/nodejs/LTS#lts-schedule) `>= 10`
 - git `>= 2.13.2`
 
 ## Related projects

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@packages/*"
   ],
   "engines": {
-    "node": ">=v8.17.0"
+    "node": ">=v10.21.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
BREAKING CHANGE: remove node 8 from circle-ci checks

also remove node 13 because we do not support experimental versions

next up:  
taking care of #1936

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
