### PR TITLE
Use read dafult export - requiring with CommonJS

### DIFF
--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -291,7 +291,7 @@ read(range: Range) => Promise<string[]>
 
 ```js
 // git commit -m "I did something"
-const read = require('@commitlint/read');
+const read = require('@commitlint/read').default;
 
 read({edit: true}).then((messages) => console.log(messages));
 // => ['I did something\n\n']


### PR DESCRIPTION
Suggesting a change that made my local setup work.

## Description

The documentation was out of sync with implementation. I suggest a small change that will fix the case for `@commitlint/read`

