### PR TITLE
fix(resolve-extends): `extends` field should be resolved from left to right

### DIFF
--- a/@commitlint/resolve-extends/src/index.test.ts
+++ b/@commitlint/resolve-extends/src/index.test.ts
@@ -243,6 +243,35 @@ test('propagates contents recursively with overlap', () => {
 	expect(actual).toEqual(expected);
 });
 
+test('extends rules from left to right with overlap', () => {
+	const input = {extends: ['left', 'right']};
+
+	const require = (id: string) => {
+		switch (id) {
+			case 'left':
+				return {rules: {a: true}};
+			case 'right':
+				return {rules: {a: false, b: true}};
+			default:
+				return {};
+		}
+	};
+
+	const ctx = {resolve: id, require: jest.fn(require)} as ResolveExtendsContext;
+
+	const actual = resolveExtends(input, ctx);
+
+	const expected = {
+		extends: ['left', 'right'],
+		rules: {
+			a: false,
+			b: true,
+		},
+	};
+
+	expect(actual).toEqual(expected);
+});
+
 test('extending contents should take precedence', () => {
 	const input = {extends: ['extender-name'], zero: 'root'};
 

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -32,7 +32,7 @@ export default function resolveExtends(
 	context: ResolveExtendsContext = {}
 ) {
 	const {extends: e} = config;
-	const extended = loadExtends(config, context).reduceRight(
+	const extended = loadExtends(config, context).reduce(
 		(r, {extends: _, ...c}) =>
 			mergeWith(r, c, (objValue, srcValue) => {
 				if (Array.isArray(objValue)) {
@@ -78,7 +78,7 @@ function loadExtends(
 			config.parserPreset = parserPreset;
 		}
 
-		return [...configs, c, ...loadExtends(c, ctx)];
+		return [...configs, ...loadExtends(c, ctx), c];
 	}, []);
 }
 


### PR DESCRIPTION
Fixes #2069.

## Description

See #2069.

BREAKING CHANGE:

The order of the `extends` resolution is changed from right-to-left to left-to-right

## Motivation and Context

See #2069.

## Usage examples

See #2069.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
