### PR TITLE
fix(rules): ignore comments in `signed-off-by`

### DIFF
--- a/@commitlint/rules/src/signed-off-by.test.ts
+++ b/@commitlint/rules/src/signed-off-by.test.ts
@@ -7,6 +7,15 @@ const messages = {
 	without: `test: subject\nbody\nfooter\n\n`,
 	inSubject: `test: subject Signed-off-by:\nbody\nfooter\n\n`,
 	inBody: `test: subject\nbody Signed-off-by:\nfooter\n\n`,
+	withSignoffAndComments: `test: subject
+
+message body
+
+Signed-off-by:
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+`,
 };
 
 const parsed = {
@@ -15,6 +24,7 @@ const parsed = {
 	without: parse(messages.without),
 	inSubject: parse(messages.inSubject),
 	inBody: parse(messages.inBody),
+	withSignoffAndComments: parse(messages.withSignoffAndComments),
 };
 
 test('empty against "always signed-off-by" should fail', async () => {
@@ -53,6 +63,16 @@ test('without against "always signed-off-by" should fail', async () => {
 
 test('without against "never signed-off-by" should succeed', async () => {
 	const [actual] = signedOffBy(await parsed.without, 'never', 'Signed-off-by:');
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('trailing comments should be ignored', async () => {
+	const [actual] = signedOffBy(
+		await parsed.withSignoffAndComments,
+		'always',
+		'Signed-off-by:'
+	);
 	const expected = true;
 	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/signed-off-by.ts
+++ b/@commitlint/rules/src/signed-off-by.ts
@@ -7,7 +7,14 @@ export const signedOffBy: SyncRule<string> = (
 	when = 'always',
 	value = ''
 ) => {
-	const lines = toLines(parsed.raw).filter(Boolean);
+	const lines = toLines(parsed.raw).filter(
+		(ln) =>
+			// skip comments
+			!ln.startsWith('#') &&
+			// ignore empty lines
+			Boolean(ln)
+	);
+
 	const last = lines[lines.length - 1];
 
 	const negated = when === 'never';


### PR DESCRIPTION
Fix `signed-off-by` rule to ignore lines starting with `#`.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Lines starting with `#` are comments. They are added by `git commit` at the end of the commit message template to show which files are included in the commit, and removed from the actual commit message.

Before this change, the rule `signed-off-by` was rejecting pretty much all commit messages created by `git commit` from the command line.

With this change in place, the rule ignores commits and accepts commit message created by `git commit` from the command line.
<!--- Describe your changes in detail -->

## Motivation and Context

Fixes #1809

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

**Configuration**

```js
// commitlint.config.js
module.exports = {
  rules: {
    'signed-off-by': [2, 'always', 'Signed-off-by:']
  }
};
```

**Command to run**
```sh
commitlint <<EOF
feat: foobar

Signed-off-by: Miroslav Bajtoš <mbajtoss@gmail.com>

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
EOF
```

**Actual output**

```
⧗   input: feat: foobar

Signed-off-by: Miroslav Bajtoš <mbajtoss@gmail.com>

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
✖   message must be signed off [signed-off-by]

✖   found 1 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
```

## How Has This Been Tested?

I added a unit-test, watched it to fail with an expected error, and then fixed the implementation to make the test pass.

I re-run the example command shown above inside `commitlint` monorepo to verify that the fixed version accepts the message with comments.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
