### PR TITLE
feat(rules): add body-full-stop rule

### DIFF
--- a/@commitlint/rules/src/body-full-stop.test.ts
+++ b/@commitlint/rules/src/body-full-stop.test.ts
@@ -1,0 +1,50 @@
+import parse from '@commitlint/parse';
+import {bodyFullStop} from './body-full-stop';
+
+const messages = {
+	empty: 'test:\n',
+	with: `test: subject\n\nbody.`,
+	without: `test: subject\n\nbody`,
+};
+
+const parsed = {
+	empty: parse(messages.empty),
+	with: parse(messages.with),
+	without: parse(messages.without),
+};
+
+test('empty against "always" should succeed', async () => {
+	const [actual] = bodyFullStop(await parsed.empty, 'always', '.');
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('empty against "never ." should succeed', async () => {
+	const [actual] = bodyFullStop(await parsed.empty, 'never', '.');
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('with against "always ." should succeed', async () => {
+	const [actual] = bodyFullStop(await parsed.with, 'always', '.');
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('with against "never ." should fail', async () => {
+	const [actual] = bodyFullStop(await parsed.with, 'never', '.');
+	const expected = false;
+	expect(actual).toEqual(expected);
+});
+
+test('without against "always ." should fail', async () => {
+	const [actual] = bodyFullStop(await parsed.without, 'always', '.');
+	const expected = false;
+	expect(actual).toEqual(expected);
+});
+
+test('without against "never ." should succeed', async () => {
+	const [actual] = bodyFullStop(await parsed.without, 'never', '.');
+	const expected = true;
+	expect(actual).toEqual(expected);
+});

--- a/@commitlint/rules/src/body-full-stop.ts
+++ b/@commitlint/rules/src/body-full-stop.ts
@@ -1,0 +1,22 @@
+import message from '@commitlint/message';
+import {SyncRule} from '@commitlint/types';
+
+export const bodyFullStop: SyncRule<string> = (
+	parsed,
+	when = 'always',
+	value = '.'
+) => {
+	const input = parsed.body;
+
+	if (!input) {
+		return [true];
+	}
+
+	const negated = when === 'never';
+	const hasStop = input[input.length - 1] === value;
+
+	return [
+		negated ? !hasStop : hasStop,
+		message(['body', negated ? 'may not' : 'must', 'end with full stop']),
+	];
+};

--- a/@commitlint/rules/src/index.ts
+++ b/@commitlint/rules/src/index.ts
@@ -1,5 +1,6 @@
 import {bodyCase} from './body-case';
 import {bodyEmpty} from './body-empty';
+import {bodyFullStop} from './body-full-stop';
 import {bodyLeadingBlank} from './body-leading-blank';
 import {bodyMaxLength} from './body-max-length';
 import {bodyMaxLineLength} from './body-max-line-length';
@@ -34,6 +35,7 @@ import {typeMinLength} from './type-min-length';
 export default {
 	'body-case': bodyCase,
 	'body-empty': bodyEmpty,
+	'body-full-stop': bodyFullStop,
 	'body-leading-blank': bodyLeadingBlank,
 	'body-max-length': bodyMaxLength,
 	'body-max-line-length': bodyMaxLineLength,

--- a/@commitlint/types/src/rules.ts
+++ b/@commitlint/types/src/rules.ts
@@ -91,6 +91,7 @@ export type EnumRuleConfig<V = RuleConfigQuality.User> = RuleConfig<
 export type RulesConfig<V = RuleConfigQuality.User> = {
 	'body-case': CaseRuleConfig<V>;
 	'body-empty': RuleConfig<V>;
+	'body-full-stop': RuleConfig<V>;
 	'body-leading-blank': RuleConfig<V>;
 	'body-max-length': LengthRuleConfig<V>;
 	'body-max-line-length': LengthRuleConfig<V>;

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -42,6 +42,16 @@ Rule configurations are either of type `array` residing on a key with the rule's
 
 ### Available rules
 
+#### body-full-stop
+
+- **condition**: `body` ends with `value`
+- **rule**: `never`
+- **value**
+
+```
+'.'
+```
+
 #### body-leading-blank
 
 - **condition**: `body` begins with blank line


### PR DESCRIPTION
## Description

This PR adds a `body-full-stop` rule.

## Motivation and Context

Fixes #2143.

## Usage examples

```js
// commitlint.config.js
module.exports = {
  rules: {
    'body-full-stop': [2, 'always', '.'],
  }
};
```

```js
echo "test: subject\n\nbody." | commitlint # passes
echo "test: test: subject\n\nbody" | commitlint # fails
```

```js
// commitlint.config.js
module.exports = {
  rules: {
    'body-full-stop': [2, 'never', '.'],
  }
};
```

```js
echo "test: subject\n\nbody." | commitlint # fails
echo "test: test: subject\n\nbody" | commitlint # passes
```

## How Has This Been Tested?

Adding more tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I don't have any knowledge nor experience in Javascript/Typescript, but this only requires copy/pasting and adapting existing code, so here is my modest contribution. I cannot state for sure if all tests passed, I developped within the Docker container but got weird issues when running `yarn test`. 
```
ts-jest[versions] (WARN) Version 25.1.0 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=26.0.0 <27.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
```
Hope it's okay...
