### PR TITLE
fix(load): use `Rule | AsyncRule | SyncRule` as rule value type in `Plugin`

### DIFF
--- a/@commitlint/load/src/utils/load-plugin.test.ts
+++ b/@commitlint/load/src/utils/load-plugin.test.ts
@@ -1,4 +1,5 @@
 import loadPlugin from './load-plugin';
+import {AsyncRule, Plugin, Rule, SyncRule} from '@commitlint/types';
 
 jest.mock('commitlint-plugin-example', () => ({example: true}), {
 	virtual: true,
@@ -8,6 +9,39 @@ jest.mock('@scope/commitlint-plugin-example', () => ({scope: true}), {
 	virtual: true,
 });
 
+jest.mock(
+	'commitlint-plugin-rule',
+	(): Plugin => {
+		const rule: Rule<number> = (_parsed, when, _value) => {
+			return [when === 'never'];
+		};
+		return {rules: {rule}};
+	},
+	{virtual: true}
+);
+
+jest.mock(
+	'commitlint-plugin-sync-rule',
+	(): Plugin => {
+		const syncRule: SyncRule<number> = (_parsed, when, _value) => {
+			return [when === 'never'];
+		};
+		return {rules: {syncRule}};
+	},
+	{virtual: true}
+);
+
+jest.mock(
+	'commitlint-plugin-async-rule',
+	(): Plugin => {
+		const asyncRule: AsyncRule<number> = (_parsed, when, _value) => {
+			return new Promise(() => [when === 'never']);
+		};
+		return {rules: {asyncRule}};
+	},
+	{virtual: true}
+);
+
 test('should load a plugin when referenced by short name', () => {
 	const plugins = loadPlugin({}, 'example');
 	expect(plugins['example']).toBe(require('commitlint-plugin-example'));
@@ -16,6 +50,21 @@ test('should load a plugin when referenced by short name', () => {
 test('should load a plugin when referenced by long name', () => {
 	const plugins = loadPlugin({}, 'commitlint-plugin-example');
 	expect(plugins['example']).toBe(require('commitlint-plugin-example'));
+});
+
+test('should load a plugin with a rule', () => {
+	const plugins = loadPlugin({}, 'commitlint-plugin-rule');
+	expect(plugins['rule']).toBe(require('commitlint-plugin-rule'));
+});
+
+test('should load a plugin with a sync rule', () => {
+	const plugins = loadPlugin({}, 'commitlint-plugin-sync-rule');
+	expect(plugins['sync-rule']).toBe(require('commitlint-plugin-sync-rule'));
+});
+
+test('should load a plugin with an async rule', () => {
+	const plugins = loadPlugin({}, 'commitlint-plugin-async-rule');
+	expect(plugins['async-rule']).toBe(require('commitlint-plugin-async-rule'));
 });
 
 test('should throw an error when a plugin has whitespace', () => {

--- a/@commitlint/types/src/load.ts
+++ b/@commitlint/types/src/load.ts
@@ -1,10 +1,16 @@
-import {Rule, RulesConfig, RuleConfigQuality} from './rules';
+import {
+	Rule,
+	RulesConfig,
+	RuleConfigQuality,
+	AsyncRule,
+	SyncRule,
+} from './rules';
 
 export type PluginRecords = Record<string, Plugin>;
 
 export interface Plugin {
 	rules: {
-		[ruleName: string]: Rule<unknown>;
+		[ruleName: string]: Rule | AsyncRule | SyncRule;
 	};
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Use `Rule` instead of `Rule<unknown>` so plugin developers don't need to cast every non-default
rule's value to `Rule<unknown>`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes an issue where TypeScript plugin developers that specify rules with a type other than `Rule<unknown>` need to cast every rule value to `Rule<unknown>` to prevent errors like shown below.
Haven't made an issue for this as I'm creating this PR right away, but happy to do so and/or discuss further.

```
TS2322: Type 'BaseRule<FunctionRule, "either">' is not assignable to type 'BaseRule<unknown, "either">'.
```

## Usage examples

<!--- Provide examples of intended usage -->

Example usage in my plugin. Note that without this change you'd need to do `'function-rules/body-case': functionRule as Rule<unknown>,`

```ts
type FunctionRule = (
  parsed: Commit,
  when: RuleConfigCondition,
) => RuleOutcome | Promise<RuleOutcome>;

const functionRule: Rule<FunctionRule> = (
  parsed: Commit,
  when: RuleConfigCondition = 'always',
  value: FunctionRule | undefined,
) => {
  if (typeof value === 'function') {
    return value(parsed, when);
  }

  throw new Error('Not a valid function!');
};

const rules: Plugin['rules'] = {
  'function-rules/body-case': functionRule,
};
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I've run the build and tests (`yarn run build` and `yarn run test`) and tested it by making the change locally in my plugin and running the build in my plugin (without any `as Rule<unknown>` cast).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

I don't think this would be breaking for plugin developers, definitely not end-user obviously.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
