### PR TITLE
feat(config-lerna-scopes): support yarn workspaces

### DIFF
--- a/@commitlint/config-lerna-scopes/fixtures/yarn/@packages/a/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/yarn/@packages/a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@packages/a",
+  "version": "1.0.0"
+}

--- a/@commitlint/config-lerna-scopes/fixtures/yarn/@packages/b/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/yarn/@packages/b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@packages/b",
+  "version": "1.0.0"
+}

--- a/@commitlint/config-lerna-scopes/fixtures/yarn/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/yarn/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "yarn",
+  "version": "1.0.0",
+  "devDependencies": {
+    "lerna": "^3.0.0"
+  },
+  "workspaces": [
+    "@packages/*"
+  ]
+}

--- a/@commitlint/config-lerna-scopes/index.js
+++ b/@commitlint/config-lerna-scopes/index.js
@@ -22,9 +22,9 @@ function getPackages(context) {
 			if (Array.isArray(workspaces) && workspaces.length) {
 				// use yarn workspaces
 				return Globby(
-					workspaces.map((ws) =>
-						Path.join(ws.replace(/\//, Path.sep), 'package.json')
-					),
+					workspaces.map((ws) => {
+						return Path.posix.join(ws, 'package.json');
+					}),
 					{cwd}
 				).then((pJsons = []) => {
 					return pJsons.map((pJson) => require(Path.join(cwd, pJson)));

--- a/@commitlint/config-lerna-scopes/index.js
+++ b/@commitlint/config-lerna-scopes/index.js
@@ -1,6 +1,7 @@
 const Path = require('path');
 const importFrom = require('import-from');
 const resolvePkg = require('resolve-pkg');
+const Globby = require('globby');
 const semver = require('semver');
 
 module.exports = {
@@ -16,8 +17,21 @@ function getPackages(context) {
 		.then(() => {
 			const ctx = context || {};
 			const cwd = ctx.cwd || process.cwd();
-			const lernaVersion = getLernaVersion(cwd);
 
+			const {workspaces} = require(Path.join(cwd, 'package.json'));
+			if (Array.isArray(workspaces) && workspaces.length) {
+				// use yarn workspaces
+				return Globby(
+					workspaces.map((ws) =>
+						Path.join(ws.replace(/\//, Path.sep), 'package.json')
+					),
+					{cwd}
+				).then((pJsons = []) => {
+					return pJsons.map((pJson) => require(Path.join(cwd, pJson)));
+				});
+			}
+
+			const lernaVersion = getLernaVersion(cwd);
 			if (semver.lt(lernaVersion, '3.0.0')) {
 				const Repository = importFrom(cwd, 'lerna/lib/Repository');
 				const PackageUtilities = importFrom(cwd, 'lerna/lib/PackageUtilities');

--- a/@commitlint/config-lerna-scopes/index.test.js
+++ b/@commitlint/config-lerna-scopes/index.test.js
@@ -72,5 +72,5 @@ test('returns expected value for yarn workspaces', async () => {
 	const {'scope-enum': fn} = config.rules;
 	const cwd = Path.join(__dirname, 'fixtures', 'yarn');
 	const [, , value] = await fn({cwd});
-	expect(value).toEqual(['a', 'b']);
+	expect(value.sort()).toEqual(['a', 'b']);
 });

--- a/@commitlint/config-lerna-scopes/index.test.js
+++ b/@commitlint/config-lerna-scopes/index.test.js
@@ -1,3 +1,4 @@
+import Path from 'path';
 import {lerna} from '@commitlint/test';
 import config from '.';
 
@@ -63,6 +64,13 @@ test('returns expected value for scoped lerna repository', async () => {
 	const {'scope-enum': fn} = config.rules;
 	const cwd = await lerna.bootstrap('scoped', __dirname);
 
+	const [, , value] = await fn({cwd});
+	expect(value).toEqual(['a', 'b']);
+});
+
+test('returns expected value for yarn workspaces', async () => {
+	const {'scope-enum': fn} = config.rules;
+	const cwd = Path.join(__dirname, 'fixtures', 'yarn');
 	const [, , value] = await fn({cwd});
 	expect(value).toEqual(['a', 'b']);
 });

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -32,6 +32,7 @@
     "node": ">=v10.22.1"
   },
   "dependencies": {
+    "globby": "^11.0.1",
     "import-from": "3.0.0",
     "resolve-pkg": "2.0.0",
     "semver": "7.3.4"

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@commitlint/config-lerna-scopes",
   "version": "11.0.0",
-  "description": "Shareable commitlint config enforcing lerna package names as scopes",
+  "description": "Shareable commitlint config enforcing lerna package and workspace names as scopes",
   "files": [
     "index.js"
   ],

--- a/@commitlint/config-lerna-scopes/readme.md
+++ b/@commitlint/config-lerna-scopes/readme.md
@@ -2,7 +2,7 @@
 
 # @commitlint/config-lerna-scopes
 
-Shareable `commitlint` config enforcing lerna package names as scopes.
+Shareable `commitlint` config enforcing lerna/yarn package/workspace names as scopes.
 Use with [@commitlint/cli](../cli) and [@commitlint/prompt-cli](../prompt-cli).
 
 ## Getting started

--- a/@commitlint/config-lerna-scopes/readme.md
+++ b/@commitlint/config-lerna-scopes/readme.md
@@ -2,7 +2,7 @@
 
 # @commitlint/config-lerna-scopes
 
-Shareable `commitlint` config enforcing lerna/yarn package/workspace names as scopes.
+Shareable `commitlint` config enforcing lerna package and workspace names as scopes.
 Use with [@commitlint/cli](../cli) and [@commitlint/prompt-cli](../prompt-cli).
 
 ## Getting started

--- a/yarn.lock
+++ b/yarn.lock
@@ -7156,10 +7156,25 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@^3.3.1, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.2.1, lodash@^4.5.1:
+lodash@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^3.3.1:
+  version "3.10.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
+
+lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.2.1, lodash@^4.5.1:
   version "4.17.19"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7156,25 +7156,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15:
-  version "4.17.15"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^3.3.1:
-  version "3.10.1"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
-
-lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.2.1, lodash@^4.5.1:
+lodash@4.17.15, lodash@^3.3.1, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.2.1, lodash@^4.5.1:
   version "4.17.19"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.17.20:
-  version "4.17.20"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description

Using _mostly_ the same logic present in the lerna config, add support for yarn workspaces. Can be used with and without lerna.

## Motivation and Context

Some users, like me, often use yarn workspaces without lerna. This config would still be very useful to validate that the scopes match.

## How Has This Been Tested?

Using the same setup of a normal lerna repo, one can just remove the `lerna.json` file and adapt the `package.json` to include a `workspaces` config. With that in mind, I copied an existing lerna fixture and adapted it to yarn.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
