### PR TITLE
feat(load): allow specifying helpUrl via config

### DIFF
--- a/@commitlint/cli/fixtures/help-url/commitlint.config.js
+++ b/@commitlint/cli/fixtures/help-url/commitlint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	rules: {
+		'type-enum': [2, 'never', ['foo']]
+	},
+	helpUrl: 'https://www.example.com/foo'
+};

--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -120,6 +120,13 @@ test('should fail for input from stdin with rule from js', async () => {
 	expect(actual.exitCode).toBe(1);
 });
 
+test('should output help URL defined in config file', async () => {
+	const cwd = await gitBootstrap('fixtures/help-url');
+	const actual = await cli([], {cwd})('foo: bar');
+	expect(actual.stdout).toContain('Get help: https://www.example.com/foo');
+	expect(actual.exitCode).toBe(1);
+});
+
 test('should produce no error output with --quiet flag', async () => {
 	const cwd = await gitBootstrap('fixtures/simple');
 	const actual = await cli(['--quiet'], {cwd})('foo: bar');

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -229,12 +229,12 @@ async function main(options: CliFlags) {
 		}
 	);
 
+	const helpUrl = flags['help-url']?.trim() || loaded.helpUrl;
+
 	const output = format(report, {
 		color: flags.color,
 		verbose: flags.verbose,
-		helpUrl: flags['help-url']
-			? flags['help-url'].trim()
-			: 'https://github.com/conventional-changelog/commitlint/#what-is-commitlint',
+		helpUrl,
 	});
 
 	if (!flags.quiet && output !== '') {

--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -112,6 +112,11 @@ export default async function load(
 		return registry;
 	}, {});
 
+	const helpUrl =
+		typeof config.helpUrl === 'string'
+			? config.helpUrl
+			: 'https://github.com/conventional-changelog/commitlint/#what-is-commitlint';
+
 	return {
 		extends: preset.extends!,
 		formatter: preset.formatter!,
@@ -120,5 +125,6 @@ export default async function load(
 		defaultIgnores: preset.defaultIgnores!,
 		plugins: preset.plugins!,
 		rules: qualifiedRules,
+		helpUrl,
 	};
 }

--- a/@commitlint/load/src/utils/pick-config.ts
+++ b/@commitlint/load/src/utils/pick-config.ts
@@ -10,5 +10,6 @@ export const pickConfig = (input: unknown): UserConfig =>
 		'parserPreset',
 		'formatter',
 		'ignores',
-		'defaultIgnores'
+		'defaultIgnores',
+		'helpUrl'
 	);

--- a/@commitlint/types/src/lint.ts
+++ b/@commitlint/types/src/lint.ts
@@ -19,6 +19,7 @@ export interface LintOptions {
 	parserOpts?: ParserOptions;
 
 	plugins?: PluginRecords;
+	helpUrl?: string;
 }
 
 export interface LintOutcome {

--- a/@commitlint/types/src/load.ts
+++ b/@commitlint/types/src/load.ts
@@ -21,6 +21,7 @@ export interface UserConfig {
 	ignores?: ((commit: string) => boolean)[];
 	defaultIgnores?: boolean;
 	plugins?: (string | Plugin)[];
+	helpUrl?: string;
 }
 
 export interface UserPreset {
@@ -43,6 +44,7 @@ export interface QualifiedConfig {
 	ignores: ((commit: string) => boolean)[];
 	defaultIgnores: boolean;
 	plugins: PluginRecords;
+	helpUrl: string;
 }
 
 export interface ParserPreset {

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -203,6 +203,10 @@ type Seed = {
    * Initial map of rules to check against
    */
   rules?: {[ruleName: string]: Rule};
+  /**
+   * URL to print as help for reports with problems
+   */
+  helpUrl?: string;
 };
 
 type Config = {
@@ -218,6 +222,10 @@ type Config = {
    * Merged map of rules to check against
    */
   rules: {[ruleName: string]: Rule};
+  /**
+   * URL to print as help for reports with problems
+   */
+  helpUrl?: string;
 };
 
 type LoadOptions = {

--- a/docs/reference-configuration.md
+++ b/docs/reference-configuration.md
@@ -34,6 +34,10 @@ type Config = {
    * Whether commitlint uses the default ignore rules.
    */
   defaultIgnores?: boolean;
+  /*
+   * Custom URL to show upon failure
+   */
+  helpUrl?: string;
 };
 
 const Configuration: Config = {
@@ -66,6 +70,11 @@ const Configuration: Config = {
    * Whether commitlint uses the default ignore rules.
    */
   defaultIgnores: true,
+  /*
+   * Custom URL to show upon failure
+   */
+  helpUrl:
+    'https://github.com/conventional-changelog/commitlint/#what-is-commitlint',
 };
 
 module.exports = Configuration;


### PR DESCRIPTION
## Description

To allow this, `helpUrl` is added as an optional base configuration
property, and falls back to the original default URL if neither the CLI
flag nor config option is specified. The CLI option takes precedence
over the config object, if both are supplied.

## Motivation and Context

It can make configuration a bit more DRY if one can use the commitlint
configuration object to specify a custom help URL vs. having wrapper
scripts and similar things to make every invocation of `commitlint` run
with `--help-url` specified.

## Usage examples

```js
// commitlint.config.js
module.exports = {
	rules: {
		'type-enum': [2, 'never', ['foo']]
	},
	helpUrl: 'https://www.example.com/foo'
};
```

```sh
echo "an invalid commit message" | commitlint # fails

⧗   input: an invalid commit message
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]
⚠   scope may not be empty [scope-empty]

✖   found 2 problems, 1 warnings
ⓘ   Get help: https://www.example.com/foo
```

## How Has This Been Tested?

Used the existing test suite as a basis for writing a new test wherein a sample `commitlint.config.js` is used which specifies the necessary `helpUrl` option, and asserted that the expected URL is shown. Existing tests already ensure that the default help URL is presented if the configuration does not specify one.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
