### PR TITLE
fix(is-ignored): ignore azure devops messages

### DIFF
--- a/@commitlint/is-ignored/src/defaults.ts
+++ b/@commitlint/is-ignored/src/defaults.ts
@@ -21,8 +21,8 @@ export const wildcards: Matcher[] = [
 	test(/^(R|r)evert (.*)/),
 	test(/^(fixup|squash)!/),
 	isSemver,
-	test(/^Merged (.*?)(in|into) (.*)/),
-	test(/^Merge remote-tracking branch (.*)/),
+	test(/^(Merged (.*?)(in|into) (.*)|Merged PR (.*): (.*))/),
+	test(/^Merge remote-tracking branch(\s*)(.*)/),
 	test(/^Automatic merge(.*)/),
 	test(/^Auto-merged (.*?) into (.*)/),
 ];

--- a/@commitlint/is-ignored/src/is-ignored.test.ts
+++ b/@commitlint/is-ignored/src/is-ignored.test.ts
@@ -122,6 +122,11 @@ test('should return true for bitbucket merge commits', () => {
 
 test('should return true for automatic merge commits', () => {
 	expect(isIgnored('Auto-merged develop into master')).toBe(true);
+	expect(isIgnored('Merge remote-tracking branch')).toBe(true);
+});
+
+test('should return true for azure devops merge commits', () => {
+	expect(isIgnored('Merged PR 123: Description here')).toBe(true);
 });
 
 test('should return false for commits containing, but not starting, with merge branch', () => {


### PR DESCRIPTION
## Description
Updated wildcard regular expressions in `@commitlint\is-ignored\src\defaults.ts`

## Motivation and Context

The following Azure DevOps auto-generated merge commit message format is being considered an error:
- "Merged PR 123: Description here" (fails because it does not contain "in" or "into")

This auto-generated merge commit message format is being considered an error:
- "Merge remote-tracking branch" (fails because is has no whitespace at the end)

## Usage examples

```sh
echo "Merge remote-tracking branch" | commitlint # passes
echo "Merged PR 123: Description here" | commitlint # passes
```

## How Has This Been Tested?

I have added tests to cover my changes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
