### PR TITLE
feat: allow scope-enum to also config delimiter

### DIFF
--- a/@commitlint/prompt/src/library/get-prompt.ts
+++ b/@commitlint/prompt/src/library/get-prompt.ts
@@ -14,6 +14,7 @@ import {
 	getHasName,
 	getMaxLength,
 } from './utils';
+import {EnumRuleOptions} from '@commitlint/types';
 
 /**
  * Get a cli prompt based on rule configuration
@@ -68,7 +69,9 @@ export default function getPrompt(
 		throw new TypeError('getPrompt: prompt.show is not a function');
 	}
 
-	const enumRule = rules.filter(getHasName('enum')).find(enumRuleIsActive);
+	const enumRule = (rules as Array<RuleEntry<EnumRuleOptions>>)
+		.filter(getHasName('enum'))
+		.find(enumRuleIsActive);
 
 	const emptyRule = rules.find(getHasName('empty'));
 
@@ -118,7 +121,7 @@ export default function getPrompt(
 		if (enumRule) {
 			const [, [, , enums]] = enumRule;
 
-			enums.forEach((enumerable) => {
+			(enums as string[]).forEach((enumerable) => {
 				const enumSettings = (settings.enumerables || {})[enumerable] || {};
 				prompt
 					.command(enumerable)

--- a/@commitlint/prompt/src/library/types.ts
+++ b/@commitlint/prompt/src/library/types.ts
@@ -1,9 +1,9 @@
 import {RuleConfigCondition, RuleConfigSeverity} from '@commitlint/types';
 
-export type RuleEntry =
+export type RuleEntry<C = unknown> =
 	| [string, Readonly<[RuleConfigSeverity.Disabled]>]
 	| [string, Readonly<[RuleConfigSeverity, RuleConfigCondition]>]
-	| [string, Readonly<[RuleConfigSeverity, RuleConfigCondition, unknown]>];
+	| [string, Readonly<[RuleConfigSeverity, RuleConfigCondition, C]>];
 
 export type InputSetting = {
 	description?: string;

--- a/@commitlint/prompt/src/library/utils.test.ts
+++ b/@commitlint/prompt/src/library/utils.test.ts
@@ -1,4 +1,5 @@
-import {RuleConfigSeverity} from '@commitlint/types';
+import {EnumRuleOptions, RuleConfigSeverity} from '@commitlint/types';
+import {RuleEntry} from './types';
 
 import {
 	enumRuleIsActive,
@@ -85,14 +86,19 @@ test('getMaxLength', () => {
 });
 
 test('check enum rule filters', () => {
-	const rules: any = {
+	const rules: Record<string, RuleEntry<EnumRuleOptions>[1]> = {
 		'enum-string': [RuleConfigSeverity.Warning, 'always', ['1', '2', '3']],
 		'type-enum': [RuleConfigSeverity.Error, 'always', ['build', 'chore', 'ci']],
 		'scope-enum': [RuleConfigSeverity.Error, 'never', ['cli', 'core', 'lint']],
 		'bar-enum': [RuleConfigSeverity.Disabled, 'always', ['foo', 'bar', 'baz']],
+		'extendable-scope-enum': [
+			RuleConfigSeverity.Disabled,
+			'always',
+			{values: ['foo', 'bar', 'baz']},
+		],
 	};
 
-	let enumRule = getRules('type', rules)
+	let enumRule = getRules<EnumRuleOptions>('type', rules)
 		.filter(getHasName('enum'))
 		.find(enumRuleIsActive);
 	expect(enumRule).toEqual([
@@ -100,22 +106,27 @@ test('check enum rule filters', () => {
 		[2, 'always', ['build', 'chore', 'ci']],
 	]);
 
-	enumRule = getRules('string', rules)
+	enumRule = getRules<EnumRuleOptions>('string', rules)
 		.filter(getHasName('enum'))
 		.find(enumRuleIsActive);
 	expect(enumRule).toEqual(undefined);
 
-	enumRule = getRules('enum', rules)
+	enumRule = getRules<EnumRuleOptions>('enum', rules)
 		.filter(getHasName('string'))
 		.find(enumRuleIsActive);
 	expect(enumRule).toEqual(['enum-string', [1, 'always', ['1', '2', '3']]]);
 
-	enumRule = getRules('bar', rules)
+	enumRule = getRules<EnumRuleOptions>('bar', rules)
 		.filter(getHasName('enum'))
 		.find(enumRuleIsActive);
 	expect(enumRule).toEqual(undefined);
 
-	enumRule = getRules('scope', rules)
+	enumRule = getRules<EnumRuleOptions>('scope', rules)
+		.filter(getHasName('enum'))
+		.find(enumRuleIsActive);
+	expect(enumRule).toEqual(undefined);
+
+	enumRule = getRules<EnumRuleOptions>('extendable-scope', rules)
 		.filter(getHasName('enum'))
 		.find(enumRuleIsActive);
 	expect(enumRule).toEqual(undefined);

--- a/@commitlint/rules/src/scope-enum.test.ts
+++ b/@commitlint/rules/src/scope-enum.test.ts
@@ -6,6 +6,7 @@ const messages = {
 	superfluous: 'foo(): baz',
 	empty: 'foo: baz',
 	multiple: 'foo(bar,baz): qux',
+	scoped: 'foo(@a/b): test',
 };
 
 const parsed = {
@@ -13,10 +14,20 @@ const parsed = {
 	superfluous: parse(messages.superfluous),
 	empty: parse(messages.empty),
 	multiple: parse(messages.multiple),
+	scoped: parse(messages.scoped),
 };
 
 test('scope-enum with plain message and always should succeed empty enum', async () => {
 	const [actual] = scopeEnum(await parsed.plain, 'always', []);
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('scope-enum allows custom delimiters', async () => {
+	const [actual] = scopeEnum(await parsed.scoped, 'always', {
+		values: ['@a/b'],
+		delimiter: /,/g,
+	});
 	const expected = true;
 	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/scope-enum.ts
+++ b/@commitlint/rules/src/scope-enum.ts
@@ -2,18 +2,27 @@ import * as ensure from '@commitlint/ensure';
 import message from '@commitlint/message';
 import {SyncRule} from '@commitlint/types';
 
-export const scopeEnum: SyncRule<string[]> = (
-	parsed,
-	when = 'always',
-	value = []
-) => {
+export const scopeEnum: SyncRule<
+	string[] | {delimiter?: RegExp; values?: string[]}
+> = (parsed, when = 'always', config = []) => {
 	if (!parsed.scope) {
 		return [true, ''];
 	}
 
+	let delimiters = /\/|\\|,/g;
+	let value: string[] = [];
+	if (!Array.isArray(config)) {
+		if (config.delimiter) {
+			delimiters = config.delimiter;
+		}
+		value = config.values || [];
+	} else {
+		value = config;
+	}
+
 	// Scopes may contain slash or comma delimiters to separate them and mark them as individual segments.
 	// This means that each of these segments should be tested separately with `ensure`.
-	const delimiters = /\/|\\|,/g;
+
 	const scopeSegments = parsed.scope.split(delimiters);
 
 	const negated = when === 'never';

--- a/@commitlint/types/src/rules.ts
+++ b/@commitlint/types/src/rules.ts
@@ -83,9 +83,16 @@ export type LengthRuleConfig<V = RuleConfigQuality.User> = RuleConfig<
 	V,
 	number
 >;
+export interface EnumRuleExtendableOptions {
+	values: string[];
+	[k: string]: any;
+}
+
+export type EnumRuleOptions = EnumRuleExtendableOptions | string[];
+
 export type EnumRuleConfig<V = RuleConfigQuality.User> = RuleConfig<
 	V,
-	string[]
+	EnumRuleOptions
 >;
 
 export type RulesConfig<V = RuleConfigQuality.User> = {

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -190,6 +190,13 @@ Infinity
   ```
   []
   ```
+  or if you want to customize delimiter regex for [multiple scopes](https://commitlint.js.org/#/concepts-commit-conventions?id=multiple-scopes)
+  ```
+  {
+    values: [],
+    delimiter: /,/g
+  }
+  ```
 
 #### scope-case
 


### PR DESCRIPTION
fix #2108

Allow scope-enum rule to also configure delimiter regex

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
