### PR TITLE
docs(readme): fix typo 'the the' -> 'the'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ fix(server): send cors headers
 feat(blog): add comment section
 ```
 
-Common types according to [commitlint-config-conventional (based on the the Angular convention)](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) can be:
+Common types according to [commitlint-config-conventional (based on the Angular convention)](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum) can be:
 
 - build
 - ci


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes "**the the** Angular convention" into "**the** Angular convention" in `README.md`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There is a typo in `README.md`.

## Usage examples

The fix is visible in the `What is commitlint` section of `README.md`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

This is a simple modification of the `README.md` file.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
