### PR TITLE
fix: api modules default export issue (#2422)

### DIFF
--- a/@commitlint/format/src/format.test.ts
+++ b/@commitlint/format/src/format.test.ts
@@ -1,4 +1,4 @@
-import {format, formatResult} from '.';
+import {format, formatResult} from './format';
 
 test('does nothing without arguments', () => {
 	const actual = format();

--- a/@commitlint/format/src/index.ts
+++ b/@commitlint/format/src/index.ts
@@ -1,2 +1,2 @@
-export {default} from './format';
-export * from './format';
+import format from './format';
+export = format;

--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -2,7 +2,7 @@
   "name": "@commitlint/lint",
   "version": "12.0.0",
   "description": "Lint a string against commitlint rules",
-  "main": "lib/lint.js",
+  "main": "lib/index.js",
   "types": "lib/lint.d.ts",
   "files": [
     "lib/"

--- a/@commitlint/lint/src/index.ts
+++ b/@commitlint/lint/src/index.ts
@@ -1,0 +1,2 @@
+import lint from './lint';
+export = lint;

--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -2,7 +2,7 @@
   "name": "@commitlint/load",
   "version": "12.0.0",
   "description": "Load shared commitlint configuration",
-  "main": "lib/load.js",
+  "main": "lib/index.js",
   "types": "lib/load.d.ts",
   "files": [
     "lib/"

--- a/@commitlint/load/src/index.ts
+++ b/@commitlint/load/src/index.ts
@@ -1,0 +1,2 @@
+import load from './load';
+export = load;

--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -2,7 +2,7 @@
   "name": "@commitlint/read",
   "version": "12.0.0",
   "description": "Read commit messages from a specified range or last edit",
-  "main": "lib/read.js",
+  "main": "lib/index.js",
   "types": "lib/read.d.ts",
   "files": [
     "lib/"

--- a/@commitlint/read/src/index.ts
+++ b/@commitlint/read/src/index.ts
@@ -1,0 +1,2 @@
+import read from './read';
+export = read;


### PR DESCRIPTION
(format | lint | load | read)  should use `export=` syntax to export their default object.
Then tsc will assign it to `module.exports`, otherwise we have to add `default` to require them

## Description

check out [export=](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require)
basically I just changed those's module's `export` behavior to be compatible with CommonJS module rule

## Motivation and Context

solves #2422 

## How Has This Been Tested?

I've done a quick test in those module(format | lint | load | read) directory by runing `yarn run(each of them)`. 

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
