### PR TITLE
docs: correct way to get the default module in examples

### DIFF
--- a/@commitlint/format/README.md
+++ b/@commitlint/format/README.md
@@ -11,7 +11,7 @@ npm install --save @commitlint/format
 ## Example
 
 ```js
-const format = require('@commitlint/format').default;
+const {format} = require('@commitlint/format');
 
 const output = format(
   {

--- a/@commitlint/format/README.md
+++ b/@commitlint/format/README.md
@@ -11,7 +11,7 @@ npm install --save @commitlint/format
 ## Example
 
 ```js
-const format = require('@commitlint/format');
+const format = require('@commitlint/format').default;
 
 const output = format(
   {

--- a/@commitlint/format/README.md
+++ b/@commitlint/format/README.md
@@ -11,7 +11,7 @@ npm install --save @commitlint/format
 ## Example
 
 ```js
-const {format} = require('@commitlint/format');
+const format = require('@commitlint/format').default;
 
 const output = format(
   {

--- a/@commitlint/lint/README.md
+++ b/@commitlint/lint/README.md
@@ -11,7 +11,7 @@ npm install --save @commitlint/lint
 ## Example
 
 ```js
-const lint = require('@commitlint/lint').default;
+const {lint} = require('@commitlint/lint');
 
 lint('foo: bar', {'type-enum': [1, 'always', ['foo']]}).then((report) =>
   console.log(report)

--- a/@commitlint/lint/README.md
+++ b/@commitlint/lint/README.md
@@ -11,7 +11,7 @@ npm install --save @commitlint/lint
 ## Example
 
 ```js
-const {lint} = require('@commitlint/lint');
+const lint = require('@commitlint/lint').default;
 
 lint('foo: bar', {'type-enum': [1, 'always', ['foo']]}).then((report) =>
   console.log(report)

--- a/@commitlint/lint/README.md
+++ b/@commitlint/lint/README.md
@@ -11,7 +11,7 @@ npm install --save @commitlint/lint
 ## Example
 
 ```js
-const lint = require('@commitlint/lint');
+const lint = require('@commitlint/lint').default;
 
 lint('foo: bar', {'type-enum': [1, 'always', ['foo']]}).then((report) =>
   console.log(report)

--- a/@commitlint/load/README.md
+++ b/@commitlint/load/README.md
@@ -11,7 +11,7 @@ npm install --save-dev @commitlint/load
 ## Example
 
 ```js
-const load = require('@commitlint/load');
+const load = require('@commitlint/load').default;
 
 load({extends: ['./package']}).then((config) => console.log(config));
 // => { extends: ['./package', './package-b'], rules: {} }

--- a/@commitlint/load/README.md
+++ b/@commitlint/load/README.md
@@ -11,7 +11,7 @@ npm install --save-dev @commitlint/load
 ## Example
 
 ```js
-const load = require('@commitlint/load').default;
+const {load} = require('@commitlint/load');
 
 load({extends: ['./package']}).then((config) => console.log(config));
 // => { extends: ['./package', './package-b'], rules: {} }

--- a/@commitlint/load/README.md
+++ b/@commitlint/load/README.md
@@ -11,7 +11,7 @@ npm install --save-dev @commitlint/load
 ## Example
 
 ```js
-const {load} = require('@commitlint/load');
+const load = require('@commitlint/load').default;
 
 load({extends: ['./package']}).then((config) => console.log(config));
 // => { extends: ['./package', './package-b'], rules: {} }

--- a/@commitlint/read/README.md
+++ b/@commitlint/read/README.md
@@ -11,7 +11,7 @@ npm install --save @commitlint/read
 ## Example
 
 ```js
-const read = require('@commitlint/read').default;
+const {read} = require('@commitlint/read');
 
 // Read last edited commit message
 read({edit: true}).then((messages) => console.log(messages));

--- a/@commitlint/read/README.md
+++ b/@commitlint/read/README.md
@@ -11,7 +11,7 @@ npm install --save @commitlint/read
 ## Example
 
 ```js
-const {read} = require('@commitlint/read');
+const read = require('@commitlint/read').default;
 
 // Read last edited commit message
 read({edit: true}).then((messages) => console.log(messages));

--- a/@commitlint/read/README.md
+++ b/@commitlint/read/README.md
@@ -11,7 +11,7 @@ npm install --save @commitlint/read
 ## Example
 
 ```js
-const read = require('@commitlint/read');
+const read = require('@commitlint/read').default;
 
 // Read last edited commit message
 read({edit: true}).then((messages) => console.log(messages));

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -72,7 +72,7 @@ format(report?: Report = {}, options?: formatOptions = {}) => string[];
 - **Example**
 
 ```js
-const {format} = require('@commitlint/format');
+const format = require('@commitlint/format').default;
 
 format(); // => [ '\u001b[1m\u001b[32m✔\u001b[39m   found 0 problems, 0 warnings\u001b[22m' ]
 
@@ -245,7 +245,7 @@ load(seed: Seed = {}, options?: LoadOptions = {cwd: process.cwd()}) => Promise<C
 - **Example**
 
 ```js
-const {load} = require('@commitlint/load');
+const load = require('@commitlint/load').default;
 
 load({
   rules: {
@@ -299,7 +299,7 @@ read(range: Range) => Promise<string[]>
 
 ```js
 // git commit -m "I did something"
-const {read} = require('@commitlint/read');
+const read = require('@commitlint/read').default;
 
 read({edit: true}).then((messages) => console.log(messages));
 // => ['I did something\n\n']
@@ -363,7 +363,7 @@ lint(message: string, rules: {[ruleName: string]: Rule}, opts?: Options) => Prom
 - **Basic Example**
 
 ```js
-const {lint} = require('@commitlint/lint');
+const lint = require('@commitlint/lint').default;
 
 lint('foo: bar').then((report) => console.log(report));
 // => { valid: true, errors: [], warnings: [] }
@@ -402,8 +402,8 @@ lint('foo-bar', {'type-enum': [2, 'always', ['foo']]}, opts).then((report) =>
 - **Load configuration**
 
 ```js
-const {load} = require('@commitlint/load');
-const {lint} = require('@commitlint/lint');
+const load = require('@commitlint/load').default;
+const lint = require('@commitlint/lint').default;
 
 const CONFIG = {
   extends: ['@commitlint/config-conventional'],
@@ -432,8 +432,8 @@ load(CONFIG)
 - **Read git history**
 
 ```js
-const {lint} = require('@commitlint/lint');
-const {read} = require('@commitlint/read');
+const lint = require('@commitlint/lint').default;
+const read = require('@commitlint/read').default;
 
 const RULES = {
   'type-enum': [2, 'always', ['foo']],
@@ -449,9 +449,9 @@ read({to: 'HEAD', from: 'HEAD~2'}).then((commits) =>
 - **Simplfied last-commit checker**
 
 ```js
-const {load} = require('@commitlint/load');
-const {read} = require('@commitlint/read');
-const {lint} = require('@commitlint/lint');
+const load = require('@commitlint/load').default;
+const read = require('@commitlint/read').default;
+const lint = require('@commitlint/lint').default;
 
 Promise.all([load(), read({from: 'HEAD~1'})])
   .then((tasks) => {

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -72,7 +72,7 @@ format(report?: Report = {}, options?: formatOptions = {}) => string[];
 - **Example**
 
 ```js
-const format = require('@commitlint/format').default;
+const {format} = require('@commitlint/format');
 
 format(); // => [ '\u001b[1m\u001b[32m✔\u001b[39m   found 0 problems, 0 warnings\u001b[22m' ]
 
@@ -245,7 +245,7 @@ load(seed: Seed = {}, options?: LoadOptions = {cwd: process.cwd()}) => Promise<C
 - **Example**
 
 ```js
-const load = require('@commitlint/load').default;
+const {load} = require('@commitlint/load');
 
 load({
   rules: {
@@ -299,7 +299,7 @@ read(range: Range) => Promise<string[]>
 
 ```js
 // git commit -m "I did something"
-const read = require('@commitlint/read').default;
+const {read} = require('@commitlint/read');
 
 read({edit: true}).then((messages) => console.log(messages));
 // => ['I did something\n\n']
@@ -363,7 +363,7 @@ lint(message: string, rules: {[ruleName: string]: Rule}, opts?: Options) => Prom
 - **Basic Example**
 
 ```js
-const lint = require('@commitlint/lint').default;
+const {lint} = require('@commitlint/lint');
 
 lint('foo: bar').then((report) => console.log(report));
 // => { valid: true, errors: [], warnings: [] }
@@ -402,8 +402,8 @@ lint('foo-bar', {'type-enum': [2, 'always', ['foo']]}, opts).then((report) =>
 - **Load configuration**
 
 ```js
-const load = require('@commitlint/load').default;
-const lint = require('@commitlint/lint').default;
+const {load} = require('@commitlint/load');
+const {lint} = require('@commitlint/lint');
 
 const CONFIG = {
   extends: ['@commitlint/config-conventional'],
@@ -432,8 +432,8 @@ load(CONFIG)
 - **Read git history**
 
 ```js
-const lint = require('@commitlint/lint').default;
-const read = require('@commitlint/read').default;
+const {lint} = require('@commitlint/lint');
+const {read} = require('@commitlint/read');
 
 const RULES = {
   'type-enum': [2, 'always', ['foo']],
@@ -449,9 +449,9 @@ read({to: 'HEAD', from: 'HEAD~2'}).then((commits) =>
 - **Simplfied last-commit checker**
 
 ```js
-const load = require('@commitlint/load').default;
-const read = require('@commitlint/read').default;
-const lint = require('@commitlint/lint').default;
+const {load} = require('@commitlint/load');
+const {read} = require('@commitlint/read');
+const {lint} = require('@commitlint/lint');
 
 Promise.all([load(), read({from: 'HEAD~1'})])
   .then((tasks) => {

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -72,7 +72,7 @@ format(report?: Report = {}, options?: formatOptions = {}) => string[];
 - **Example**
 
 ```js
-const format = require('@commitlint/format');
+const format = require('@commitlint/format').default;
 
 format(); // => [ '\u001b[1m\u001b[32m✔\u001b[39m   found 0 problems, 0 warnings\u001b[22m' ]
 
@@ -245,7 +245,7 @@ load(seed: Seed = {}, options?: LoadOptions = {cwd: process.cwd()}) => Promise<C
 - **Example**
 
 ```js
-const load = require('@commitlint/load');
+const load = require('@commitlint/load').default;
 
 load({
   rules: {
@@ -363,7 +363,7 @@ lint(message: string, rules: {[ruleName: string]: Rule}, opts?: Options) => Prom
 - **Basic Example**
 
 ```js
-const lint = require('@commitlint/lint');
+const lint = require('@commitlint/lint').default;
 
 lint('foo: bar').then((report) => console.log(report));
 // => { valid: true, errors: [], warnings: [] }
@@ -402,8 +402,8 @@ lint('foo-bar', {'type-enum': [2, 'always', ['foo']]}, opts).then((report) =>
 - **Load configuration**
 
 ```js
-const load = require('@commitlint/load');
-const lint = require('@commitlint/lint');
+const load = require('@commitlint/load').default;
+const lint = require('@commitlint/lint').default;
 
 const CONFIG = {
   extends: ['@commitlint/config-conventional'],
@@ -432,8 +432,8 @@ load(CONFIG)
 - **Read git history**
 
 ```js
-const lint = require('@commitlint/lint');
-const read = require('@commitlint/read');
+const lint = require('@commitlint/lint').default;
+const read = require('@commitlint/read').default;
 
 const RULES = {
   'type-enum': [2, 'always', ['foo']],
@@ -449,9 +449,9 @@ read({to: 'HEAD', from: 'HEAD~2'}).then((commits) =>
 - **Simplfied last-commit checker**
 
 ```js
-const load = require('@commitlint/load');
-const read = require('@commitlint/read');
-const lint = require('@commitlint/lint');
+const load = require('@commitlint/load').default;
+const read = require('@commitlint/read').default;
+const lint = require('@commitlint/lint').default;
 
 Promise.all([load(), read({from: 'HEAD~1'})])
   .then((tasks) => {


### PR DESCRIPTION
a walkaround for #2423, add `default` to all of the api module's `require` method in example code