### PR TITLE
test(load): use installModules instead of npm install

### DIFF
--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -37,7 +37,8 @@
     "@commitlint/test": "^12.0.0",
     "@commitlint/utils": "^12.0.0",
     "@types/lodash": "4.14.168",
-    "execa": "^5.0.0"
+    "execa": "^5.0.0",
+    "conventional-changelog-atom": "^2.0.8"
   },
   "dependencies": {
     "@commitlint/execute-rule": "^12.0.0",

--- a/@commitlint/load/src/load.test.ts
+++ b/@commitlint/load/src/load.test.ts
@@ -7,7 +7,6 @@ jest.mock('@scope/commitlint-plugin-example', () => scopedPlugin, {
 });
 
 import path from 'path';
-import execa from 'execa';
 import resolveFrom from 'resolve-from';
 import {fix, git, npm} from '@commitlint/test';
 
@@ -411,10 +410,9 @@ test('recursive resolves parser preset from conventional atom', async () => {
 	const cwd = await gitBootstrap(
 		'fixtures/recursive-parser-preset-conventional-atom'
 	);
-	// the package file is nested in 2 folders, `npm.bootstrap` cant do that
-	await execa('npm', ['install'], {
-		cwd: path.resolve(cwd, 'first-extended', 'second-extended'),
-	});
+	await npm.installModules(
+		path.resolve(cwd, 'first-extended', 'second-extended')
+	);
 
 	const actual = await load({}, {cwd});
 
@@ -423,7 +421,7 @@ test('recursive resolves parser preset from conventional atom', async () => {
 	expect((actual.parserPreset.parserOpts as any).headerPattern).toEqual(
 		/^(:.*?:) (.*)$/
 	);
-}, 10000);
+});
 
 test('resolves parser preset from conventional commits without factory support', async () => {
 	const cwd = await npmBootstrap(

--- a/@packages/test/src/npm.ts
+++ b/@packages/test/src/npm.ts
@@ -4,8 +4,7 @@ import resolvePkg from 'resolve-pkg';
 
 import * as git from './git';
 
-export async function bootstrap(fixture: string, directory?: string) {
-	const cwd = await git.bootstrap(fixture, directory);
+export async function installModules(cwd: string) {
 	const manifestPath = path.join(cwd, 'package.json');
 	const targetModulesPath = path.join(cwd, 'node_modules');
 
@@ -36,7 +35,11 @@ export async function bootstrap(fixture: string, directory?: string) {
 			})
 		);
 	}
+}
 
+export async function bootstrap(fixture: string, directory?: string) {
+	const cwd = await git.bootstrap(fixture, directory);
+	await installModules(cwd);
 	return cwd;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,7 +3439,7 @@ contains-path@^0.1.0:
   resolved "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
-conventional-changelog-angular@5.0.12:
+conventional-changelog-angular@5.0.12, conventional-changelog-angular@^5.0.11, conventional-changelog-angular@^5.0.3:
   version "5.0.12"
   resolved "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz#c979b8b921cbfe26402eb3da5bbfda02d865a2b9"
   integrity sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==
@@ -3447,20 +3447,11 @@ conventional-changelog-angular@5.0.12:
     compare-func "^2.0.0"
     q "^1.5.1"
 
-conventional-changelog-angular@^5.0.11:
-  version "5.0.11"
-  resolved "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz#99a3ca16e4a5305e0c2c2fae3ef74fd7631fc3fb"
-  integrity sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==
+conventional-changelog-atom@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz#a759ec61c22d1c1196925fca88fe3ae89fd7d8de"
+  integrity sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==
   dependencies:
-    compare-func "^2.0.0"
-    q "^1.5.1"
-
-conventional-changelog-angular@^5.0.3:
-  version "5.0.6"
-  resolved "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.6.tgz#269540c624553aded809c29a3508fdc2b544c059"
-  integrity sha512-QDEmLa+7qdhVIv8sFZfVxU1VSyVvnXPsxq8Vam49mKUcO1Z8VTLEJk9uI21uiJUsnmm0I4Hrsdc9TgkOQo9WSA==
-  dependencies:
-    compare-func "^1.3.1"
     q "^1.5.1"
 
 conventional-changelog-conventionalcommits@^4.3.1:


### PR DESCRIPTION
## Description

expose helper function `installModules` to ease test time and timeouts on windows machines 

this change removes ~5sec from tests on my machine

## Motivation and Context

constant timeout on windows during development

https://github.com/npm/npm/issues/21148

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
