### PR TITLE
docs: remove double quote character added by #2391

### DIFF
--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -30,5 +30,5 @@ Options:
   -V, --verbose        enable verbose output for reports without problems
                                                                        [boolean]
   -v, --version        display version information                     [boolean]
-  -h, --help           Show help                                       [boolean]"
+  -h, --help           Show help                                       [boolean]
 ```


### PR DESCRIPTION
A trailing double quote was added to [./docs/reference-cli.md](./docs/reference-cli.md) when #2391 landed.

## Description

Removes trailing double quote `"`  [./docs/reference-cli.md](./docs/reference-cli.md) that landed with #2391.

## Motivation and Context

Unnecessary double quote `"` in docs.

## Usage examples

N/A

## How Has This Been Tested?

Viewed file in my fork: https://github.com/psyrendust/commitlint/blob/971c5195e06e5af7d5bf66b30f9931efbf5a9f0d/docs/reference-cli.md

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
