### PR TITLE
chore: disable renovate for private unpublished packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
       "config:base",
       ":semanticCommitType(chore)",
       ":semanticCommitScopeDisabled"
+    ],
+    "ignoreDeps": [
+      "@commitlint/test",
+      "@commitlint/test-environment",
+      "@commitlint/utils"
     ]
   },
   "workspaces": [


### PR DESCRIPTION
Do not trigger renovate checks for private internal packages

closes #2464, closes #2465