### PR TITLE
docs(readme): sort type-enum value in @commitlint/config-conventional/README.md

### DIFF
--- a/@commitlint/config-conventional/README.md
+++ b/@commitlint/config-conventional/README.md
@@ -30,8 +30,8 @@ Consult [docs/rules](https://conventional-changelog.github.io/commitlint/#/refer
   ```
   [
     'build',
-    'ci',
     'chore',
+    'ci',
     'docs',
     'feat',
     'fix',


### PR DESCRIPTION
## Description

This PR sorts `type-enum` value in `@commitlint/config-conventional/README.md` to match the implementation.