### PR TITLE
Updating reference of configuration 

### DIFF
--- a/docs/reference-configuration.md
+++ b/docs/reference-configuration.md
@@ -8,6 +8,10 @@ The file is expected
 - export a configuration object
 - adhere to the schema outlined below
 
+## Config option CLI
+
+Add the path to the configuration file. Example: `commitlint --config commitlint.config.js`
+
 ## Configuration object example
 
 ### JavaScript


### PR DESCRIPTION
Updating the docs to explain how to pass the configuration using the CL

## Description

Updating the docs to show to how to pass the configuration file using the CLI 
## Motivation and Context

I have `commilint` with `husky` and I have `commitlint.config.js` on the root of my project. However, it was not picking it up. I changed it to `yarn commitlint --config commitlint.config.js --edit $1` and started picking it up properly. 

## Usage examples

`.husky/commit-msg` 

```bash
#!/bin/sh
. "$(dirname "$0")/_/husky.sh"

yarn commitlint --config commitlint.config.js --edit $1
```

`commitlint.config.js`
```js
module.exports = {
  extends: ["@commitlint/config-conventional"],
  ignores: [(commitMessage) => commitMessage.includes("chore(release):")],
};

```

## How Has This Been Tested?

I tested this on two private projects, on GitLab and GitHub and locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Updating docs
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
