### PR TITLE
docs: fixed shell substitutions in local setup guide

### DIFF
--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -33,9 +33,9 @@ npx husky install
 yarn husky install
 
 # Add hook
-npx husky add .husky/commit-msg "npx --no-install commitlint --edit $1"
+npx husky add .husky/commit-msg 'npx --no-install commitlint --edit $1'
 # or
-yarn husky add .husky/commit-msg "yarn commitlint --edit $1"
+yarn husky add .husky/commit-msg 'yarn commitlint --edit $1'
 ```
 
 If the file `.husky/commit-msg` already exists, you can edit the file and put this:


### PR DESCRIPTION
Fixed a shell substitution in the local setup guide where `$1` was being resolved instead of being put into the Husky hook.

## Description

Changed the `"` in the example to `'` to avoid shell substitutions.

## Motivation and Context

As reported in https://github.com/conventional-changelog/commitlint/issues/2511, the `$1` was not being put into the hook properly (as the second example gave). This brings the two in line with each other.

## Usage examples

This is for setting up Husky with the package.

```shell
$ yarn husky add .husky/commit-msg 'yarn commitlint --edit $1'
$ cat .husky/commit-msg
#!/bin/sh
. "$(dirname "$0")/_/husky.sh"

yarn commitlint --edit $1
$
```

## How Has This Been Tested?

Manually tested it in Bash.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I didn't update tests since this was documentation.