### PR TITLE
fix(rules): fix subject-full-stop rule config value type

### DIFF
--- a/@commitlint/types/src/rules.ts
+++ b/@commitlint/types/src/rules.ts
@@ -114,7 +114,7 @@ export type RulesConfig<V = RuleConfigQuality.User> = {
 	'signed-off-by': RuleConfig<V>;
 	'subject-case': CaseRuleConfig<V>;
 	'subject-empty': RuleConfig<V>;
-	'subject-full-stop': RuleConfig<V>;
+	'subject-full-stop': RuleConfig<V, string>;
 	'subject-max-length': LengthRuleConfig<V>;
 	'subject-min-length': LengthRuleConfig<V>;
 	'type-case': CaseRuleConfig<V>;


### PR DESCRIPTION
Fix `subject-full-stop` rule configuration type declaration

## Description

As described in the official website [here](https://commitlint.js.org/#/reference-rules?id=subject-full-stop), the `subject-full-stop` rule has a default value of `.` and its value is of type `string` (or `undefined`), which is missing in current type declaration of [rules.ts module](https://github.com/conventional-changelog/commitlint/blob/7767ca2/%40commitlint/types/src/rules.ts) and causes the TypeScript compiler to throw and error.

## Motivation and Context

Wrong type declaration of configuration

## Usage examples

Previously:

```ts
import type { QualifiedRules } from '@commitlint/types';

export function fullStopFilter(rule: QualifiedRules['subject-full-stop']): string {
  const [level, applicable, ruleValue] = rule;
}
```
this would cause the error:

```txt
Property '2' does not exist on type 'readonly [RuleConfigSeverity.Disabled] | readonly [RuleConfigSeverity, RuleConfigCondition]'.ts(2339)
```

This merge request fixex the bug and `ruleValue` will be of type `string | undefined`.

## How Has This Been Tested?

I am writing a plugin for `commitlint`, which uses the configuration type declaration exposed by `@commitlint/types` package. Although, the `subject-full-stop` rule configuration should have a default value, as described in the documentation, destructing the configuration array returns TypeScript error: `Property '2' does not exist on type 'readonly [RuleConfigSeverity.Disabled] | readonly [RuleConfigSeverity, RuleConfigCondition]'.ts(2339)`. This will logically should fix the bug as type declarations _can_ handle the rule types with values.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

P.S. I could not execute package tests because of the following `yarn run test` script execution error:

```sh
$ jest
● Validation Error:

  Test environment @commitlint/test-environment cannot be found. Make sure the testEnvironment configuration option points to an existing node module.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html

error Command failed with exit code 1.

```
