### PR TITLE
fix(types): update chalk import

### DIFF
--- a/@commitlint/types/src/format.ts
+++ b/@commitlint/types/src/format.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import * as chalk from 'chalk';
 import {QualifiedRules} from './load';
 import {RuleConfigSeverity} from './rules';
 


### PR DESCRIPTION
The import was importing as default but is not exported as
default. Now the import is importing `* as` so you don't have to use
the tsconfig option `esModuleInterop`

<!--- Provide a general summary of your changes in the Title above -->

## Description

When importing "@commitlint/config-conventional" into a typescript project you cannot compile it without setting `esModuleInterop` to true in you tsconfig you get the below error

```
node_modules/@commitlint/types/lib/format.d.ts:1:8 - error TS1259: Module '"src/node_modules/@commitlint/types/node_modules/chalk/index"' can only be default-imported using the 'esModuleInterop' flag

1 import chalk from 'chalk';
         ~~~~~
  node_modules/@commitlint/types/node_modules/chalk/index.d.ts:415:1
    415 export = chalk;
        ~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.

Found 1 error.
```

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

Don't think this is applicable it's when I import from "@commitlint/config-conventional" and try to compile typescript

## How Has This Been Tested?

I have tested this in my project with and without `esModuleInterop` in my tsconfig. All the tests are passing. I don't know how to test it other than that. If you want more let me know.

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
