### PR TITLE
docs: fix husky add hook in 'Getting started'

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,15 @@ npm install husky --save-dev
 # or
 yarn add husky --dev
 
-# Active hooks
+# Activate hooks
 npx husky install
 # or
 yarn husky install
 
 # Add hook
-npx husky add .husky/commit-msg "npx --no-install commitlint --edit $1"
+npx husky add .husky/commit-msg 'npx --no-install commitlint --edit $1'
 # or
-yarn husky add .husky/commit-msg "yarn commitlint --edit $1"
+yarn husky add .husky/commit-msg 'yarn commitlint --edit $1'
 ```
 
 **Detailed Setup instructions**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fix `README.md` instructions regarding getting started with husky. Double quotes do not escape `$1` since it's a positional parameter.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improve `README.md` documentation.

## Usage examples

- [Repl.it](https://repl.it/@remarkablemark/Install-husky-hook-example)
- [YouTube](https://youtu.be/2J9VnYiZ_Ts)

<!--- Provide examples of intended usage -->

<!--

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

-->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

https://github.com/remarkablemark/husky-commitlint-demo

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
