### PR TITLE
Remove get-sdtin dependency

### DIFF
--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -48,7 +48,6 @@
     "@commitlint/load": "^12.1.1",
     "@commitlint/read": "^12.1.1",
     "@commitlint/types": "^12.1.1",
-    "get-stdin": "9.0.0",
     "lodash": "^4.17.19",
     "resolve-from": "5.0.0",
     "resolve-global": "1.0.0",

--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -48,7 +48,7 @@
     "@commitlint/load": "^12.1.1",
     "@commitlint/read": "^12.1.1",
     "@commitlint/types": "^12.1.1",
-    "get-stdin": "8.0.0",
+    "get-stdin": "9.0.0",
     "lodash": "^4.17.19",
     "resolve-from": "5.0.0",
     "resolve-global": "1.0.0",

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -2,7 +2,6 @@ import load from '@commitlint/load';
 import lint from '@commitlint/lint';
 import read from '@commitlint/read';
 import isFunction from 'lodash/isFunction';
-import stdin from 'get-stdin';
 import resolveFrom from 'resolve-from';
 import resolveGlobal from 'resolve-global';
 import yargs from 'yargs';
@@ -125,6 +124,22 @@ main({edit: false, ...cli.argv}).catch((err) => {
 		throw err;
 	}, 0);
 });
+
+async function stdin() {
+	let result = '';
+
+	if (process.stdin.isTTY) {
+		return result;
+	}
+
+	process.stdin.setEncoding('utf8');
+
+	for await (const chunk of process.stdin) {
+		result += chunk;
+	}
+
+	return result;
+}
 
 async function main(options: CliFlags) {
 	const raw = options._;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4945,11 +4945,6 @@ get-port@^5.0.0, get-port@^5.1.1:
   resolved "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
-get-stdin@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz#3983ff82e03d56f1b2ea0d3e60325f39d703a575"
-  integrity sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==
-
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4945,10 +4945,10 @@ get-port@^5.0.0, get-port@^5.1.1:
   resolved "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
-get-stdin@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
-  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
+get-stdin@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz#3983ff82e03d56f1b2ea0d3e60325f39d703a575"
+  integrity sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==
 
 get-stdin@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
As in https://github.com/conventional-changelog/commitlint/pull/2552 the package `get-stdin` has moved to an ESM package. Reading their upgrade guide It looks like to use that you will need to move to an ESM package to use `get-stdin`. This removes the dependency and implements the one function in `cli.ts`.

This function is only being used once and only one function. I think this is a good way to go with minimal overhead. 

Let me know what you think   

## Description

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
