### PR TITLE
fix!: fix signed-off-by detection

### DIFF
--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -44,7 +44,8 @@
     "@commitlint/ensure": "^12.1.1",
     "@commitlint/message": "^12.1.1",
     "@commitlint/to-lines": "^12.1.1",
-    "@commitlint/types": "^12.1.1"
+    "@commitlint/types": "^12.1.1",
+    "execa": "^5.0.0"
   },
   "gitHead": "70f7f4688b51774e7ac5e40e896cdaa3f132b2bc"
 }

--- a/@commitlint/rules/src/signed-off-by.test.ts
+++ b/@commitlint/rules/src/signed-off-by.test.ts
@@ -3,15 +3,17 @@ import {signedOffBy} from './signed-off-by';
 
 const messages = {
 	empty: 'test:\n',
-	with: `test: subject\nbody\nfooter\nSigned-off-by:\n\n`,
-	without: `test: subject\nbody\nfooter\n\n`,
-	inSubject: `test: subject Signed-off-by:\nbody\nfooter\n\n`,
-	inBody: `test: subject\nbody Signed-off-by:\nfooter\n\n`,
-	withSignoffAndComments: `test: subject
+	with: `test: subject\n\nbody\n\nfooter\n\nSigned-off-by:\n\n`,
+	without: `test: subject\n\nbody\n\nfooter\n\n`,
+	inSubject: `test: subject Signed-off-by:\n\nbody\n\nfooter\n\n`,
+	inBody: `test: subject\n\nbody Signed-off-by:\n\nfooter\n\n`,
+	withSignoffAndNoise: `test: subject
 
 message body
 
+Arbitrary-trailer:
 Signed-off-by:
+Another-arbitrary-trailer:
 
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
@@ -24,7 +26,7 @@ const parsed = {
 	without: parse(messages.without),
 	inSubject: parse(messages.inSubject),
 	inBody: parse(messages.inBody),
-	withSignoffAndComments: parse(messages.withSignoffAndComments),
+	withSignoffAndNoise: parse(messages.withSignoffAndNoise),
 };
 
 test('empty against "always signed-off-by" should fail', async () => {
@@ -67,9 +69,9 @@ test('without against "never signed-off-by" should succeed', async () => {
 	expect(actual).toEqual(expected);
 });
 
-test('trailing comments should be ignored', async () => {
+test('comments and other trailers should be ignored', async () => {
 	const [actual] = signedOffBy(
-		await parsed.withSignoffAndComments,
+		await parsed.withSignoffAndNoise,
 		'always',
 		'Signed-off-by:'
 	);


### PR DESCRIPTION
## Description

This change replaces the manual parsing of the commit message when looking for `Signed-off-by:` trailers with an invocation of `git interpret-trailers`, which parses the trailers of the commit message passed via stdin. It's not as robust as I'd like it to be - it should ideally take into account the local Git configuration - but it at least resolves a major issue blocking my team from using the `signed-off-by` rule.

One known issue with this approach is that `BREAKING CHANGE` - if it occurs grouped alongside the sign-off trailers - will break detection. This appears to be due to the fact that Git does not accept trailers with spaces, instead treating them as part of the body (this seems to be an issue of the Conventional Commits specification more than anything). This does not occur with `BREAKING-CHANGE`, which is considered a valid trailer.

## Motivation and Context

The signed-off-by rule does not correctly detect `Signed-off-by:` trailers if they are not the final non-comment line of the commit. This change ensures that sign-off trailers are correctly detected according to the formatting rules Git uses to insert them.

For example, the following commit message breaks today:

```
fix: commit subject

Commit body.

Signed-off-by: Chris Kay <chris.kay@arm.com>
Change-Id: I71af06c09d95c2c58e3fd766c4a61c5652637151
```

## How Has This Been Tested?

This was tested by updating and running the existing signed-off-by rule tests to ensure that trailers after the `Signed-off-by:` trailer are now accepted.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
