### PR TITLE
fix: typo in command

### DIFF
--- a/@commitlint/cz-commitlint/README.md
+++ b/@commitlint/cz-commitlint/README.md
@@ -51,9 +51,9 @@ echo "module.exports = {extends: ['@commitlint/config-conventional']};" > commit
 
 ```bash
 git add .
-npm run cz
+npm run commit
 # or yarn
-yarn cz
+yarn commit
 ```
 
 ## Related


### PR DESCRIPTION
Fix typo in commands of example usage

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
