### PR TITLE
fix(cli): remove hard coded comment char with linting `COMMIT_EDIT_MSG`

### DIFF
--- a/@commitlint/cli/fixtures/comment-char/commitlint.config.js
+++ b/@commitlint/cli/fixtures/comment-char/commitlint.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	rules: {
+		'subject-empty': [2, 'never']
+	},
+	parserPreset: {
+        parserOpts: {
+            commentChar: '$'
+        }
+    },
+};

--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -329,6 +329,16 @@ test('should handle --amend with signoff', async () => {
 	expect(commit).toBeTruthy();
 }, 10000);
 
+test('should fail with an empty message and a commentChar is set', async () => {
+	const cwd = await gitBootstrap('fixtures/comment-char');
+	await execa('git', ['config', '--local', 'core.commentChar', '$'], {cwd});
+	await fs.writeFile(path.join(cwd, '.git', 'COMMIT_EDITMSG'), '#1234');
+
+	const actual = await cli(['--edit', '.git/COMMIT_EDITMSG'], {cwd})();
+	expect(actual.stdout).toContain('[subject-empty]');
+	expect(actual.exitCode).toBe(1);
+});
+
 test('should handle linting with issue prefixes', async () => {
 	const cwd = await gitBootstrap('fixtures/issue-prefixes');
 	const actual = await cli([], {cwd})('foobar REF-1');

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -220,8 +220,10 @@ async function main(args: MainArgs) {
 	}
 	const format = loadFormatter(loaded, flags);
 
-	// Strip comments if reading from `.git/COMMIT_EDIT_MSG`
-	if (flags.edit) {
+	// Strip comments if reading from `.git/COMMIT_EDIT_MSG` using the
+	// commentChar from the parser preset falling back to a `#` if that is not
+	// set
+	if (flags.edit && typeof opts.parserOpts.commentChar !== 'string') {
 		opts.parserOpts.commentChar = '#';
 	}
 


### PR DESCRIPTION
## Description

When running the cli and passing the `--edit` flag the comment char
was hard coded to a `#`. Even if there is a `commentChar` set in the
`parserOpts` the cli will override it with a `#`.

Now the cli will only set it to a `#` if its not already set in the
`parserOpts`

Fixes Issue: #2351

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
