### PR TITLE
fix(types): adds TargetCaseType[] for CaseRuleConfig

### DIFF
--- a/@commitlint/types/src/rules.ts
+++ b/@commitlint/types/src/rules.ts
@@ -77,7 +77,7 @@ export type RuleConfig<
 
 export type CaseRuleConfig<V = RuleConfigQuality.User> = RuleConfig<
 	V,
-	TargetCaseType
+	TargetCaseType | TargetCaseType[]
 >;
 export type LengthRuleConfig<V = RuleConfigQuality.User> = RuleConfig<
 	V,


### PR DESCRIPTION
## Description

`CaseRuleConfig` now accepts `TargetCaseType | TargetCaseType[]`.

Fixes #2631.

## Motivation and Context

Building a plugin + config package and running into the issue with all the `CaseRuleConfig` types don't except an array of cases. 

## Usage examples

```ts
// index.ts (config package)
const config: UserConfig = {
  extends: ['@commitlint/config-conventional'],
  plugins: ['@bigcommerce/commitlint-plugin-jira'],
  rules: {
    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
    // @ts-expect-error
    'subject-case': [2, 'never', ['start-case', 'pascal-case']],
  },
};

exports = config;
```

## How Has This Been Tested?

Installed and tested changes locally
![Screen Shot 2021-07-08 at 13 15 08](https://user-images.githubusercontent.com/10539418/124971247-93370880-dfee-11eb-9e86-d96baae54d8b.png)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
