### PR TITLE
fix(is-ignored): fail invalid revert commits

### DIFF
--- a/@commitlint/is-ignored/src/defaults.ts
+++ b/@commitlint/is-ignored/src/defaults.ts
@@ -18,7 +18,7 @@ export const wildcards: Matcher[] = [
 	test(
 		/^((Merge pull request)|(Merge (.*?) into (.*?)|(Merge branch (.*?)))(?:\r?\n)*$)/m
 	),
-	test(/^(R|r)evert (.*)/),
+	test(/^(R|r)evert "(.*)/),
 	test(/^(fixup|squash)!/),
 	isSemver,
 	test(/^(Merged (.*?)(in|into) (.*)|Merged PR (.*): (.*))/),

--- a/@commitlint/is-ignored/src/is-ignored.test.ts
+++ b/@commitlint/is-ignored/src/is-ignored.test.ts
@@ -83,6 +83,24 @@ test('should return true for revert commits', () => {
 	).toBe(true);
 });
 
+test('should return false for invalid revert commits', () => {
+	expect(
+		isIgnored(
+			`Revert docs: add recipe for linting of all commits in a PR (#36)\n\nThis reverts commit 1e69d542c16c2a32acfd139e32efa07a45f19111.`
+		)
+	).toBe(false);
+	expect(
+		isIgnored(
+			`revert docs: add recipe for linting of all commits in a PR (#36)\n\nThis reverts commit 1e69d542c16c2a32acfd139e32efa07a45f19111.`
+		)
+	).toBe(false);
+	expect(
+		isIgnored(
+			`revert 'docs: add recipe for linting of all commits in a PR (#36)'\n\nThis reverts commit 1e69d542c16c2a32acfd139e32efa07a45f19111.`
+		)
+	).toBe(false);
+});
+
 test('should ignore npm semver commits', () => {
 	VERSION_MESSAGES.forEach((message) => expect(isIgnored(message)).toBe(true));
 });


### PR DESCRIPTION
## Description

Fail invalid revert commits.

**Note:**
I would like to discuss this change a little further to see if this is an actual valid approach.

## Motivation and Context

Usually a revert commit will follow this convention if you use `git revert <sha>`:
```
Revert "<commit>"
// or
revert "<commit>"
```

This modifies the ignored messages to validate commit messages that don't follow that convention.

## Usage examples

See tests for invalid revert commits that should be validated.

## How Has This Been Tested?

Added tests around invalid revert commits.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
