### PR TITLE
fix(cz-commitlint): fix minor formatting issues

### DIFF
--- a/@commitlint/config-conventional/index.js
+++ b/@commitlint/config-conventional/index.js
@@ -36,7 +36,7 @@ module.exports = {
 	prompt: {
 		questions: {
 			type: {
-				description: "Select the type of change that you're committing:",
+				description: "Select the type of change that you're committing",
 				enum: {
 					feat: {
 						description: 'A new feature',

--- a/@commitlint/cz-commitlint/src/Question.test.ts
+++ b/@commitlint/cz-commitlint/src/Question.test.ts
@@ -102,7 +102,7 @@ describe('message', () => {
 			enumList: ['cli', 'core'],
 		}).question;
 		expect(question).toHaveProperty('message', expect.any(Function));
-		expect((question.message as any)()).toBe('please input: ');
+		expect((question.message as any)()).toBe('please input:');
 	});
 
 	test('should display skip hint when it is input and can skip', () => {
@@ -112,7 +112,7 @@ describe('message', () => {
 		}).question;
 		expect(question).toHaveProperty('message', expect.any(Function));
 		expect((question.message as any)()).toBe(
-			'please input(press enter to skip): \n'
+			'please input (press enter to skip):\n'
 		);
 	});
 
@@ -123,7 +123,7 @@ describe('message', () => {
 			skip: true,
 		} as any).question;
 		expect(question).toHaveProperty('message', expect.any(Function));
-		expect((question.message as any)()).toBe('please input: \n');
+		expect((question.message as any)()).toBe('please input:\n');
 	});
 
 	test('should display upper limit hint when it is input and has max length', () => {
@@ -155,7 +155,7 @@ describe('message', () => {
 		} as any).question;
 		expect(question).toHaveProperty('message', expect.any(Function));
 		expect((question.message as any)()).toBe(
-			'please input(press enter to skip): 10 chars at least, upper 80 chars\n'
+			'please input (press enter to skip): 10 chars at least, upper 80 chars\n'
 		);
 	});
 

--- a/@commitlint/cz-commitlint/src/Question.ts
+++ b/@commitlint/cz-commitlint/src/Question.ts
@@ -176,11 +176,17 @@ export default class Question {
 				return messages.join(', ');
 			})();
 
-			const skipMessage = this.skip ? this.getMessage('skip') : '';
+			const skipMessage = this.skip && this.getMessage('skip');
 
-			return this.title + skipMessage + ': ' + countLimitMessage + '\n';
+			return (
+				this.title +
+				(skipMessage ? ` ${skipMessage}` : '') +
+				':' +
+				(countLimitMessage ? ` ${countLimitMessage}` : '') +
+				'\n'
+			);
 		} else {
-			return this.title + ': ';
+			return `${this.title}:`;
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a space after the title before the skip message and removes the double colon in the
`config-conventional` type of change prompt. For example (when using
`@commitlint/config-conventional`), the following would previously be printed:

```
Select the type of change that you're committing::  feat
What is the scope of this change (e.g. component or file name)(press enter to skip): (max 96 chars)
```

Now with this change:

```
Select the type of change that you're committing: feat
What is the scope of this change (e.g. component or file name) (press enter to skip): (max 96 chars)
```