### PR TITLE
chore: update lodash to 4.17.21

### DIFF
--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -77,7 +77,7 @@
     "babel-polyfill": "6.26.0",
     "chalk": "2.4.2",
     "get-stdin": "7.0.0",
-    "lodash": "4.17.15",
+    "lodash": "4.17.21",
     "meow": "5.0.0",
     "resolve-from": "5.0.0",
     "resolve-global": "1.0.0"

--- a/@commitlint/config-patternplate/package.json
+++ b/@commitlint/config-patternplate/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@commitlint/config-angular": "^8.3.4",
     "globby": "10.0.1",
-    "lodash": "4.17.15"
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "@commitlint/utils": "^8.3.4"

--- a/@commitlint/ensure/package.json
+++ b/@commitlint/ensure/package.json
@@ -38,6 +38,6 @@
     "globby": "10.0.1"
   },
   "dependencies": {
-    "lodash": "4.17.15"
+    "lodash": "4.17.21"
   }
 }

--- a/@commitlint/format/package.json
+++ b/@commitlint/format/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@commitlint/utils": "^8.3.4",
     "@types/lodash": "4.14.144",
-    "lodash": "4.17.15",
+    "lodash": "4.17.21",
     "typescript": "3.6.4"
   },
   "dependencies": {

--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -73,6 +73,6 @@
     "@commitlint/parse": "^8.3.4",
     "@commitlint/rules": "^8.3.4",
     "babel-runtime": "^6.23.0",
-    "lodash": "4.17.15"
+    "lodash": "4.17.21"
   }
 }

--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -73,7 +73,7 @@
     "babel-runtime": "^6.23.0",
     "chalk": "2.4.2",
     "cosmiconfig": "^5.2.0",
-    "lodash": "4.17.15",
+    "lodash": "4.17.21",
     "resolve-from": "^5.0.0"
   }
 }

--- a/@commitlint/prompt/package.json
+++ b/@commitlint/prompt/package.json
@@ -68,7 +68,7 @@
     "@commitlint/load": "^8.3.5",
     "babel-runtime": "^6.23.0",
     "chalk": "^2.0.0",
-    "lodash": "4.17.15",
+    "lodash": "4.17.21",
     "throat": "^5.0.0",
     "vorpal": "^1.12.0"
   }

--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "import-fresh": "^3.0.0",
-    "lodash": "4.17.15",
+    "lodash": "4.17.21",
     "resolve-from": "^5.0.0",
     "resolve-global": "^1.0.0"
   }

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -67,7 +67,7 @@
     "conventional-changelog-angular": "1.6.6",
     "cross-env": "6.0.3",
     "globby": "10.0.1",
-    "lodash": "4.17.15"
+    "lodash": "4.17.21"
   },
   "dependencies": {
     "@commitlint/ensure": "^8.3.4",

--- a/@packages/utils/package.json
+++ b/@packages/utils/package.json
@@ -49,7 +49,7 @@
     "@marionebl/sander": "0.6.1",
     "execa": "0.11.0",
     "is-builtin-module": "3.0.0",
-    "lodash": "4.17.15",
+    "lodash": "4.17.21",
     "meow": "4.0.1",
     "read-pkg": "5.2.0",
     "require-from-string": "2.0.2",


### PR DESCRIPTION
CVE-2021-23337 in package lodash https://nvd.nist.gov/vuln/detail/CVE-2021-23337

This will probably need to be backported to v9 and v10 I will look at them soon. I will also look into the other versions

Ref: 2687