### PR TITLE
docs: add releases EOL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@
 - [Shared configuration](#shared-configuration)
 - [API](#api)
 - [Tools](#tools)
-- [Roadmap](#roadmap)
-- [Version Support](#version-support)
+- [Version Support and Releaes](#version-support-and-releaes)
 - [Related projects](#related-projects)
 - [License](#license)
 - [Development](#development)
@@ -176,10 +175,26 @@ is room and need for improvement. The items on the roadmap should enhance `commi
 - [ ] **DX**: Incorporate an extended version of [lennym/commit-template](https://github.com/lennym/commit-template) deducing a template from commitlint configuration
 - [ ] **DX**: Rewrite `@commitlint/prompt` for better usability (might involve a lot of yak-shaving)
 
-## Version Support
+## Version Support and Releaes
 
 - Node.js [LTS](https://github.com/nodejs/LTS#lts-schedule) `>= 12`
 - git `>= 2.13.2`
+
+### Releases
+
+Security patches will be applied to versions which are not yet EOL.  
+Features will only be applied to the current main version.
+
+| Release                                                                          | Inital release | End-of-life |
+| -------------------------------------------------------------------------------- | -------------- | ----------- |
+| [v13](https://github.com/conventional-changelog/commitlint/releases/tag/v13.0.0) | 24.05.2021     | 24.05.2022  |
+| [v12](https://github.com/conventional-changelog/commitlint/releases/tag/v12.0.0) | 23.02.2021     | 23.02.2022  |
+| [v11](https://github.com/conventional-changelog/commitlint/releases/tag/v11.0.0) | 13.09.2020     | 13.09.2020  |
+
+_Dates are subject to change._
+
+We're not a sponsored OSS project. Therefor we can't promise that we will release patch versions for older releases in a timley manner.  
+If you are stuck on an older version and need a security patch we're happy if you can provide a PR.
 
 ## Related projects
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,6 +3,7 @@
   - [Local setup](guides-local-setup.md)
   - [CI setup](guides-ci-setup.md)
   - [Use prompt](guides-use-prompt.md)
+  - [Releases](guides-releases.md)
   - [Upgrade commitlint](guides-upgrade.md)
 
 - **Concepts**

--- a/docs/guides-releases.md
+++ b/docs/guides-releases.md
@@ -1,0 +1,15 @@
+# Releases
+
+Security patches will be applied to versions which are not yet EOL.  
+Features will only be applied to the current main version.
+
+| Release                                                                          | Inital release | End-of-life |
+| -------------------------------------------------------------------------------- | -------------- | ----------- |
+| [v13](https://github.com/conventional-changelog/commitlint/releases/tag/v13.0.0) | 24.05.2021     | 24.05.2022  |
+| [v12](https://github.com/conventional-changelog/commitlint/releases/tag/v12.0.0) | 23.02.2021     | 23.02.2022  |
+| [v11](https://github.com/conventional-changelog/commitlint/releases/tag/v11.0.0) | 13.09.2020     | 13.09.2020  |
+
+_Dates are subject to change._
+
+We're not a sponsored OSS project. Therefor we can't promise that we will release patch versions for older releases in a timley manner.  
+If you are stuck on an older version and need a security patch we're happy if you can provide a PR.


### PR DESCRIPTION
After #2687 came up @AdeAttwood suggested to add something like this to our readme:  https://nodejs.org/en/about/releases/  

So at least we communicate a policy and be transparent about what we (at least try to) do.  
My understanding is we would try to port the the lodash issue (#2688) back to v8 to v12 and release patch releases but that would be it for now.  
After that we would [point to this table](https://github.com/conventional-changelog/commitlint/tree/docs/releases-eol#version-support-and-releaes) if something similiar happens again.

What do you think?

- [x] add to commitlint website docs