### PR TITLE
docs: added commitlint-gitlab-ci in community docs

### DIFF
--- a/docs/reference-community-projects.md
+++ b/docs/reference-community-projects.md
@@ -12,3 +12,4 @@ If you want to add a project to this list [open a pull request](https://github.c
 
 - [commitlint.io](https://github.com/tomasen/commitlintio) - helps your project to ensures nice and tidy commit messages without needing any download or installation
 - [commitlint plugin function rules](https://github.com/vidavidorra/commitlint-plugin-function-rules) - use functions as rule value to create rules based on commit messages, with regular expressions and more
+- [commitlint-gitlab-ci](https://gitlab.com/dmoonfire/commitlint-gitlab-ci/) - a small wrapper around `commitlint` for working with the quirks of Gitlab's CI without failing jobs


### PR DESCRIPTION
## Description

Added a link to a community tool for working with Gitlab CI without throwing errors.

## Motivation and Context

This addresses https://github.com/conventional-changelog/commitlint/issues/885#issuecomment-888001845 which references a problem when `commitlint` is first run on a Gitlab CI and blows up because it cannot read the SHA. After a number of discussions, I wrote a little utility to encapsulate the last "best" set of scripts to make it easy to work with Gitlab CI.

## Usage examples

```sh
npx commitlint-gitlab-ci -x @commitlint/config-conventional
```

## How Has This Been Tested?

The documentation was just a copy of the link. The utility was manually tested on a number of Gitlab CI.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
