### PR TITLE
docs: correct the "Test simple usage" command

### DIFF
--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -48,7 +48,7 @@ Check the [husky documentation](https://typicode.github.io/husky/#/?id=manual) o
 For a first simple usage test of commlitlint you can do the following:
 
 ```bash
-npx commitlint -- --from HEAD~1 --to HEAD --verbose
+npx commitlint --from HEAD~1 --to HEAD --verbose
 ```
 
 This will check your last commit and return an error if invalid or a positive output if valid.


### PR DESCRIPTION
With the extra `--` in the command line, commitlint checked my entire git history.  Removing the `--` makes it check just the latest commit.

<!--- Provide a general summary of your changes in the Title above -->


## How Has This Been Tested?

I ran both the old and new commands.  The old one wasn't good, and the new one was :)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
