### PR TITLE
chore: add .npmrc to force legacy peer resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
While working on https://github.com/conventional-changelog/commitlint/pull/2715, we discovered that this repo needs the legacy npm peer resolution. See https://github.com/conventional-changelog/commitlint/pull/2715#issuecomment-903269974

The added `.npmrc` forces that it to happen.