### PR TITLE
Enforce Secure Version of `conventional-commits-parser`

### DIFF
--- a/@commitlint/parse/package.json
+++ b/@commitlint/parse/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@commitlint/types": "^13.1.0",
     "conventional-changelog-angular": "^5.0.11",
-    "conventional-commits-parser": "^3.0.0"
+    "conventional-commits-parser": "^3.2.2"
   },
   "gitHead": "70f7f4688b51774e7ac5e40e896cdaa3f132b2bc"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4037,19 +4037,6 @@ conventional-commits-filter@^2.0.7:
     lodash.ismatch "^4.4.0"
     modify-values "^1.0.0"
 
-conventional-commits-parser@^3.0.0:
-  version "3.0.8"
-  resolved "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.8.tgz#23310a9bda6c93c874224375e72b09fb275fe710"
-  integrity sha512-YcBSGkZbYp7d+Cr3NWUeXbPDFUN6g3SaSIzOybi8bjHL5IJ5225OSCxJJ4LgziyEJ7AaJtE9L2/EU6H7Nt/DDQ==
-  dependencies:
-    JSONStream "^1.0.4"
-    is-text-path "^1.0.1"
-    lodash "^4.17.15"
-    meow "^5.0.0"
-    split2 "^2.0.0"
-    through2 "^3.0.0"
-    trim-off-newlines "^1.0.0"
-
 conventional-commits-parser@^3.2.0:
   version "3.2.1"
   resolved "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz#ba44f0b3b6588da2ee9fd8da508ebff50d116ce2"
@@ -4062,6 +4049,18 @@ conventional-commits-parser@^3.2.0:
     split2 "^3.0.0"
     through2 "^4.0.0"
     trim-off-newlines "^1.0.0"
+
+conventional-commits-parser@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.2.tgz#190fb9900c6e02be0c0bca9b03d57e24982639fd"
+  integrity sha512-Jr9KAKgqAkwXMRHjxDwO/zOCDKod1XdAESHAGuJX38iZ7ZzVti/tvVoysO0suMsdAObp9NQ2rHSsSbnAqZ5f5g==
+  dependencies:
+    JSONStream "^1.0.4"
+    is-text-path "^1.0.1"
+    lodash "^4.17.15"
+    meow "^8.0.0"
+    split2 "^3.0.0"
+    through2 "^4.0.0"
 
 conventional-recommended-bump@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
## Description

Ensure that installing `@commitlint/parse` will not accidentally depend
on an insecure version of `conventional-commits-parser` by requiring
v3.22.2 or above as a dependency.

## Motivation and Context

Dependabot gave us a security advisory but did not provide any means of
rectifying it. I used `yarn why` to determine that `trim-off-newlines`
is depended upon by `conventional-commits-parser`, which is depended
upon by `@commitlint/parse`, so this seemed like a good place to require
a higher version of the library to quell the security warning.

![Screen Shot 2021-09-27 at 3 39 40 PM](https://user-images.githubusercontent.com/113026/134975458-4064052a-e68b-4de7-93c1-74246a555743.png)

## Usage examples

n/a

## How Has This Been Tested?

Ran `yarn test` locally to ensure that it didn't break anything obvious.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Package update

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.