### PR TITLE
feat: extend helpUrl from shareable config

### DIFF
--- a/@commitlint/format/src/format.test.ts
+++ b/@commitlint/format/src/format.test.ts
@@ -257,3 +257,24 @@ test('format result omits help for empty problems', () => {
 		expect.arrayContaining([expect.stringContaining('Get help:')])
 	);
 });
+
+test('format result should not contain `Get help` prefix if helpUrl is not provided', () => {
+	const actual = formatResult(
+		{
+			warnings: [
+				{
+					level: 2,
+					name: 'warning-name',
+					message: 'There was a warning',
+				},
+			],
+		},
+		{
+			helpUrl: '',
+		}
+	);
+
+	expect(actual).not.toEqual(
+		expect.arrayContaining([expect.stringContaining('Get help:')])
+	);
+});

--- a/@commitlint/format/src/format.ts
+++ b/@commitlint/format/src/format.ts
@@ -89,14 +89,17 @@ export function formatResult(
 	const fmtSummary =
 		enabled && typeof summary === 'string' ? chalk.bold(summary) : summary;
 
-	const help = hasProblems ? `ⓘ   Get help: ${options.helpUrl}` : undefined;
+	const help =
+		hasProblems && options.helpUrl
+			? `ⓘ   Get help: ${options.helpUrl}`
+			: undefined;
 
 	return [
 		...problems,
 		hasProblems ? '' : undefined,
 		fmtSummary,
 		help,
-		help ? '' : undefined,
+		hasProblems ? '' : undefined,
 	].filter((line): line is string => typeof line === 'string');
 }
 

--- a/@commitlint/load/fixtures/help-url/commitlint.config.js
+++ b/@commitlint/load/fixtures/help-url/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	helpUrl: 'https://github.com/conventional-changelog/commitlint'
+};

--- a/@commitlint/load/src/load.test.ts
+++ b/@commitlint/load/src/load.test.ts
@@ -453,3 +453,21 @@ test('resolves parser preset from conventional commits without factory support',
 		/^(\w*)(?:\((.*)\))?!?: (.*)$/
 	);
 });
+
+test('helpUrl should be loaded from the shareable config', async () => {
+	const cwd = await gitBootstrap('fixtures/help-url');
+	const actual = await load({}, {cwd});
+
+	expect(actual.helpUrl).toStrictEqual(
+		'https://github.com/conventional-changelog/commitlint'
+	);
+});
+
+test('default helpUrl should be loaded if not provided in shareable configs', async () => {
+	const cwd = await gitBootstrap('fixtures/basic');
+	const actual = await load({}, {cwd});
+
+	expect(actual.helpUrl).toStrictEqual(
+		'https://github.com/conventional-changelog/commitlint/#what-is-commitlint'
+	);
+});

--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -111,7 +111,9 @@ export default async function load(
 	}, {});
 
 	const helpUrl =
-		typeof config.helpUrl === 'string'
+		typeof extended.helpUrl === 'string'
+			? extended.helpUrl
+			: typeof config.helpUrl === 'string'
 			? config.helpUrl
 			: 'https://github.com/conventional-changelog/commitlint/#what-is-commitlint';
 

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -15,6 +15,7 @@ export interface ResolvedConfig {
 export interface ResolveExtendsConfig {
 	parserPreset?: unknown;
 	extends?: string | string[];
+	helpUrl?: string;
 	[key: string]: unknown;
 }
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npx husky install
 yarn husky install
 
 # Add hook
-npx husky add .husky/commit-msg 'npx --no-install commitlint --edit "$1"'
+npx husky add .husky/commit-msg 'npx --no -- commitlint --edit "$1"'
 ```
 
 Check the [husky documentation](https://typicode.github.io/husky/#/?id=manual) on how you can automatically have Git hooks enabled after install for different `yarn` versions.
@@ -193,7 +193,7 @@ is room and need for improvement. The items on the roadmap should enhance `commi
 
 ### Releases
 
-Security patches will be applied to versions which are not yet EOL.  
+Security patches will be applied to versions which are not yet EOL.
 Features will only be applied to the current main version.
 
 | Release                                                                          | Inital release | End-of-life |
@@ -204,7 +204,7 @@ Features will only be applied to the current main version.
 
 _Dates are subject to change._
 
-We're not a sponsored OSS project. Therefor we can't promise that we will release patch versions for older releases in a timley manner.  
+We're not a sponsored OSS project. Therefor we can't promise that we will release patch versions for older releases in a timley manner.
 If you are stuck on an older version and need a security patch we're happy if you can provide a PR.
 
 ## Related projects
@@ -242,7 +242,7 @@ For more information on how to contribute please take a look at our [contributio
 ### Publishing a release
 
 Before publishing a release do a `yarn run publish --dry-run` to get the upcoming version and update the version
-in the [`should print help` test](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/cli/src/cli.test.ts#L431).  
+in the [`should print help` test](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/cli/src/cli.test.ts#L431).
 Commit that change before creating the new version without `--dry-run`.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ For more information on how to contribute please take a look at our [contributio
 ### Publishing a release
 
 Before publishing a release do a `yarn run publish --dry-run` to get the upcoming version and update the version
-in the [`should print help` test](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/cli/src/cli.test.ts#L431).
+in the [`should print help` test](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/cli/src/cli.test.ts#L431).\
 Commit that change before creating the new version without `--dry-run`.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ npx lerna publish --conventional-commits --dist-tag next --otp <one-time passwor
 
 If for some reason this stops in between, you can manually publish missing packages like this:
 
-```
+```sh
 npm publish <package-name> --tag next --otp <one-time password>
 ```
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ is room and need for improvement. The items on the roadmap should enhance `commi
 
 ### Releases
 
-Security patches will be applied to versions which are not yet EOL.
+Security patches will be applied to versions which are not yet EOL.\
 Features will only be applied to the current main version.
 
 | Release                                                                          | Inital release | End-of-life |
@@ -204,7 +204,7 @@ Features will only be applied to the current main version.
 
 _Dates are subject to change._
 
-We're not a sponsored OSS project. Therefor we can't promise that we will release patch versions for older releases in a timley manner.
+We're not a sponsored OSS project. Therefor we can't promise that we will release patch versions for older releases in a timley manner.\
 If you are stuck on an older version and need a security patch we're happy if you can provide a PR.
 
 ## Related projects

--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -33,12 +33,12 @@ npx husky install
 yarn husky install
 
 # Add hook
-npx husky add .husky/commit-msg 'npx --no-install commitlint --edit $1'
+npx husky add .husky/commit-msg 'npx --no -- commitlint --edit $1'
 # or
 yarn husky add .husky/commit-msg 'yarn commitlint --edit $1'
 ```
 
-**Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)**  
+**Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)**
 Check the [husky documentation](https://typicode.github.io/husky/#/?id=manual) on how you can automatically have Git hooks enabled after install for different `yarn` versions.
 
 ## Test
@@ -70,7 +70,7 @@ No staged files match any of provided globs.
 husky > commit-msg hook failed (add --no-verify to bypass)
 ```
 
-Since [v8.0.0](https://github.com/conventional-changelog/commitlint/releases/tag/v8.0.0) `commitlint` won't output anything if there is not problem with your commit.  
+Since [v8.0.0](https://github.com/conventional-changelog/commitlint/releases/tag/v8.0.0) `commitlint` won't output anything if there is not problem with your commit.
 (You can use the `--verbose` flag to get positive output)
 
 ```bash

--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -38,7 +38,7 @@ npx husky add .husky/commit-msg 'npx --no -- commitlint --edit $1'
 yarn husky add .husky/commit-msg 'yarn commitlint --edit $1'
 ```
 
-**Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)**
+**Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)**\
 Check the [husky documentation](https://typicode.github.io/husky/#/?id=manual) on how you can automatically have Git hooks enabled after install for different `yarn` versions.
 
 ## Test
@@ -70,7 +70,7 @@ No staged files match any of provided globs.
 husky > commit-msg hook failed (add --no-verify to bypass)
 ```
 
-Since [v8.0.0](https://github.com/conventional-changelog/commitlint/releases/tag/v8.0.0) `commitlint` won't output anything if there is not problem with your commit.
+Since [v8.0.0](https://github.com/conventional-changelog/commitlint/releases/tag/v8.0.0) `commitlint` won't output anything if there is not problem with your commit.\
 (You can use the `--verbose` flag to get positive output)
 
 ```bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Allow helpUrl to be extended from from shareable config
- This also hides `Get help:` string if helpUrl is not configured.   
- update docs containing deprecated `--no-install` npx option

## Motivation and Context

It is not possible to customize the helpUrl via shareable config. It has to be added into individual repos'. This allows shareable config to have helpUrl.

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js <-- shareable config
module.exports = {
  helpUrl: 'https://commitlint.js.org/'
};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

- Added test cases for changes made.
- created a new project and using yarn link to installed the local changes for testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
