### PR TITLE
fix(types): fix signature of QualifiedRuleConfig for async configurations (#2868)

### DIFF
--- a/@commitlint/load/src/load.test.ts
+++ b/@commitlint/load/src/load.test.ts
@@ -32,6 +32,22 @@ test('uses seed as configured', async () => {
 	expect(actual.rules['body-case']).toStrictEqual([1, 'never', 'camel-case']);
 });
 
+test('rules should be loaded from local', async () => {
+	const actual = await load({
+		rules: {
+			direct: [1, 'never', 'foo'],
+			func: () => [1, 'never', 'foo'],
+			async: async () => [1, 'never', 'foo'],
+			promise: () => Promise.resolve([1, 'never', 'foo']),
+		},
+	});
+
+	expect(actual.rules['direct']).toStrictEqual([1, 'never', 'foo']);
+	expect(actual.rules['func']).toStrictEqual([1, 'never', 'foo']);
+	expect(actual.rules['async']).toStrictEqual([1, 'never', 'foo']);
+	expect(actual.rules['promise']).toStrictEqual([1, 'never', 'foo']);
+});
+
 test('rules should be loaded from relative config file', async () => {
 	const file = 'config/commitlint.config.js';
 	const cwd = await gitBootstrap('fixtures/specify-config-file');

--- a/@commitlint/types/src/rules.ts
+++ b/@commitlint/types/src/rules.ts
@@ -65,7 +65,7 @@ export enum RuleConfigQuality {
 
 export type QualifiedRuleConfig<T> =
 	| (() => RuleConfigTuple<T>)
-	| (() => RuleConfigTuple<Promise<T>>)
+	| (() => Promise<RuleConfigTuple<T>>)
 	| RuleConfigTuple<T>;
 
 export type RuleConfig<


### PR DESCRIPTION
Allow Typescript projects to provide a function returning a Promise of a rule configuration

## Description

Fixes the type signature of [QualifiedRuleConfig](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/types/src/rules.ts) that didn't match the current implementation and adds tests to check on all  allowed types of rule configuration.

## Motivation and Context

Fixing mismatched types and allow correct use of asynchronous rule configurations without requiring additional custom plugins.

## Usage examples

<!--- Provide examples of intended usage -->

```ts
// commitlint.config.ts
import type { UserConfig } from '@commitlint/types';

const config: Userconfig = {
  rules: {
    'scope-enum': () => Promise.resolve([1, 'always', ['one', 'two', 'three']])
  }
};

export default config
```

```sh
echo "feat(one): message" | commitlint # passes
```

## How Has This Been Tested?

Additional tests have been added to [@commitlint/load](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/load) to verify the change and the (previously uncovered) other configuration options.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
