### PR TITLE
feat(cz-commitlint): support select scope with radio list by setting disableMultipleScopes

### DIFF
--- a/@commitlint/cz-commitlint/src/SectionHeader.test.ts
+++ b/@commitlint/cz-commitlint/src/SectionHeader.test.ts
@@ -68,6 +68,16 @@ describe('getQuestionConfig', () => {
 			})
 		);
 	});
+
+	test("should 'scope' disable multiple select with disableMultipleScopes", () => {
+		setPromptConfig({
+			settings: {
+				disableMultipleScopes: true,
+			},
+		});
+		const config = getQuestionConfig('scope');
+		expect(config).not.toContain('multipleSelectDefaultDelimiter');
+	});
 });
 
 describe('combineCommitMessage', () => {

--- a/@commitlint/cz-commitlint/src/SectionHeader.test.ts
+++ b/@commitlint/cz-commitlint/src/SectionHeader.test.ts
@@ -55,10 +55,11 @@ describe('getQuestionConfig', () => {
 		);
 	});
 
-	test("should 'scope' supports multiple select separated with settings.scopeEnumSeparator", () => {
+	test("should 'scope' supports multiple select separated with settings.scopeEnumSeparator and enableMultipleScopes", () => {
 		setPromptConfig({
 			settings: {
 				scopeEnumSeparator: '/',
+				enableMultipleScopes: true,
 			},
 		});
 		const config = getQuestionConfig('scope');
@@ -69,12 +70,7 @@ describe('getQuestionConfig', () => {
 		);
 	});
 
-	test("should 'scope' disable multiple select with disableMultipleScopes", () => {
-		setPromptConfig({
-			settings: {
-				disableMultipleScopes: true,
-			},
-		});
+	test("should 'scope' disable multiple select by default", () => {
 		const config = getQuestionConfig('scope');
 		expect(config).not.toContain('multipleSelectDefaultDelimiter');
 	});

--- a/@commitlint/cz-commitlint/src/SectionHeader.ts
+++ b/@commitlint/cz-commitlint/src/SectionHeader.ts
@@ -50,11 +50,6 @@ export function getQuestions(): Array<DistinctQuestion> {
 	headerRuleFields.forEach((name) => {
 		const questionConfig = getQuestionConfig(name);
 		if (questionConfig) {
-			if (name === 'scope') {
-				questionConfig.multipleSelectDefaultDelimiter =
-					getPromptSettings()['scopeEnumSeparator'];
-				questionConfig.multipleValueDelimiters = /\/|\\|,/g;
-			}
 			const instance = new HeaderQuestion(
 				name,
 				questionConfig,
@@ -74,8 +69,11 @@ export function getQuestionConfig(
 
 	if (questionConfig) {
 		if (name === 'scope') {
-			questionConfig.multipleSelectDefaultDelimiter =
-				getPromptSettings()['scopeEnumSeparator'];
+			if (!getPromptSettings()['disableMultipleScopes']) {
+				questionConfig.multipleSelectDefaultDelimiter =
+					getPromptSettings()['scopeEnumSeparator'];
+			}
+			// split scope string to segments, match commitlint rules
 			questionConfig.multipleValueDelimiters = /\/|\\|,/g;
 		}
 	}

--- a/@commitlint/cz-commitlint/src/SectionHeader.ts
+++ b/@commitlint/cz-commitlint/src/SectionHeader.ts
@@ -69,7 +69,7 @@ export function getQuestionConfig(
 
 	if (questionConfig) {
 		if (name === 'scope') {
-			if (!getPromptSettings()['disableMultipleScopes']) {
+			if (getPromptSettings()['enableMultipleScopes']) {
 				questionConfig.multipleSelectDefaultDelimiter =
 					getPromptSettings()['scopeEnumSeparator'];
 			}

--- a/@commitlint/cz-commitlint/src/store/defaultPromptConfigs.ts
+++ b/@commitlint/cz-commitlint/src/store/defaultPromptConfigs.ts
@@ -1,7 +1,7 @@
 export default {
 	settings: {
 		scopeEnumSeparator: ',',
-		disableMultipleScopes: false,
+		enableMultipleScopes: false,
 	},
 	messages: {
 		skip: '(press enter to skip)',

--- a/@commitlint/cz-commitlint/src/store/defaultPromptConfigs.ts
+++ b/@commitlint/cz-commitlint/src/store/defaultPromptConfigs.ts
@@ -1,6 +1,7 @@
 export default {
 	settings: {
 		scopeEnumSeparator: ',',
+		disableMultipleScopes: false,
 	},
 	messages: {
 		skip: '(press enter to skip)',

--- a/@commitlint/cz-commitlint/src/store/prompts.test.ts
+++ b/@commitlint/cz-commitlint/src/store/prompts.test.ts
@@ -132,9 +132,9 @@ describe('setPromptConfig', () => {
 	test('should pass on settings', () => {
 		setPromptConfig({
 			settings: {
-				disableMultipleScopes: true,
+				enableMultipleScopes: true,
 			},
 		});
-		expect(getPromptSettings()['disableMultipleScopes']).toEqual(true);
+		expect(getPromptSettings()['enableMultipleScopes']).toEqual(true);
 	});
 });

--- a/@commitlint/cz-commitlint/src/store/prompts.test.ts
+++ b/@commitlint/cz-commitlint/src/store/prompts.test.ts
@@ -115,9 +115,7 @@ describe('setPromptConfig', () => {
 				scopeEnumSeparator: '/',
 			},
 		});
-		expect(getPromptSettings()).toEqual({
-			scopeEnumSeparator: '/',
-		});
+		expect(getPromptSettings()['scopeEnumSeparator']).toEqual('/');
 
 		const processExit = jest
 			.spyOn(process, 'exit')
@@ -129,5 +127,14 @@ describe('setPromptConfig', () => {
 		});
 		expect(processExit).toHaveBeenCalledWith(1);
 		processExit.mockClear();
+	});
+
+	test('should pass on settings', () => {
+		setPromptConfig({
+			settings: {
+				disableMultipleScopes: true,
+			},
+		});
+		expect(getPromptSettings()['disableMultipleScopes']).toEqual(true);
 	});
 });

--- a/@commitlint/types/src/prompt.ts
+++ b/@commitlint/types/src/prompt.ts
@@ -18,6 +18,7 @@ export type PromptName =
 export type PromptConfig = {
 	settings: {
 		scopeEnumSeparator: string;
+		disableMultipleScopes: boolean;
 	};
 	messages: PromptMessages;
 	questions: Partial<

--- a/@commitlint/types/src/prompt.ts
+++ b/@commitlint/types/src/prompt.ts
@@ -18,7 +18,7 @@ export type PromptName =
 export type PromptConfig = {
 	settings: {
 		scopeEnumSeparator: string;
-		disableMultipleScopes: boolean;
+		enableMultipleScopes: boolean;
 	};
 	messages: PromptMessages;
 	questions: Partial<

--- a/docs/reference-prompt.md
+++ b/docs/reference-prompt.md
@@ -8,8 +8,8 @@ There are three fields: `settings`, `messages` and `questions`
 
 Set optional options.
 
-- `scopeEnumSeparator`: `(string)` Commitlint supports [multiple scopes](./concepts-commit-conventions.md?id=multiple-scopes), you can specify the delimiter.
-- `disableMultipleScopes`: `(boolean)` Disable multiple scopes, select scope with a radio list.
+- `enableMultipleScopes`: `(boolean)` Enable multiple scopes, select scope with a radio list, disabled by default.
+- `scopeEnumSeparator`: `(string)` Commitlint supports [multiple scopes](./concepts-commit-conventions.md?id=multiple-scopes), you can specify the delimiter.It is applied when `enableMultipleScopes` set true.
 
 ## `messages`
 

--- a/docs/reference-prompt.md
+++ b/docs/reference-prompt.md
@@ -8,35 +8,36 @@ There are three fields: `settings`, `messages` and `questions`
 
 Set optional options.
 
-- scopeEnumSeparator: Commitlint supports [multiple scopes](./concepts-commit-conventions.md?id=multiple-scopes), you can specify the delimiter.
+- `scopeEnumSeparator`: `(string)` Commitlint supports [multiple scopes](./concepts-commit-conventions.md?id=multiple-scopes), you can specify the delimiter.
+- `disableMultipleScopes`: `(boolean)` Disable multiple scopes, select scope with a radio list.
 
 ## `messages`
 
 Set hint contents, you can configure it to support localization.
 
-- skip: The field can be skip by enter
-- max: Maximum number of characters
-- min: Minimum number of characters
-- emptyWarning: The field can not be empty
-- upperLimitWarning: The characters limit is exceeded
-- lowerLimitWarning: The characters is less than lower limit
+- `skip`: The field can be skip by enter
+- `max`: Maximum number of characters
+- `min`: Minimum number of characters
+- `emptyWarning`: The field can not be empty
+- `upperLimitWarning`: The characters limit is exceeded
+- `lowerLimitWarning`: The characters is less than lower limit
 
 ## `questions`
 
 Specify the interactive steps, Steps can only be configure in
 
-- header
-- type
-- scope
-- subject
-- body
-- footer
-- isBreaking
-- breaking
-- breakingBody
-- isIssueAffected
-- issues
-- issuesBody
+- `header`
+- `type`
+- `scope`
+- `subject`
+- `body`
+- `footer`
+- `isBreaking`
+- `breaking`
+- `breakingBody`
+- `isIssueAffected`
+- `issues`
+- `issuesBody`
 
 <div class="sequence">
     <img src="./assets/cz-commitlint.png"/>
@@ -49,6 +50,7 @@ module.exports = {
     ...
   },
   prompt: {
+    settings: {},
     messages: {
       skip: ':skip',
       max: 'upper %d chars',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
support select scope with radio list by setting disableMultipleScopes

## Description

add config option `prompt.settings.disableMultipleScopes`, give a option to disable multiple scopes, select scope with a radio list.

## Motivation and Context

Ref: #2896 

It's convenient to select by enter when only a single one scope is required.

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  prompt: {
    settings: {
      disableMultipleScopes: true
    }
  }
};
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Add unit test in config entry.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
