### PR TITLE
fix(cz-commitlint): combine commit body with issuesBody/breakingBody …

### DIFF
--- a/@commitlint/cz-commitlint/src/SectionBody.test.ts
+++ b/@commitlint/cz-commitlint/src/SectionBody.test.ts
@@ -74,4 +74,13 @@ describe('combineCommitMessage', () => {
 		});
 		expect(commitMessage).toBe('This is issue body message.');
 	});
+
+	test('should use issueBody when body message is empty string but commit has issue note', () => {
+		setRules({});
+		const commitMessage = combineCommitMessage({
+			body: '',
+			issuesBody: 'This is issue body message.',
+		});
+		expect(commitMessage).toBe('This is issue body message.');
+	});
 });

--- a/@commitlint/cz-commitlint/src/SectionBody.ts
+++ b/@commitlint/cz-commitlint/src/SectionBody.ts
@@ -19,7 +19,7 @@ export function combineCommitMessage(answers: Answers): string {
 	const leadingBlankFn = getLeadingBlankFn(getRule('body', 'leading-blank'));
 	const {body, breakingBody, issuesBody} = answers;
 
-	const commitBody = body ?? breakingBody ?? issuesBody ?? '-';
+	const commitBody = body || breakingBody || issuesBody || '-';
 
 	if (commitBody) {
 		return leadingBlankFn(


### PR DESCRIPTION
Fix issue when empty body string overrides non-empty issuesBody or breakingBody.

## Description

Changing nullish coalescing operator (??) with logical OR (||) for commit body. Nullish operator will not correctly evaluate empty string '' as will skip any text inputed to issuesBody or breakingBody.

Also adding a simple test to check this behavior in the future.

## Motivation and Context

Fixing incorrect commit body evaluation.

Fixes https://github.com/conventional-changelog/commitlint/issues/2813

## Usage examples

No new behavior was introduced.

## How Has This Been Tested?

Newly written test as part of the pull request.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
