### PR TITLE
fix(is-ignored): ignore merge tag commit messages

### DIFF
--- a/@commitlint/is-ignored/src/defaults.ts
+++ b/@commitlint/is-ignored/src/defaults.ts
@@ -18,6 +18,7 @@ export const wildcards: Matcher[] = [
 	test(
 		/^((Merge pull request)|(Merge (.*?) into (.*?)|(Merge branch (.*?)))(?:\r?\n)*$)/m
 	),
+	test(/^(Merge tag (.*?))(?:\r?\n)*$/m),
 	test(/^(R|r)evert (.*)/),
 	test(/^(fixup|squash)!/),
 	isSemver,

--- a/@commitlint/is-ignored/src/is-ignored.test.ts
+++ b/@commitlint/is-ignored/src/is-ignored.test.ts
@@ -70,6 +70,26 @@ test('should return true for branch merges with newline characters and more char
 	);
 });
 
+test('should return true for tag merges', () => {
+	expect(isIgnored("Merge tag '1.1.1'")).toBe(true);
+	expect(isIgnored("Merge tag 'a tag'")).toBe(true);
+});
+
+test('should return true for tag merges with newline characters', () => {
+	expect(isIgnored("Merge tag '1.1.1'\n")).toBe(true);
+	expect(isIgnored("Merge tag '1.1.1'\r\n")).toBe(true);
+});
+
+test('should return true for tag merges with multiple newline characters', () => {
+	expect(isIgnored("Merge tag '1.1.1'\n\n\n")).toBe(true);
+	expect(isIgnored("Merge tag '1.1.1'\r\n\r\n\r\n")).toBe(true);
+});
+
+test('should return true for tag merges with newline characters and more characters after it', () => {
+	expect(isIgnored("Merge tag '1.1.1'\n ")).toBe(true);
+	expect(isIgnored("Merge tag '1.1.1'\r\n # some comment")).toBe(true);
+});
+
 test('should return true for revert commits', () => {
 	expect(
 		isIgnored(
@@ -131,6 +151,10 @@ test('should return true for azure devops merge commits', () => {
 
 test('should return false for commits containing, but not starting, with merge branch', () => {
 	expect(isIgnored('foo bar Merge branch xxx')).toBe(false);
+});
+
+test('should return false for commits containing, but not starting, with merge tag', () => {
+	expect(isIgnored("foo bar Merge tag '1.1.1'")).toBe(false);
 });
 
 test('should return false for ignored message if defaults is false', () => {


### PR DESCRIPTION
## Description

Updated wildcard regular expressions in `@commitlint/is-ignored`.

## Motivation and Context



Merging a tag in another branch can lead to conflicts. In this case, the default Git commit message after resolving the conflicts will be like: `Merge tag 'x.y.z'`

There is specific plumbing to consider a branch merge commit as valid
```sh
echo "Merge branch 'a branch'" | commitlint 
# Everything ok
```

But currently, a tag merge commit is being considered as an error:
```sh
echo "Merge tag 'a tag'" | commitlint 
⧗   input: Merge tag 'a tag'
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]

✖   found 2 problems, 0 warnings
```
So I updated the wildcards to get a consistent behavior between branch and tag merge:
 - `Merge branch 'a branch'`
 - `Merge tag 'a tag'`

## Usage examples

Running commitlint with a tag merge commit:
```sh
echo "Merge tag 'a tag'" | commitlint 
# Everything ok
```

## How Has This Been Tested?

I have added unit tests to cover cases similar to the branch merge commit ones.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation. -> I don't think so, right?
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
