### PR TITLE
fix: commit body should be empty by default

### DIFF
--- a/@commitlint/cz-commitlint/src/SectionBody.test.ts
+++ b/@commitlint/cz-commitlint/src/SectionBody.test.ts
@@ -83,4 +83,12 @@ describe('combineCommitMessage', () => {
 		});
 		expect(commitMessage).toBe('This is issue body message.');
 	});
+
+	test('should return empty message when body is empty', () => {
+		setRules({});
+		const commitMessage = combineCommitMessage({
+			body: '',
+		});
+		expect(commitMessage).toBe('');
+	});
 });

--- a/@commitlint/cz-commitlint/src/SectionBody.ts
+++ b/@commitlint/cz-commitlint/src/SectionBody.ts
@@ -19,7 +19,7 @@ export function combineCommitMessage(answers: Answers): string {
 	const leadingBlankFn = getLeadingBlankFn(getRule('body', 'leading-blank'));
 	const {body, breakingBody, issuesBody} = answers;
 
-	const commitBody = body || breakingBody || issuesBody || '-';
+	const commitBody = body || breakingBody || issuesBody || '';
 
 	if (commitBody) {
 		return leadingBlankFn(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

commit body should be empty by default

## Motivation and Context

https://github.com/conventional-changelog/commitlint/issues/2971

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
