### PR TITLE
feat(load): accept functions as parser presets

### DIFF
--- a/@commitlint/config-validator/src/__snapshots__/validate.test.ts.snap
+++ b/@commitlint/config-validator/src/__snapshots__/validate.test.ts.snap
@@ -56,6 +56,7 @@ exports[`validation should fail for parserPreset 1`] = `
 "Commitlint configuration in parserPreset.js is invalid:
 	- Property \\"parserPreset\\" has the wrong type - should be string.
 	- Property \\"parserPreset\\" has the wrong type - should be object.
+	- \\"parserPreset\\" should be a function. Value: [].
 	- \\"parserPreset\\" should match exactly one schema in oneOf. Value: [].
 "
 `;

--- a/@commitlint/config-validator/src/commitlint.schema.json
+++ b/@commitlint/config-validator/src/commitlint.schema.json
@@ -57,7 +57,8 @@
             "parserOpts": {}
           },
           "additionalProperties": true
-        }
+        },
+        {"typeof": "function"}
       ]
     },
     "helpUrl": {

--- a/@commitlint/load/src/utils/load-parser-opts.test.ts
+++ b/@commitlint/load/src/utils/load-parser-opts.test.ts
@@ -1,0 +1,55 @@
+import {loadParserOpts} from './load-parser-opts';
+
+test('handles a plain preset', async () => {
+	const preset = {
+		parserOpts: {},
+	};
+
+	expect(await loadParserOpts(preset)).toEqual(preset);
+});
+
+test('handles primitive values', async () => {
+	expect(await loadParserOpts('')).toEqual(undefined);
+	expect(await loadParserOpts(undefined)).toEqual(undefined);
+});
+
+test('handles an object without any parserOpts', async () => {
+	const preset = {};
+	expect(await loadParserOpts(preset)).toEqual(preset);
+});
+
+test('handles nested parserOpts', async () => {
+	const opts = {a: 4};
+
+	// plain nested parserOpts
+	let loaded = await loadParserOpts({
+		parserOpts: {
+			parserOpts: opts,
+		},
+	});
+	expect(loaded).toHaveProperty('parserOpts', opts);
+
+	// async nested parserOpts
+	loaded = await loadParserOpts({
+		parserOpts: Promise.resolve({
+			parserOpts: opts,
+		}),
+	});
+	expect(loaded).toHaveProperty('parserOpts', opts);
+});
+
+test('runs a sync function which returns the preset', async () => {
+	const preset = {};
+	const fn = () => preset;
+	const opts = await loadParserOpts(fn);
+
+	expect(opts).toEqual(preset);
+});
+
+test('runs an async function which returns the preset', async () => {
+	const preset = {};
+	const fn = async () => preset;
+	const opts = await loadParserOpts(fn);
+
+	expect(opts).toEqual(preset);
+});

--- a/@commitlint/load/src/utils/load-parser-opts.ts
+++ b/@commitlint/load/src/utils/load-parser-opts.ts
@@ -1,5 +1,7 @@
 import {ParserPreset} from '@commitlint/types';
 
+type Awaitable<T> = T | PromiseLike<T>;
+
 function isObjectLike(obj: unknown): obj is Record<string, unknown> {
 	return Boolean(obj) && typeof obj === 'object'; // typeof null === 'object'
 }
@@ -15,8 +17,16 @@ function isParserOptsFunction<T extends ParserPreset>(
 }
 
 export async function loadParserOpts(
-	pendingParser: string | ParserPreset | Promise<ParserPreset> | undefined
+	pendingParser:
+		| string
+		| Awaitable<ParserPreset>
+		| (() => Awaitable<ParserPreset>)
+		| undefined
 ): Promise<ParserPreset | undefined> {
+	if (typeof pendingParser === 'function') {
+		return loadParserOpts(pendingParser());
+	}
+
 	if (!pendingParser || typeof pendingParser !== 'object') {
 		return undefined;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Previously, `load` could accept `parserPresets` as both values and promises of
values. Per #2964 however, there was expectations for it to also support
functions returning said values.

This commit enables to specify `parserPresets` in all the same ways as
rules. That is, both commitlint rules and `parserPresets` can be specified as:

- Plain values
- Promises
- Functions returning plain values
- Functions returning promises

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See discussion in #2964.

## How Has This Been Tested?

Wrote unit tests for `load-parser-opts` covering both new and old functionality.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
