### PR TITLE
Satisfy `cosmiconfig-typescript-loader` peer dependency

### DIFF
--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -46,6 +46,7 @@
     "@commitlint/execute-rule": "^16.0.0",
     "@commitlint/resolve-extends": "^16.1.0",
     "@commitlint/types": "^16.0.0",
+    "@types/node": ">=12",
     "chalk": "^4.0.0",
     "cosmiconfig": "^7.0.0",
     "cosmiconfig-typescript-loader": "^1.0.0",


### PR DESCRIPTION
## Description

Add @types/node as a dependency of @commitlint/load to satisfy peer dependency from
cosmiconfig-typescript-loader (by way of ts-node's peer dependency of the same)

Fixes #3007


## Motivation and Context

Depending on **@commitlint/prompt** or **@commitlint/cli** results in peer dependency warnings.

<img width="1121" alt="peer-dependency-warning" src="https://user-images.githubusercontent.com/288160/152616259-0e40378f-b844-4560-a242-3f3bf8ff002b.png">

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
