### PR TITLE
Ignoring node_modules folders inside nested workspaces as Lerna scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ package.json.lerna_backup
 /*.iml
 tsconfig.tsbuildinfo
 coverage
+
+# For testing nested workspaces does not have the package's dependencies name in the scope
+!**/config-lerna-scopes/fixtures/nested-workspaces/**/node_modules

--- a/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/@packages/a/nested-a/node_modules/dependency-a/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/@packages/a/nested-a/node_modules/dependency-a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@packages/dependency-a",
+  "version": "1.0.0"
+}

--- a/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/@packages/a/nested-a/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/@packages/a/nested-a/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@packages/nested-a",
+  "version": "1.0.0"
+}

--- a/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/@packages/b/nested-b/node_modules/dependency-b/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/@packages/b/nested-b/node_modules/dependency-b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@packages/dependency-b",
+  "version": "1.0.0"
+}

--- a/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/@packages/b/nested-b/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/@packages/b/nested-b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@packages/nested-b",
+  "version": "1.0.0"
+}

--- a/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/package.json
+++ b/@commitlint/config-lerna-scopes/fixtures/nested-workspaces/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "nested-workspaces",
+  "version": "1.0.0",
+  "workspaces": [
+    "@packages/**"
+  ],
+  "devDependencies": {
+    "lerna": "^4.0.0",
+    "@lerna/project": "^4.0.0"
+  }
+}

--- a/@commitlint/config-lerna-scopes/index.js
+++ b/@commitlint/config-lerna-scopes/index.js
@@ -25,7 +25,7 @@ function getPackages(context) {
 					workspaces.map((ws) => {
 						return Path.posix.join(ws, 'package.json');
 					}),
-					{cwd}
+					{cwd, ignore: ['**/node_modules/**']}
 				).then((pJsons = []) => {
 					return pJsons.map((pJson) => require(Path.join(cwd, pJson)));
 				});

--- a/@commitlint/config-lerna-scopes/index.test.js
+++ b/@commitlint/config-lerna-scopes/index.test.js
@@ -82,3 +82,14 @@ test('returns expected value for yarn workspaces', async () => {
 	const [, , value] = await fn({cwd});
 	expect(value.sort()).toEqual(['a', 'b']);
 });
+
+test('returns expected value for yarn workspaces has nested packages', async () => {
+	const {'scope-enum': fn} = config.rules;
+	const cwd = await npm.bootstrap('fixtures/nested-workspaces', __dirname);
+
+	const [, , value] = await fn({cwd});
+	expect(value).toEqual(expect.arrayContaining(['nested-a', 'nested-b']));
+	expect(value).toEqual(
+		expect.not.arrayContaining(['dependency-a', 'dependency-b'])
+	);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
For nested workspaces, the config rules also gave the name of the packages' dependencies as Lerna scope.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The issue of https://github.com/conventional-changelog/commitlint/issues/3023

## Usage examples
<!--- Provide examples of intended usage -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
