### PR TITLE
docs: fix typo in 'reference-configuration.md'

### DIFF
--- a/docs/reference-configuration.md
+++ b/docs/reference-configuration.md
@@ -177,7 +177,7 @@ module.exports = {
 ## Parser presets
 
 The parser preset used to parse commit messages can be configured.
-Use ids resolveable by the node resolve algorithm.
+Use ids resolvable by the node resolve algorithm.
 
 This means installed npm packages and local files can be used.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fix a typo in file `docs/reference-configuration.md`: 

```diff
- resolveable
+ resolvable
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Found a typo error while reading and wanted to help fix it.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Since it is only a document modification, no testing is required

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
