### PR TITLE
chore: clarify to end user which tool found errors

### DIFF
--- a/@commitlint/config-lerna-scopes/readme.md
+++ b/@commitlint/config-lerna-scopes/readme.md
@@ -29,16 +29,16 @@ packages
 
 ❯ echo "build(api): change something in api's build" | commitlint
 ⧗   input: build(api): change something in api's build
-✔   found 0 problems, 0 warnings
+✔   commitlint found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
 ⧗   input: test(foo): this won't pass
 ✖   scope must be one of [api, app, web] [scope-enum]
-✖   found 1 problems, 0 warnings
+✖   commitlint found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
 ⧗   input: ci: do some general maintenance
-✔   found 0 problems, 0 warnings
+✔   commitlint found 0 problems, 0 warnings
 ```
 
 Consult [docs/rules](https://conventional-changelog.github.io/commitlint/#/reference-rules) for a list of available rules.

--- a/@commitlint/config-nx-scopes/readme.md
+++ b/@commitlint/config-nx-scopes/readme.md
@@ -29,16 +29,16 @@ packages
 
 ❯ echo "build(api): change something in api's build" | commitlint
 ⧗   input: build(api): change something in api's build
-✔   found 0 problems, 0 warnings
+✔   commitlint found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
 ⧗   input: test(foo): this won't pass
 ✖   scope must be one of [api, app, web] [scope-enum]
-✖   found 1 problems, 0 warnings
+✖   commitlint found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
 ⧗   input: ci: do some general maintenance
-✔   found 0 problems, 0 warnings
+✔   commitlint found 0 problems, 0 warnings
 ```
 
 Consult [docs/rules](https://conventional-changelog.github.io/commitlint/#/reference-rules) for a list of available rules.

--- a/@commitlint/config-rush-scopes/readme.md
+++ b/@commitlint/config-rush-scopes/readme.md
@@ -29,16 +29,16 @@ packages
 
 ❯ echo "build(api): change something in api's build" | commitlint
 ⧗   input: build(api): change something in api's build
-✔   found 0 problems, 0 warnings
+✔   commitlint found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
 ⧗   input: test(foo): this won't pass
 ✖   scope must be one of [api, app, web] [scope-enum]
-✖   found 1 problems, 0 warnings
+✖   commitlint found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
 ⧗   input: ci: do some general maintenance
-✔   found 0 problems, 0 warnings
+✔   commitlint found 0 problems, 0 warnings
 ```
 
 Consult [docs/rules](https://conventional-changelog.github.io/commitlint/#/reference-rules) for a list of available rules.

--- a/@commitlint/format/README.md
+++ b/@commitlint/format/README.md
@@ -58,7 +58,7 @@ process.stdout.write(output);
   '✖   This will show up red as it has level 2 [some-error]',
   '    This will not show up as it has level 0 [some-hint]',
   '⚠   This will show up yellow as it has level 1 [some-warning]',
-  '✖   found 1 problems, 2 warnings'
+  '✖   commitlint found 1 problems, 2 warnings'
 ] */
 ```
 

--- a/@commitlint/format/src/format.ts
+++ b/@commitlint/format/src/format.ts
@@ -83,7 +83,7 @@ export function formatResult(
 
 	const summary =
 		options.verbose || hasProblems
-			? `${deco}   found ${el} problems, ${wl} warnings`
+			? `${deco}   commitlint found ${el} problems, ${wl} warnings`
 			: undefined;
 
 	const fmtSummary =

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ echo 'foo: bar' | commitlint
 ⧗   input: foo: bar
 ✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]
 
-✖   found 1 problems, 0 warnings
+✖   commitlint found 1 problems, 0 warnings
 ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
 ```
 

--- a/docs/assets/commitlint.json
+++ b/docs/assets/commitlint.json
@@ -91,7 +91,7 @@
     [1.177726, "\u001b[90m⧗\u001b[39m   input: \u001b[1mfoo\u001b[22m\r\n"],
     [
       0.000414,
-      "\u001b[31m✖\u001b[39m   message may not be empty \u001b[90m[subject-empty]\u001b[39m\r\n\u001b[31m✖\u001b[39m   type may not be empty \u001b[90m[type-empty]\u001b[39m\r\n\u001b[1m\u001b[31m✖\u001b[39m   found 2 problems, 0 warnings\u001b[22m\r\n"
+      "\u001b[31m✖\u001b[39m   message may not be empty \u001b[90m[subject-empty]\u001b[39m\r\n\u001b[31m✖\u001b[39m   type may not be empty \u001b[90m[type-empty]\u001b[39m\r\n\u001b[1m\u001b[31m✖\u001b[39m   commitlint found 2 problems, 0 warnings\u001b[22m\r\n"
     ],
     [
       0.058677,
@@ -218,7 +218,7 @@
     ],
     [
       0.000581,
-      "\u001b[31m✖\u001b[39m   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] \u001b[90m[type-enum]\u001b[39m\r\n\u001b[1m\u001b[31m✖\u001b[39m   found 1 problems, 0 warnings\u001b[22m\r\n"
+      "\u001b[31m✖\u001b[39m   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] \u001b[90m[type-enum]\u001b[39m\r\n\u001b[1m\u001b[31m✖\u001b[39m   commitlint found 1 problems, 0 warnings\u001b[22m\r\n"
     ],
     [
       0.058213,
@@ -458,7 +458,7 @@
     ],
     [
       0.00037,
-      "\u001b[31m✖\u001b[39m   scope must be one of [cli, commitlint-config-angular, commitlint-config-lerna-scopes, commitlint-config-patternplate, config-angular, config-lerna-scopes, config-patternplate, core, example-prompt, prompt-cli, prompt, utils] \u001b[90m[scope-enum]\u001b[39m\r\n\u001b[1m\u001b[31m✖\u001b[39m   found 1 problems, 0 warnings\u001b[22m\r\n"
+      "\u001b[31m✖\u001b[39m   scope must be one of [cli, commitlint-config-angular, commitlint-config-lerna-scopes, commitlint-config-patternplate, config-angular, config-lerna-scopes, config-patternplate, core, example-prompt, prompt-cli, prompt, utils] \u001b[90m[scope-enum]\u001b[39m\r\n\u001b[1m\u001b[31m✖\u001b[39m   commitlint found 1 problems, 0 warnings\u001b[22m\r\n"
     ],
     [
       0.059556,
@@ -576,7 +576,7 @@
     ],
     [
       0.000452,
-      "\u001b[1m\u001b[32m✔\u001b[39m   found 0 problems, 0 warnings\u001b[22m\r\n"
+      "\u001b[1m\u001b[32m✔\u001b[39m   commitlint found 0 problems, 0 warnings\u001b[22m\r\n"
     ],
     [8.4e-5, "\r\n"],
     [

--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -68,7 +68,7 @@ No staged files match any of provided globs.
 ⧗   input: foo: this will fail
 ✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]
 
-✖   found 1 problems, 0 warnings
+✖   commitlint found 1 problems, 0 warnings
 ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
 
 husky > commit-msg hook failed (add --no-verify to bypass)

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -74,7 +74,7 @@ format(report?: Report = {}, options?: formatOptions = {}) => string[];
 ```js
 const format = require('@commitlint/format').default;
 
-format(); // => [ '\u001b[1m\u001b[32m✔\u001b[39m   found 0 problems, 0 warnings\u001b[22m' ]
+format(); // => [ '\u001b[1m\u001b[32m✔\u001b[39m   commitlint found 0 problems, 0 warnings\u001b[22m' ]
 
 format(
   {
@@ -110,7 +110,7 @@ format(
   '✖   This will show up red as it has level 2 [some-error]',
   '    This will not show up as it has level 0 [some-hint]',
   '⚠   This will show up yellow as it has level 1 [some-warning]',
-  '✖   found 1 problems, 2 warnings'
+  '✖   commitlint found 1 problems, 2 warnings'
 ] */
 ```
 


### PR DESCRIPTION

## Description

Added a single word to the output that shows where errors or warnings were found.  Clarify to the end user 

## Motivation and Context

I just spent an hour listening to a friend who just got a new job, and so he is going through all of the normal on-boarding and steep learning curves that hit a new person all at once.  He encountered this commitlint error, and it provided yet-another diversion (see "yak shaving") from his intended task.  I sympathized, but also wondered why commitlint did not mention its name anywhere in the error message.  Just saying the name might help someone who is Googling (although I was also able to search just the raw error message).  I just felt like this one-word change might help someone.

## Usage examples

```sh
echo "foo" | commitlint  # fails
⧗   input: foo
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]

✖   commitlint found 2 problems, 0 warnings
```

## How Has This Been Tested?

Since I do not run javascript or typescript at all, I did not test this change.  However, from inspection, it looks like this would work correctly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
