### PR TITLE
docs: husky add .husky/commit-msg docs fix

### DIFF
--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -40,7 +40,7 @@ yarn husky install
 cat <<EEE > .husky/commit-msg
 #!/bin/sh
 . "\$(dirname "\$0")/_/husky.sh"
- 
+
 npx --no -- commitlint --edit "\${1}"
 EEE
 

--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -37,9 +37,13 @@ npx husky install
 yarn husky install
 
 # Add hook
-npx husky add .husky/commit-msg 'npx --no -- commitlint --edit $1'
-# or
-yarn husky add .husky/commit-msg 'yarn commitlint --edit $1'
+cat <<EEE > .husky/commit-msg
+#!/bin/sh
+. "\$(dirname "\$0")/_/husky.sh"
+ 
+npx --no -- commitlint --edit "\${1}"
+EEE
+
 ```
 
 **Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)**\


### PR DESCRIPTION
Executing 

```

npx husky add .husky/commit-msg 'npx --no -- commitlint --edit $1'
# or
yarn husky add .husky/commit-msg 'yarn commitlint --edit $1'

```

doesn't seem to produce desired .husky/commit-msg file content

```
#!/bin/sh
. "$(dirname "$0")/_/husky.sh"

npx --no -- commitlint --edit $1
```

instead it produces

```
#!/bin/sh
. "$(dirname "$0")/_/husky.sh"

npx --no -- commitlint --edit 
```

because $1 is interpolated, adding slash doesn't seem to help, hence suggested fix (fix is bit ugly I admit, up to you guys to accept it or fixing it your way)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
