### PR TITLE
fix(rules): footer-leading-blank should work with body comments

### DIFF
--- a/@commitlint/rules/src/footer-leading-blank.test.ts
+++ b/@commitlint/rules/src/footer-leading-blank.test.ts
@@ -8,6 +8,8 @@ const messages = {
 	without: 'test: subject\nbody\nBREAKING CHANGE: something important',
 	withoutBody:
 		'feat(new-parser): introduces a new parsing library\n\nBREAKING CHANGE: new library does not support foo-construct',
+	withBodyWithComment:
+		'feat(new-parser): introduces a new parsing library\n\nBody Line 1\n# comment\nBody Line 2\n\nBREAKING CHANGE: new library does not support foo-construct',
 	with: 'test: subject\nbody\n\nBREAKING CHANGE: something important',
 	withMulitLine:
 		'test: subject\nmulti\nline\nbody\n\nBREAKING CHANGE: something important',
@@ -20,6 +22,9 @@ const parsed = {
 	trailing: parse(messages.trailing),
 	without: parse(messages.without),
 	withoutBody: parse(messages.withoutBody),
+	withBodyWithComment: parse(messages.withBodyWithComment, undefined, {
+		commentChar: '#',
+	}),
 	with: parse(messages.with),
 	withMulitLine: parse(messages.withMulitLine),
 	withDoubleNewLine: parse(messages.withDoubleNewLine),
@@ -153,6 +158,15 @@ test('with double blank line before footer and double line in body should fail f
 
 test('with double blank line before footer and double line in body should succeed for "always"', async () => {
 	const [actual] = footerLeadingBlank(await parsed.withDoubleNewLine, 'always');
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('with body containing comments should succeed for "always"', async () => {
+	const [actual] = footerLeadingBlank(
+		await parsed.withBodyWithComment,
+		'always'
+	);
 	const expected = true;
 	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/footer-leading-blank.ts
+++ b/@commitlint/rules/src/footer-leading-blank.ts
@@ -10,9 +10,9 @@ export const footerLeadingBlank: SyncRule = (parsed, when = 'always') => {
 
 	const negated = when === 'never';
 	const rawLines = toLines(parsed.raw);
-	const bodyLines = parsed.body ? toLines(parsed.body) : [];
-	const bodyOffset = bodyLines.length > 0 ? rawLines.indexOf(bodyLines[0]) : 1;
-	const [leading] = rawLines.slice(bodyLines.length + bodyOffset);
+	const footerLines = toLines(parsed.footer);
+	const footerOffset = rawLines.indexOf(footerLines[0]);
+	const [leading] = rawLines.slice(footerOffset - 1);
 
 	// Check if the first line of footer is empty
 	const succeeds = leading === '';

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Features will only be applied to the current main version.
 
 _Dates are subject to change._
 
-We're not a sponsored OSS project. Therefor we can't promise that we will release patch versions for older releases in a timley manner.\
+We're not a sponsored OSS project. Therefore we can't promise that we will release patch versions for older releases in a timely manner.\
 If you are stuck on an older version and need a security patch we're happy if you can provide a PR.
 
 ## Related projects


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`footer-leading-blank` had a bug: It calculated the start line of the body and added the number of body lines to identify the line before the footer. This will not work if the body contains a comment line, as it is not counted as "body line".

The new implementation looks for the first footer line and selects the line before.

This way the line above the footer will be identified correctly, assumed the first footer line is not existent as a previous line in the body.

Example of bug: `bodyLines.length` will be 2 in the following example, as the comment was filtered out
```
feat: feature

Body Line 1        <-- this line was identified as first body line
# comment         <-- this line must be the last line of the body as the body is 2 lines long
Body Line 2        <-- this is the line after the body as it is line 3 + 2 and therefore it should be empty

footer: value
```

## Motivation and Context

See description.

Closes #3120

## Usage examples

```js
// commitlint.config.js
module.exports = {
  rules: {
    'footer-leading-blank': [2, 'always']
  },
  parserPreset: {
    parserOpts: {
      commentChar: '#'
    }
  }
};
```

```sh
echo "feat: feature\n\nBody Line 1\n# comment\nBody Line 2\n\nBREAKING CHANGE: breaks" | commitlint # passes after fix
```

## How Has This Been Tested?

Added a test case which fails before the bug was fixed, but now passes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
