### PR TITLE
Since it doesn't work well anyway,let's replace it

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,18 +104,23 @@ yarn add husky --dev
 npx husky install
 # or
 yarn husky install
+```
 
-# Add hook
-npx husky add .husky/commit-msg 'npx --no -- commitlint --edit "$1"'
-# Sometimes above command doesn't work in some command interpreters
-# You can try other commands below to write npx --no -- commitlint --edit $1
-# in the commit-msg file.
-npx husky add .husky/commit-msg \"npx --no -- commitlint --edit '$1'\"
-# or
-npx husky add .husky/commit-msg "npx --no -- commitlint --edit $1"
+### Add hook
 
-# or
-yarn husky add .husky/commit-msg 'yarn commitlint --edit $1'
+```sh
+cat <<EEE > .husky/commit-msg
+#!/bin/sh
+. "\$(dirname "\$0")/_/husky.sh"
+
+npx --no -- commitlint --edit "\${1}"
+EEE
+```
+
+Make hook executable
+
+```sh
+chmod a+x .husky/commit-msg
 ```
 
 Check the [husky documentation](https://typicode.github.io/husky/#/?id=manual) on how you can automatically have Git hooks enabled after install for different `yarn` versions.


### PR DESCRIPTION
Process of registering commit-msg hook doesn't seem to be reliable, let's maybe replace it with solution suggested in other PR https://github.com/conventional-changelog/commitlint/pull/3113

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
