### PR TITLE
docs: replace all `git.io` links with their actual urls

### DIFF
--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -248,8 +248,8 @@ async function main(args: MainArgs) {
 					name: 'empty-rules',
 					message: [
 						'Please add rules to your `commitlint.config.js`',
-						'    - Getting started guide: https://git.io/fhHij',
-						'    - Example config: https://git.io/fhHip',
+						'    - Getting started guide: https://commitlint.js.org/#/?id=getting-started',
+						'    - Example config: https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/index.js',
 					].join('\n'),
 				},
 			],

--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ If you are stuck on an older version and need a security patch we're happy if yo
 
 ## Related projects
 
-- [conventional-changelog](https://git.io/v18sw) – Generate a changelog from conventional commit history
-- [commitizen](https://git.io/vwTym) – Simple commit conventions for internet citizens
-- [create-semantic-module](https://git.io/vFjFg) – CLI for quickly integrating commitizen and commitlint in new or existing projects
+- [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) – Generate a changelog from conventional commit history
+- [commitizen](https://github.com/commitizen/cz-cli) – Simple commit conventions for internet citizens
+- [create-semantic-module](https://github.com/jlegrone/create-semantic-module) – CLI for quickly integrating commitizen and commitlint in new or existing projects
 
 ## License
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace git.io within the error message with its original URL.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
