### PR TITLE
feat: add ability to filter Nx projects in @commitlint/config-nx-scopes

### DIFF
--- a/@commitlint/config-nx-scopes/index.js
+++ b/@commitlint/config-nx-scopes/index.js
@@ -8,7 +8,7 @@ module.exports = {
 	},
 };
 
-function getProjects(context) {
+function getProjects(context, filterFunc) {
 	return Promise.resolve()
 		.then(() => {
 			const ctx = context || {};
@@ -24,6 +24,15 @@ function getProjects(context) {
 		})
 		.then((projects) => {
 			return projects
+				.filter((project) =>
+					filterFunc
+						? filterFunc({
+								name: project.name,
+								type: project.projectType,
+								tags: project.tags,
+						  })
+						: true
+				)
 				.filter((project) => project.targets)
 				.map((project) => project.name)
 				.map((name) => (name.charAt(0) === '@' ? name.split('/')[1] : name));

--- a/@commitlint/config-nx-scopes/index.js
+++ b/@commitlint/config-nx-scopes/index.js
@@ -8,7 +8,10 @@ module.exports = {
 	},
 };
 
-function getProjects(context, filterFunc) {
+/**
+ * @param {(params: Pick<Nx.ProjectConfiguration, 'name' | 'projectType' | 'tags'>) => boolean} selector
+ */
+function getProjects(context, selector = () => true) {
 	return Promise.resolve()
 		.then(() => {
 			const ctx = context || {};
@@ -25,13 +28,11 @@ function getProjects(context, filterFunc) {
 		.then((projects) => {
 			return projects
 				.filter((project) =>
-					filterFunc
-						? filterFunc({
-								name: project.name,
-								type: project.projectType,
-								tags: project.tags,
-						  })
-						: true
+					selector({
+						name: project.name,
+						projectType: project.projectType,
+						tags: project.tags,
+					})
 				)
 				.filter((project) => project.targets)
 				.map((project) => project.name)

--- a/@commitlint/config-nx-scopes/readme.md
+++ b/@commitlint/config-nx-scopes/readme.md
@@ -14,7 +14,7 @@ echo "module.exports = {extends: ['@commitlint/config-nx-scopes']};" > commitlin
 
 ## Filtering projects
 
-You can filter projects by providing a filter function as the second parameter to `getProjects()`. The function will be called with an object containing each projects' `name`, `type`, and `tags`. Simply return a boolean to indicate whether the project should be included or not.
+You can filter projects by providing a filter function as the second parameter to `getProjects()`. The function will be called with an object containing each projects' `name`, `projectType`, and `tags`. Simply return a boolean to indicate whether the project should be included or not.
 
 As an example, the following code demonstrates how to select only applications that are not end-to-end tests.
 

--- a/@commitlint/config-nx-scopes/readme.md
+++ b/@commitlint/config-nx-scopes/readme.md
@@ -14,7 +14,7 @@ echo "module.exports = {extends: ['@commitlint/config-nx-scopes']};" > commitlin
 
 ## Filtering projects
 
-You can filter projects by providing a filter function as the second parameter to `getProjects()`. The function will be called with each projects' `name`, `type`, and `tags`. Simply return a boolean to indicate whether the project should be included or not.
+You can filter projects by providing a filter function as the second parameter to `getProjects()`. The function will be called with an object containing each projects' `name`, `type`, and `tags`. Simply return a boolean to indicate whether the project should be included or not.
 
 As an example, the following code demonstrates how to select only applications that are not end-to-end tests.
 

--- a/@commitlint/config-nx-scopes/readme.md
+++ b/@commitlint/config-nx-scopes/readme.md
@@ -12,6 +12,28 @@ npm install --save-dev @commitlint/config-nx-scopes @commitlint/cli
 echo "module.exports = {extends: ['@commitlint/config-nx-scopes']};" > commitlint.config.js
 ```
 
+## Filtering projects by type
+
+You can filter projects by type by specifying the project type parameter.
+
+In your .commitlintrc.js file:
+
+```javascript
+const {
+  utils: {getProjects},
+} = require('@commitlint/config-nx-scopes');
+
+module.exports = {
+  rules: {
+    'scope-enum': async (ctx) => [
+      2,
+      'always',
+      [...(await getProjects(ctx, 'application'))], // ⬅ or 'library'
+    ],
+  },
+};
+```
+
 ## Examples
 
 ```

--- a/@commitlint/config-nx-scopes/readme.md
+++ b/@commitlint/config-nx-scopes/readme.md
@@ -12,9 +12,11 @@ npm install --save-dev @commitlint/config-nx-scopes @commitlint/cli
 echo "module.exports = {extends: ['@commitlint/config-nx-scopes']};" > commitlint.config.js
 ```
 
-## Filtering projects by type
+## Filtering projects
 
-You can filter projects by type by specifying the project type parameter.
+You can filter projects by providing a filter function as the second parameter to `getProjects()`. The function will be called with each projects' `name`, `type`, and `tags`. Simply return a boolean to indicate whether the project should be included or not.
+
+As an example, the following code demonstrates how to select only applications that are not end-to-end tests.
 
 In your .commitlintrc.js file:
 
@@ -28,9 +30,41 @@ module.exports = {
     'scope-enum': async (ctx) => [
       2,
       'always',
-      [...(await getProjects(ctx, 'application'))], // ⬅ or 'library'
+      [
+        ...(await getProjects(
+          ctx,
+          ({name, type}) => !name.includes('e2e') && type == 'application'
+        )),
+      ],
     ],
   },
+  // . . .
+};
+```
+
+Here is another example where projects tagged with 'stage:end-of-life' are not allowed to be used as the scope for a commit.
+
+In your .commitlintrc.js file:
+
+```javascript
+const {
+  utils: {getProjects},
+} = require('@commitlint/config-nx-scopes');
+
+module.exports = {
+  rules: {
+    'scope-enum': async (ctx) => [
+      2,
+      'always',
+      [
+        ...(await getProjects(
+          ctx,
+          ({tags}) => !tags.includes('stage:end-of-life')
+        )),
+      ],
+    ],
+  },
+  // . . .
 };
 ```
 

--- a/@commitlint/config-nx-scopes/readme.md
+++ b/@commitlint/config-nx-scopes/readme.md
@@ -33,7 +33,8 @@ module.exports = {
       [
         ...(await getProjects(
           ctx,
-          ({name, type}) => !name.includes('e2e') && type == 'application'
+          ({name, projectType}) =>
+            !name.includes('e2e') && projectType == 'application'
         )),
       ],
     ],


### PR DESCRIPTION
## Description

Adds the ability to filter the scopes provided by @commitlint/config-nx-scopes by Nx project type (e.g. only load projects of type 'application')

## Motivation and Context

Users of Nx repos with lots of libraries may not want _every project_ available as an option for a commit's scope.

## Usage examples

```js
const {
  utils: { getProjects }
} = require('@commitlint/config-nx-scopes')

module.exports = {
  rules: {
    'scope-enum': async ctx => [
      2,
      'always',
      [...(await getProjects(ctx, 'application'))]  // ⬅ or 'library'
    ]
  }
}
```

## How Has This Been Tested?

`npm link` and used locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Solves: #3152 