### PR TITLE
docs: remove scope-case rule #3157

### DIFF
--- a/@commitlint/config-conventional/README.md
+++ b/@commitlint/config-conventional/README.md
@@ -74,21 +74,6 @@ echo ": some message" # fails
 echo "fix: some message" # passes
 ```
 
-#### scope-case
-
-- **condition**: `scope` is in case `value`
-- **rule**: `always`
-- **level**: `error`
-
-```
-'lowerCase'
-```
-
-```sh
-echo "fix(SCOPE): some message" # fails
-echo "fix(scope): some message" # passes
-```
-
 #### subject-case
 
 - **condition**: `subject` is in one of the cases `['sentence-case', 'start-case', 'pascal-case', 'upper-case']`


### PR DESCRIPTION
## Description
&emsp;Removed `scope-case` rule from [@commitlint/config-conventional/README.md](https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/README.md) to update the documentation.

## Motivation and Context
&emsp;I referenced to the #828 . The pr modified [@commitlint/config-conventional/index.js](https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/index.js). Verification of scope-case has been removed. But the documentation was not updated together.
&emsp;And to fix #3157 .

## Usage examples
&emsp;Removed the following contents from the documentation. 

#### scope-case

- **condition**: `scope` is in case `value`
- **rule**: `always`
- **level**: `error`

```
'lowerCase'
```

```sh
echo "fix(SCOPE): some message" # fails
echo "fix(scope): some message" # passes
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
