### PR TITLE
docs: align subject case rule in readme #3159

### DIFF
--- a/@commitlint/config-conventional/README.md
+++ b/@commitlint/config-conventional/README.md
@@ -92,7 +92,7 @@ echo "fix(scope): some message" # passes
 #### subject-case
 
 - **condition**: `subject` is in one of the cases `['sentence-case', 'start-case', 'pascal-case', 'upper-case']`
-- **rule**: `never`
+- **rule**: `always`
 - **level**: `error`
 
 ```sh

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -278,12 +278,12 @@ Infinity
 
 #### subject-case
 
-- **condition**: `subject` is in case `value`
+- **condition**: `subject` is in one of the cases `['sentence-case', 'start-case', 'pascal-case', 'upper-case']`
 - **rule**: `always`
 - **value**
 
 ```
-'lower-case'
+['sentence-case', 'start-case', 'pascal-case', 'upper-case']
 ```
 
 - **possible values**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
&emsp;Update the `scope-case` rule in [docs/reference-rules.md](https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md) and [@commitlint/config-conventional/README.md](https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/README.md) to be same.

## Motivation and Context
&emsp;To fix #3159.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
