### PR TITLE
chore(config-validator): update ajv to v8

### DIFF
--- a/@commitlint/config-validator/package.json
+++ b/@commitlint/config-validator/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@commitlint/types": "^17.0.0",
-    "ajv": "^6.12.6"
+    "ajv": "^8.11.0"
   },
   "gitHead": "d829bf6260304ca8d6811f329fcdd1b6c50e9749"
 }

--- a/@commitlint/config-validator/src/__snapshots__/validate.test.ts.snap
+++ b/@commitlint/config-validator/src/__snapshots__/validate.test.ts.snap
@@ -2,134 +2,134 @@
 
 exports[`validation should fail for defaultIgnoresNotBoolean 1`] = `
 "Commitlint configuration in defaultIgnoresNotBoolean.js is invalid:
-	- Property \\"defaultIgnores\\" has the wrong type - should be boolean.
+	- Property \\"defaultIgnores\\" has the wrong type - must be boolean.
 "
 `;
 
 exports[`validation should fail for extendsAsObject 1`] = `
 "Commitlint configuration in extendsAsObject.js is invalid:
-	- Property \\"extends\\" has the wrong type - should be array.
-	- Property \\"extends\\" has the wrong type - should be string.
-	- \\"extends\\" should match exactly one schema in oneOf. Value: {\\"test\\":1}.
+	- Property \\"extends\\" has the wrong type - must be array.
+	- Property \\"extends\\" has the wrong type - must be string.
+	- \\"/extends\\" must match exactly one schema in oneOf. Value: {\\"test\\":1}.
 "
 `;
 
 exports[`validation should fail for extendsWithFunction 1`] = `
 "Commitlint configuration in extendsWithFunction.js is invalid:
-	- Property \\"extends[0]\\" has the wrong type - should be string.
-	- Property \\"extends\\" has the wrong type - should be string.
-	- \\"extends\\" should match exactly one schema in oneOf. Value: [null].
+	- Property \\"extends/0\\" has the wrong type - must be string.
+	- Property \\"extends\\" has the wrong type - must be string.
+	- \\"/extends\\" must match exactly one schema in oneOf. Value: [null].
 "
 `;
 
 exports[`validation should fail for formatterAsObject 1`] = `
 "Commitlint configuration in formatterAsObject.js is invalid:
-	- Property \\"formatter\\" has the wrong type - should be string.
+	- Property \\"formatter\\" has the wrong type - must be string.
 "
 `;
 
 exports[`validation should fail for helpUrlAsArray 1`] = `
 "Commitlint configuration in helpUrlAsArray.js is invalid:
-	- Property \\"helpUrl\\" has the wrong type - should be string.
+	- Property \\"helpUrl\\" has the wrong type - must be string.
 "
 `;
 
 exports[`validation should fail for helpUrlNotString 1`] = `
 "Commitlint configuration in helpUrlNotString.js is invalid:
-	- Property \\"helpUrl\\" has the wrong type - should be string.
+	- Property \\"helpUrl\\" has the wrong type - must be string.
 "
 `;
 
 exports[`validation should fail for ignoresFunction 1`] = `
 "Commitlint configuration in ignoresFunction.js is invalid:
-	- Property \\"ignores\\" has the wrong type - should be array.
+	- Property \\"ignores\\" has the wrong type - must be array.
 "
 `;
 
 exports[`validation should fail for ignoresNotFunction 1`] = `
 "Commitlint configuration in ignoresNotFunction.js is invalid:
-	- \\"ignores[0]\\" should be a function. Value: 1.
+	- \\"/ignores/0\\" should be a function. Value: 1.
 "
 `;
 
 exports[`validation should fail for parserPreset 1`] = `
 "Commitlint configuration in parserPreset.js is invalid:
-	- Property \\"parserPreset\\" has the wrong type - should be string.
-	- Property \\"parserPreset\\" has the wrong type - should be object.
-	- \\"parserPreset\\" should be a function. Value: [].
-	- \\"parserPreset\\" should match exactly one schema in oneOf. Value: [].
+	- Property \\"parserPreset\\" has the wrong type - must be string.
+	- Property \\"parserPreset\\" has the wrong type - must be object.
+	- \\"/parserPreset\\" should be a function. Value: [].
+	- \\"/parserPreset\\" must match exactly one schema in oneOf. Value: [].
 "
 `;
 
 exports[`validation should fail for pluginsNotArray 1`] = `
 "Commitlint configuration in pluginsNotArray.js is invalid:
-	- Property \\"plugins\\" has the wrong type - should be array.
+	- Property \\"plugins\\" has the wrong type - must be array.
 "
 `;
 
 exports[`validation should fail for rules1 1`] = `
 "Commitlint configuration in rules1.js is invalid:
-	- \\"rules['a'][0]\\" should be equal to one of the allowed values. Value: 3.
-	- \\"rules['a']\\" should be a function. Value: [3].
-	- \\"rules['a']\\" should match exactly one schema in oneOf. Value: [3].
+	- \\"/rules/a/0\\" must be equal to one of the allowed values. Value: 3.
+	- \\"/rules/a\\" should be a function. Value: [3].
+	- \\"/rules/a\\" must match exactly one schema in oneOf. Value: [3].
 "
 `;
 
 exports[`validation should fail for rules2 1`] = `
 "Commitlint configuration in rules2.js is invalid:
-	- \\"rules['b']\\" should NOT have more than 3 items. Value: [1,\\"test\\",2,2].
-	- \\"rules['b']\\" should be a function. Value: [1,\\"test\\",2,2].
-	- \\"rules['b']\\" should match exactly one schema in oneOf. Value: [1,\\"test\\",2,2].
+	- \\"/rules/b\\" must NOT have more than 3 items. Value: [1,\\"test\\",2,2].
+	- \\"/rules/b\\" should be a function. Value: [1,\\"test\\",2,2].
+	- \\"/rules/b\\" must match exactly one schema in oneOf. Value: [1,\\"test\\",2,2].
 "
 `;
 
 exports[`validation should fail for rules3 1`] = `
 "Commitlint configuration in rules3.js is invalid:
-	- \\"rules['c']\\" should NOT have fewer than 1 items. Value: [].
-	- \\"rules['c']\\" should be a function. Value: [].
-	- \\"rules['c']\\" should match exactly one schema in oneOf. Value: [].
+	- \\"/rules/c\\" must NOT have fewer than 1 items. Value: [].
+	- \\"/rules/c\\" should be a function. Value: [].
+	- \\"/rules/c\\" must match exactly one schema in oneOf. Value: [].
 "
 `;
 
 exports[`validation should fail for rules4 1`] = `
 "Commitlint configuration in rules4.js is invalid:
-	- Property \\"rules['d'][0]\\" has the wrong type - should be number.
-	- \\"rules['d'][0]\\" should be equal to one of the allowed values. Value: [].
-	- \\"rules['d']\\" should be a function. Value: [[],[],[]].
-	- \\"rules['d']\\" should match exactly one schema in oneOf. Value: [[],[],[]].
+	- Property \\"rules/d/0\\" has the wrong type - must be number.
+	- \\"/rules/d/0\\" must be equal to one of the allowed values. Value: [].
+	- \\"/rules/d\\" should be a function. Value: [[],[],[]].
+	- \\"/rules/d\\" must match exactly one schema in oneOf. Value: [[],[],[]].
 "
 `;
 
 exports[`validation should fail for rules5 1`] = `
 "Commitlint configuration in rules5.js is invalid:
-	- Property \\"rules['e']\\" has the wrong type - should be array.
-	- \\"rules['e']\\" should be a function. Value: {}.
-	- \\"rules['e']\\" should match exactly one schema in oneOf. Value: {}.
+	- Property \\"rules/e\\" has the wrong type - must be array.
+	- \\"/rules/e\\" should be a function. Value: {}.
+	- \\"/rules/e\\" must match exactly one schema in oneOf. Value: {}.
 "
 `;
 
 exports[`validation should fail for rulesAsArray 1`] = `
 "Commitlint configuration in rulesAsArray.js is invalid:
-	- Property \\"rules\\" has the wrong type - should be object.
+	- Property \\"rules\\" has the wrong type - must be object.
 "
 `;
 
 exports[`validation should fail for whenConfigIsNotObject 1`] = `
 "Commitlint configuration in whenConfigIsNotObject.js is invalid:
-	- Config has the wrong type - should be object.
+	- Config has the wrong type - must be object.
 "
 `;
 
 exports[`validation should fail for whenConfigIsNotObject2 1`] = `
 "Commitlint configuration in whenConfigIsNotObject2.js is invalid:
-	- Config has the wrong type - should be object.
+	- Config has the wrong type - must be object.
 "
 `;
 
 exports[`validation should fail for withPluginsAsObject 1`] = `
 "Commitlint configuration in withPluginsAsObject.js is invalid:
-	- Property \\"plugins[0]\\" has the wrong type - should be string.
-	- \\"plugins[0]\\" should have required property '.rules'. Value: {}.
-	- \\"plugins[0]\\" should match some schema in anyOf. Value: {}.
+	- Property \\"plugins/0\\" has the wrong type - must be string.
+	- \\"/plugins/0\\" must have required property 'rules'. Value: {}.
+	- \\"/plugins/0\\" must match a schema in anyOf. Value: {}.
 "
 `;

--- a/@commitlint/config-validator/src/commitlint.schema.json
+++ b/@commitlint/config-validator/src/commitlint.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "default": {},
   "type": "object",
   "definitions": {
     "rule": {
@@ -82,8 +81,13 @@
         "anyOf": [
           {"type": "string"},
           {
+            "type": "object",
             "required": ["rules"],
-            "rules": {}
+            "properties": {
+              "rules": {
+                "type": "object"
+              }
+            }
           }
         ]
       }

--- a/@commitlint/config-validator/src/formatErrors.ts
+++ b/@commitlint/config-validator/src/formatErrors.ts
@@ -13,23 +13,23 @@ export function formatErrors(errors: ErrorObject[]): string {
 				error.keyword === 'additionalProperties' &&
 				'additionalProperty' in error.params
 			) {
-				const formattedPropertyPath = error.dataPath.length
-					? `${error.dataPath.slice(1)}.${error.params.additionalProperty}`
+				const formattedPropertyPath = error.instancePath.length
+					? `${error.instancePath.slice(1)}.${error.params.additionalProperty}`
 					: error.params.additionalProperty;
 
 				return `Unexpected top-level property "${formattedPropertyPath}"`;
 			}
 			if (error.keyword === 'type') {
-				const formattedField = error.dataPath.slice(1);
+				const formattedField = error.instancePath.slice(1);
 				if (!formattedField) {
 					return `Config has the wrong type - ${error.message}`;
 				}
 				return `Property "${formattedField}" has the wrong type - ${error.message}`;
 			}
 			const field =
-				(error.dataPath[0] === '.'
-					? error.dataPath.slice(1)
-					: error.dataPath) || 'Config';
+				(error.instancePath[0] === '.'
+					? error.instancePath.slice(1)
+					: error.instancePath) || 'Config';
 			if (error.keyword === 'typeof') {
 				return `"${field}" should be a ${error.schema}. Value: ${JSON.stringify(
 					error.data

--- a/@commitlint/config-validator/src/validate.ts
+++ b/@commitlint/config-validator/src/validate.ts
@@ -19,14 +19,14 @@ export function validateConfig(
 ): asserts config is UserConfig {
 	const ajv = new Ajv({
 		meta: false,
+		strict: false,
 		useDefaults: true,
 		validateSchema: false,
-		missingRefs: 'ignore',
 		verbose: true,
-		schemaId: 'auto',
 	});
 
-	ajv.addKeyword('typeof', {
+	ajv.addKeyword({
+		keyword: 'typeof',
 		validate: function typeOfFunc(schema: any, data: any) {
 			return typeof data === schema;
 		},

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,7 +3016,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.6:
+ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3024,6 +3024,16 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.6:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-align@^3.0.0:
@@ -6464,6 +6474,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -8383,7 +8398,7 @@ require-directory@^2.1.1:
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-from-string@2.0.2:
+require-from-string@2.0.2, require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==


### PR DESCRIPTION
## Description

ajv introduced some breaking changes from v6 to v7, and from v7 to v8. Most can
be found in [their migration guide](https://ajv.js.org/v6-to-v8-migration.html).

This commit addresses the following:

- `ErrorObject.dataPath` was renamed to `ErrorObject.instacePath`
- Wordings of some errors changed (e.g. "should" -> "must")
- Strict mode does not allow a top-level `default` value
- Strict tuple checking was confused by the `rule` array definition, see
[Unconstrained tuples](https://ajv.js.org/strict-mode.html#unconstrained-tuples)
- The `plugins` schema included an invalid object definition for `rules`
- `schemaId` is no longer an ajv option
- `missingRefs` no longer seems to affect the usage of ajv in the project
- `addKeyword` has its signature changed

The tests pass and everyone's seemingly happy; do say if anything's still
scary-looking.

## Motivation and Context

Obsoletes #2888.

## How Has This Been Tested?

Ran the unit tests, did a couple of manual smoke runs.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
