### PR TITLE
docs: correct subject case rule in readme config-conventional #3340

### DIFF
--- a/@commitlint/config-conventional/README.md
+++ b/@commitlint/config-conventional/README.md
@@ -77,7 +77,7 @@ echo "fix: some message" # passes
 #### subject-case
 
 - **condition**: `subject` is in one of the cases `['sentence-case', 'start-case', 'pascal-case', 'upper-case']`
-- **rule**: `always`
+- **rule**: `never`
 - **level**: `error`
 
 ```sh


### PR DESCRIPTION
## Description

Update subject-case rule in [@commitlint/config-conventional/README.md](https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/README.md).

## Motivation and Context

To fix #3340 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
