### PR TITLE
docs(README.md): update husky hook file creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ yarn husky install
 ### Add hook
 
 ```sh
-cat <<EEE > .husky/commit-msg
+echo '
 #!/bin/sh
 . "\$(dirname "\$0")/_/husky.sh"
 
-npx --no -- commitlint --edit "\${1}"
-EEE
+npx --no -- commitlint --edit ${1}
+' > .husky/commit-msg
 ```
 
 Make hook executable


### PR DESCRIPTION
updated the "commit-msg" hook creation. Fixed `ENOENT: no such file or directory, open` error on pre-commit

## Description
Following the docs mentioned [here](https://commitlint.js.org/#/guides-local-setup) I noticed 2 things.
1. The file creation portion doesn't work for me (using macOS Or WSL Ubuntu on Windows)
2. When I create the file manually - the commit-msg hooks gives the error `ENOENT: no such file or directory, open` error on pre-commit`


## Motivation and Context

1. updated the file creation to use echo and the output redirection operator.
2. noticed the error `ENOENT: no such file or directory, open` error on pre-commit` is to do with the sting interpellation.
changed the string from `"\${1}"` to `\${1}` (removed the quotes)

## Usage examples

In the root of the project directory, can now just run

```bash
echo '
#!/bin/sh
. "\$(dirname "\$0")/_/husky.sh"

npx --no -- commitlint --edit ${1}
' > .husky/commit-msg
```

## How Has This Been Tested?

I created a new folder structure on my desktop `.husky` and ran the command to see if the file gets created with the correct content inside of the file.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
