### PR TITLE
feat(cli): add strict mode (#3384)

### DIFF
--- a/@commitlint/cli/fixtures/warning/commitlint.config.js
+++ b/@commitlint/cli/fixtures/warning/commitlint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    rules: {
+        'type-enum': [2, 'always', ['feat']],
+        'subject-max-length': [1, 'always', 4]
+    }
+};

--- a/@commitlint/cli/src/cli-error.ts
+++ b/@commitlint/cli/src/cli-error.ts
@@ -2,11 +2,13 @@ export class CliError extends Error {
 	__proto__ = Error;
 
 	public type: string;
+	public error_code: number;
 
-	constructor(message: string, type: string) {
+	constructor(message: string, type: string, error_code = 1) {
 		super(message);
 
 		this.type = type;
+		this.error_code = error_code;
 
 		Object.setPrototypeOf(this, CliError.prototype);
 	}

--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -482,6 +482,24 @@ test('should work with relative formatter path', async () => {
 	expect(actual.exitCode).toBe(0);
 });
 
+test('strict: should exit with 3 on error', async () => {
+	const cwd = await gitBootstrap('fixtures/warning');
+	const actual = await cli(['--strict'], {cwd})('foo: abcdef');
+	expect(actual.exitCode).toBe(3);
+});
+
+test('strict: should exit with 2 on warning', async () => {
+	const cwd = await gitBootstrap('fixtures/warning');
+	const actual = await cli(['--strict'], {cwd})('feat: abcdef');
+	expect(actual.exitCode).toBe(2);
+});
+
+test('strict: should exit with 0 on success', async () => {
+	const cwd = await gitBootstrap('fixtures/warning');
+	const actual = await cli(['--strict'], {cwd})('feat: abc');
+	expect(actual.exitCode).toBe(0);
+});
+
 test('should print help', async () => {
 	const cwd = await gitBootstrap('fixtures/default');
 	const actual = await cli(['--help'], {cwd})();
@@ -507,7 +525,7 @@ test('should print help', async () => {
 		  -f, --from           lower end of the commit range to lint; applies if
 		                       edit=false                                       [string]
 		      --git-log-args   addditional git log arguments as space separated string,
-		                       example \'--first-parent --cherry-pick\'           [string]
+		                       example '--first-parent --cherry-pick'           [string]
 		  -o, --format         output format of the results                     [string]
 		  -p, --parser-preset  configuration preset to use for
 		                       conventional-commits-parser                      [string]
@@ -516,6 +534,8 @@ test('should print help', async () => {
 		                       edit=false                                       [string]
 		  -V, --verbose        enable verbose output for reports without problems
 		                                                                       [boolean]
+		  -s, --strict         enable strict mode; result code 2 for warnings, 3 for
+		                       errors                                          [boolean]
 		  -v, --version        display version information                     [boolean]
 		  -h, --help           Show help                                       [boolean]"
 	`);

--- a/@commitlint/cli/src/types.ts
+++ b/@commitlint/cli/src/types.ts
@@ -16,6 +16,7 @@ export interface CliFlags {
 	version?: boolean;
 	verbose?: boolean;
 	'print-config'?: boolean;
+	strict?: boolean;
 	_: (string | number)[];
 	$0: string;
 }


### PR DESCRIPTION
## Description

Added a flag which changes the result codes:
result codes (`-s, --strict`):
- 0 success
- 1 runtime error (e.g. invalid config)
- 2 linter warning
- 3 linter error

result codes (default):
- 0 success / linter warning
- 1 runtime error / linter error

## Motivation and Context
issue: #3384

## Usage examples

```js
// commitlint.config.js
module.exports = {
    rules: {
        'type-enum': [2, 'always', ['feat']],
        'subject-max-length': [1, 'always', 4]
    }
};
```

```sh
echo "feat: 12" | commitlint -s # exit 0
echo "feat: 12" | commitlint -s a # exit 1
echo "feat: 123456" | commitlint -s # exit 2
echo "feat2: 123456" | commitlint -s # exit 3
```

## How Has This Been Tested?

- Added new tests to the coverage
- all usage examples

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
