### PR TITLE
feat(config-nx-scopes): update nx dependency version to ^15.0.0

### DIFF
--- a/@commitlint/config-nx-scopes/package.json
+++ b/@commitlint/config-nx-scopes/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "peerDependencies": {
-    "nx": "^14.0.0"
+    "nx": "^14.0.0 || ^15.0.0"
   },
   "peerDependenciesMeta": {
     "nx": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update NX dev and peer dependencies version to version ^15.0.0

<!--- Describe your changes in detail -->

## Motivation and Context

Fixes #3413.

A new NX version was release some days ago and when you update NX in our repository, npm install fails with `Conflicting peer dependency: nx@14.8.6` as @commitlint/config-nx-scopes has a peerDependency set to ^14.0.0 for NX.

The way @commitlint/config-nx-scopes search for the scopes (NX projects) is not affected, so this is only an update in package.json. 

I also updated the fixture files to have the latest version format, but this does not affect this plugin.

I have changed the NX version in peerDependency to ^15.0.0 (instead of support both 14 and 15). Not sure if it is better to add it as `^14.0.0 || ^15.0.0`, if so, please let me know, and I will change it

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
