### PR TITLE
build: Expand lerna version range to accept v6

### DIFF
--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "peerDependencies": {
-    "lerna": "^5.0.0"
+    "lerna": "^5.0.0 || ^6"
   },
   "peerDependenciesMeta": {
     "lerna": {


### PR DESCRIPTION
See https://github.com/conventional-changelog/commitlint/issues/3409.

Even with the peerDependencies: optional, npm will *still* kick and scream and end your process if you try to use this with lerna v6.

Note that this is NOT a breaking change - and simply allows people with lerna v6 to work with the package. People on lerna v5 will not even notice the difference.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Allows this package to work with lerna v6

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
