### PR TITLE
chore: change globby library to glob

### DIFF
--- a/@commitlint/config-lerna-scopes/index.js
+++ b/@commitlint/config-lerna-scopes/index.js
@@ -1,7 +1,7 @@
+const glob = require('glob');
 const Path = require('path');
 const importFrom = require('import-from');
 const resolvePkg = require('resolve-pkg');
-const Globby = require('globby');
 const semver = require('semver');
 
 module.exports = {
@@ -21,14 +21,13 @@ function getPackages(context) {
 			const {workspaces} = require(Path.join(cwd, 'package.json'));
 			if (Array.isArray(workspaces) && workspaces.length) {
 				// use yarn workspaces
-				return Globby(
-					workspaces.map((ws) => {
-						return Path.posix.join(ws, 'package.json');
-					}),
-					{cwd, ignore: ['**/node_modules/**']}
-				).then((pJsons = []) => {
-					return pJsons.map((pJson) => require(Path.join(cwd, pJson)));
+
+				const wsGlobs = workspaces.flatMap((ws) => {
+					const path = Path.posix.join(ws, 'package.json');
+					return glob.sync(path, {cwd, ignore: ['**/node_modules/**']});
 				});
+
+				return wsGlobs.map((pJson) => require(Path.join(cwd, pJson)));
 			}
 
 			const lernaVersion = getLernaVersion(cwd);

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -38,7 +38,7 @@
     "node": ">=v14"
   },
   "dependencies": {
-    "globby": "^11.0.1",
+    "glob": "^8.0.3",
     "import-from": "4.0.0",
     "resolve-pkg": "2.0.0",
     "semver": "7.3.7"

--- a/@commitlint/config-patternplate/index.js
+++ b/@commitlint/config-patternplate/index.js
@@ -1,5 +1,5 @@
+const glob = require('glob');
 const path = require('path');
-const globby = require('globby');
 const merge = require('lodash.merge');
 
 function pathToId(root, filePath) {
@@ -9,10 +9,8 @@ function pathToId(root, filePath) {
 
 function getPatternIDs() {
 	const root = path.resolve(process.cwd(), './patterns');
-	const glob = path.resolve(root, '**/pattern.json');
-	return globby(glob).then((results) =>
-		results.map((result) => pathToId(root, result))
-	);
+	const pattern = path.resolve(root, '**/pattern.json');
+	return glob.sync(pattern).map((result) => pathToId(root, result));
 }
 
 module.exports = merge(require('@commitlint/config-angular'), {

--- a/@commitlint/config-patternplate/package.json
+++ b/@commitlint/config-patternplate/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@commitlint/config-angular": "^17.3.0",
-    "globby": "^11.0.0",
+    "glob": "^8.0.3",
     "lodash.merge": "^4.6.2"
   },
   "devDependencies": {

--- a/@commitlint/ensure/package.json
+++ b/@commitlint/ensure/package.json
@@ -41,7 +41,7 @@
     "@types/lodash.snakecase": "^4.1.7",
     "@types/lodash.startcase": "^4.4.7",
     "@types/lodash.upperfirst": "^4.3.7",
-    "globby": "^11.0.0"
+    "glob": "^8.0.3"
   },
   "dependencies": {
     "@commitlint/types": "^17.0.0",

--- a/@commitlint/ensure/src/index.test.ts
+++ b/@commitlint/ensure/src/index.test.ts
@@ -1,11 +1,11 @@
 import path from 'path';
-import globby from 'globby';
+import glob from 'glob';
 import camelCase from 'lodash.camelcase';
 import * as ensure from '.';
 
 test('exports all checkers', async () => {
 	const ignore = ['types'];
-	const expected = (await glob('*.ts'))
+	const expected = _glob('*.ts')
 		.map((f) => camelCase(f))
 		.sort()
 		.filter((item) => !ignore.includes(item));
@@ -18,8 +18,8 @@ test('rules export functions', () => {
 	expect(actual.every((rule) => typeof rule === 'function')).toBe(true);
 });
 
-async function glob(pattern: string): Promise<string[]> {
-	const files = await globby(pattern, {
+function _glob(pattern: string): string[] {
+	const files = glob.sync(pattern, {
 		ignore: ['**/index.ts', '**/*.test.ts'],
 		cwd: __dirname,
 	});

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -39,7 +39,7 @@
     "@commitlint/test": "^17.2.0",
     "@commitlint/utils": "^17.0.0",
     "conventional-changelog-angular": "5.0.13",
-    "globby": "^11.0.0"
+    "glob": "^8.0.3"
   },
   "dependencies": {
     "@commitlint/ensure": "^17.3.0",

--- a/@commitlint/rules/src/index.test.ts
+++ b/@commitlint/rules/src/index.test.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 import fs from 'fs';
-import globby from 'globby';
+import glob from 'glob';
 import rules from '.';
 
-test('exports all rules', async () => {
-	const expected = (await glob('*.ts')).sort();
+test('exports all rules', () => {
+	const expected = _glob('*.ts').sort();
 	const actual = Object.keys(rules).sort();
 	expect(actual).toEqual(expected);
 });
@@ -27,8 +27,8 @@ test('all rules are present in documentation', () => {
 	expect(Object.keys(rules)).toEqual(expect.arrayContaining(results));
 });
 
-async function glob(pattern: string | string[]) {
-	const files = await globby(pattern, {
+function _glob(pattern: string) {
+	const files = glob.sync(pattern, {
 		ignore: ['**/index.ts', '**/*.test.ts'],
 		cwd: __dirname,
 	});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6155,7 +6155,7 @@ glob@7.2.3, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.1:
+glob@^8.0.1, glob@^8.0.3:
   version "8.0.3"
   resolved "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
   integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
@@ -6212,7 +6212,7 @@ globals@^13.15.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.0, globby@^11.0.1, globby@^11.0.2, globby@^11.1.0:
+globby@^11.0.1, globby@^11.0.2, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- added `glob` as a dependency in the packages that used `globby`
- removed `globby` as a dependency
- replaced (mostly async) functions from `globby` with (sync) function from `glob`
- did one modification because `globby` accepted an array of string as param, but `glob` accepts only one string as param

## Motivation and Context

Closes #2370 

## How Has This Been Tested?

I ran all of the tests with the `yarn test` command. I'm not sure does this change needs new tests, but if so, I'm happy to add them.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
