### PR TITLE
chore: add syntax highlighting and format arrays in doc

### DIFF
--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -10,7 +10,7 @@ Rule configurations are either of type `array` residing on a key with the rule's
 
 **Plain array**
 
-```
+```js
   "rules": {
     "header-max-length": [0, "always", 72],
   }
@@ -18,7 +18,7 @@ Rule configurations are either of type `array` residing on a key with the rule's
 
 **Function returning array**
 
-```
+```js
   "rules": {
     "header-max-length": () => [0, "always", 72],
   }
@@ -26,7 +26,7 @@ Rule configurations are either of type `array` residing on a key with the rule's
 
 **Async function returning array**
 
-```
+```js
   "rules": {
     "header-max-length": async () => [0, "always", 72],
   }
@@ -34,7 +34,7 @@ Rule configurations are either of type `array` residing on a key with the rule's
 
 **Function returning a promise resolving to array**
 
-```
+```js
   "rules": {
     "header-max-length": () => Promise.resolve([0, "always", 72]),
   }
@@ -104,16 +104,16 @@ Infinity
 
 - **possible values**
 
-```
+```js
 [
-  'lower-case', // default
-  'upper-case', // UPPERCASE
-  'camel-case', // camelCase
-  'kebab-case', // kebab-case
-  'pascal-case', // PascalCase
+  'lower-case',    // default
+  'upper-case',    // UPPERCASE
+  'camel-case',    // camelCase
+  'kebab-case',    // kebab-case
+  'pascal-case',   // PascalCase
   'sentence-case', // Sentence case
-  'snake-case', // snake_case
-  'start-case' // Start Case
+  'snake-case',    // snake_case
+  'start-case'     // Start Case
 ]
 ```
 
@@ -169,16 +169,16 @@ Infinity
 
 - **possible values**
 
-```
+```js
 [
-  'lower-case', // default
-  'upper-case', // UPPERCASE
-  'camel-case', // camelCase
-  'kebab-case', // kebab-case
-  'pascal-case', // PascalCase
+  'lower-case',    // default
+  'upper-case',    // UPPERCASE
+  'camel-case',    // camelCase
+  'kebab-case',    // kebab-case
+  'pascal-case',   // PascalCase
   'sentence-case', // Sentence case
-  'snake-case', // snake_case
-  'start-case' // Start Case
+  'snake-case',    // snake_case
+  'start-case'     // Start Case
 ]
 ```
 
@@ -238,16 +238,16 @@ Infinity
 
 - **possible values**
 
-```
+```js
 [
-  'lower-case', // default
-  'upper-case', // UPPERCASE
-  'camel-case', // camelCase
-  'kebab-case', // kebab-case
-  'pascal-case', // PascalCase
+  'lower-case',    // default
+  'upper-case',    // UPPERCASE
+  'camel-case',    // camelCase
+  'kebab-case',    // kebab-case
+  'pascal-case',   // PascalCase
   'sentence-case', // Sentence case
-  'snake-case', // snake_case
-  'start-case' // Start Case
+  'snake-case',    // snake_case
+  'start-case'     // Start Case
 ]
 ```
 
@@ -282,22 +282,22 @@ Infinity
 - **rule**: `always`
 - **value**
 
-```
+```js
 ['sentence-case', 'start-case', 'pascal-case', 'upper-case']
 ```
 
 - **possible values**
 
-```
+```js
 [
-  'lower-case', // default
-  'upper-case', // UPPERCASE
-  'camel-case', // camelCase
-  'kebab-case', // kebab-case
-  'pascal-case', // PascalCase
+  'lower-case',    // default
+  'upper-case',    // UPPERCASE
+  'camel-case',    // camelCase
+  'kebab-case',    // kebab-case
+  'pascal-case',   // PascalCase
   'sentence-case', // Sentence case
-  'snake-case', // snake_case
-  'start-case' // Start Case
+  'snake-case',    // snake_case
+  'start-case'.    // Start Case
 ]
 ```
 
@@ -346,7 +346,7 @@ Infinity
 - **condition**: `type` is found in value
 - **rule**: `always`
 - **value**
-  ```
+  ```js
   ['feat', 'fix', 'docs', 'style', 'refactor', 'test', 'revert']
   ```
 
@@ -360,16 +360,16 @@ Infinity
   ```
 - **possible values**
 
-```
+```js
 [
-  'lower-case', // default
-  'upper-case', // UPPERCASE
-  'camel-case', // camelCase
-  'kebab-case', // kebab-case
-  'pascal-case', // PascalCase
+  'lower-case',    // default
+  'upper-case',    // UPPERCASE
+  'camel-case',    // camelCase
+  'kebab-case',    // kebab-case
+  'pascal-case',   // PascalCase
   'sentence-case', // Sentence case
-  'snake-case', // snake_case
-  'start-case' // Start Case
+  'snake-case',    // snake_case
+  'start-case'     // Start Case
 ];
 ```
 


### PR DESCRIPTION
This is just a doc formatting update. I added syntax highlighting to code examples, and aligned the comments in the arrays to make them easier to read

## Description

The change is from this:

```js
  'sentence-case', // Sentence case
  'snake-case', // snake_case
  'start-case' // Start Case
```

to this:

```js
  'sentence-case', // Sentence case
  'snake-case',    // snake_case
  'start-case'     // Start Case
```

## Motivation and Context

This makes it easier to parse the list of rules and definitions at a glance.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
