### PR TITLE
chore: move @types/node to devDependencies

### DIFF
--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -40,6 +40,7 @@
     "@types/lodash.isplainobject": "^4.0.7",
     "@types/lodash.merge": "^4.6.7",
     "@types/lodash.uniq": "^4.5.7",
+    "@types/node": "^14.0.0",
     "conventional-changelog-atom": "^2.0.8",
     "execa": "^5.0.0"
   },
@@ -48,7 +49,6 @@
     "@commitlint/execute-rule": "^17.0.0",
     "@commitlint/resolve-extends": "^17.3.0",
     "@commitlint/types": "^17.0.0",
-    "@types/node": "^14.0.0",
     "chalk": "^4.1.0",
     "cosmiconfig": "^8.0.0",
     "cosmiconfig-typescript-loader": "^4.0.0",


### PR DESCRIPTION
## Description

Moved the `@types/node` from `dependencies` to `devDependencies`

## Motivation and Context
I am using a mono repo and all my packages use a single version of `@types/node`. Since, the `@types/node` in this `@commitlint/load` package is very old and doesn't match the version in my projects, it creates a different node_modules directory for all my sub-projects because of this version mis-match.

## How Has This Been Tested?

Build succeeds

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
