### PR TITLE
fix: stop truncating the body in presence of dashes

### DIFF
--- a/@commitlint/parse/src/index.test.ts
+++ b/@commitlint/parse/src/index.test.ts
@@ -168,6 +168,25 @@ test('registers inline #', async () => {
 	expect(actual.body).toBe('things #reference');
 });
 
+test('keep -side notes- in the body section', async () => {
+	const header = "type(some/scope): subject"
+	const body = 
+		"CI on master branch caught this:\n\n" +
+		"```\n" +
+		"Unhandled Exception:\n" +
+		"System.AggregateException: One or more errors occurred. (Some problem when connecting to 'api.mycryptoapi.com/eth')\n\n" +
+		"--- End of stack trace from previous location where exception was thrown ---\n\n" +
+		"at GWallet.Backend.FSharpUtil.ReRaise (System.Exception ex) [0x00000] in /Users/runner/work/geewallet/geewallet/src/GWallet.Backend/FSharpUtil.fs:206\n" +
+		"...\n" +
+		"```";
+
+	const message = header + "\n\n" + body
+
+	const actual = await parse(message);
+
+	expect(actual.body).toBe(body);
+});
+
 test('parses references leading subject', async () => {
 	const message = '#1 some subject';
 	const opts = await require('conventional-changelog-angular');

--- a/@commitlint/parse/src/index.ts
+++ b/@commitlint/parse/src/index.ts
@@ -12,6 +12,7 @@ export default async function parse(
 	const opts = {
 		...defaultOpts,
 		...(parserOpts || {}),
+		fieldPattern: null
 	};
 	const parsed = parser(message, opts) as Commit;
 	parsed.raw = message;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes https://github.com/conventional-changelog/commitlint/issues/3428

## Description

In the current version of commitlint the body is truncated unexpectedly when there is a pattern like '- Something between dashes -' in the commit message body. I investigated this issue https://github.com/conventional-changelog/commitlint/issues/3428 and noticed that the reason for this behavior is that in the commit parser package the commitlint uses ([conventional-commit-parser](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/README.md)), this pattern '- something -' is a special pattern for any arbitrary filed. For example, if you put '-myNote-' in the commit message body, everything that comes after this field will be saved in an arbitrary field called myNote (Or whatever is written between dashes) and you can use it like other fields (header, body, etc.), but I believe we should disable this functionality because, in the commit messages like the one I mentioned in https://github.com/conventional-changelog/commitlint/issues/3428 issue, the user might put stack trace in the commit message body and this way it will be truncated unexpectedly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
