### PR TITLE
chore: convert @types/node version to *

### DIFF
--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -40,7 +40,6 @@
     "@types/lodash.isplainobject": "^4.0.7",
     "@types/lodash.merge": "^4.6.7",
     "@types/lodash.uniq": "^4.5.7",
-    "@types/node": "^14.0.0",
     "conventional-changelog-atom": "^2.0.8",
     "execa": "^5.0.0"
   },
@@ -49,6 +48,7 @@
     "@commitlint/execute-rule": "^17.4.0",
     "@commitlint/resolve-extends": "^17.4.0",
     "@commitlint/types": "^17.4.0",
+    "@types/node": "*",
     "chalk": "^4.1.0",
     "cosmiconfig": "^8.0.0",
     "cosmiconfig-typescript-loader": "^4.0.0",


### PR DESCRIPTION
Update to this: https://github.com/conventional-changelog/commitlint/pull/3464