### PR TITLE
Fixes a bug when a ts commitlint config is compiled twice

### DIFF
--- a/@commitlint/load/src/utils/load-config.ts
+++ b/@commitlint/load/src/utils/load-config.ts
@@ -13,6 +13,7 @@ export async function loadConfig(
 	configPath?: string
 ): Promise<LoadConfigResult | null> {
 	const moduleName = 'commitlint';
+	const tsLoader = TypeScriptLoader();
 	const explorer = cosmiconfig(moduleName, {
 		searchPlaces: [
 			// cosmiconfig overrides default searchPlaces if any new search place is added (For e.g. `*.ts` files),
@@ -34,8 +35,8 @@ export async function loadConfig(
 			`${moduleName}.config.cts`,
 		],
 		loaders: {
-			'.ts': TypeScriptLoader(),
-			'.cts': TypeScriptLoader(),
+			'.ts': tsLoader,
+			'.cts': tsLoader,
 		},
 	});
 


### PR DESCRIPTION
## Description

This PR fixes a bug which was introduced in commitlint v17.4.0 (https://github.com/conventional-changelog/commitlint/commit/85ad18b8990567df516effcacbf04edbcbb6b6d7). If two instances of TypeScriptLoader() are used a .ts commitlint config is somehow compiled twice. This leads sometimes, depending on the config, to a compilation error.  

A repository which contains the code to reproduce the error, can be found [here](https://github.com/mailaenderli/commitlinit-bug-repro).  
## Motivation and Context

Fixes a minor bug

## Usage examples
```
"not a conventional commit" | npx commitlint
```
`.commitlintrc.ts`
```
const dummyGetScope = (ctx: any) => 'testScope'

const config = {
  extends: ['@commitlint/config-conventional'],
  rules: {
    'scope-enum': async (ctx: any) => [2, 'always', [...(await dummyGetScope(ctx)), 'your', 'other', 'scopes']]
  },
};

export default config;
```

### Expected
```
 ⧗   input: not a conventional commit
 ✖   subject may not be empty [subject-empty]
 ✖   type may not be empty [type-empty]

 ✖   found 2 problems, 0 warnings
 ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
```

### Actual
```
 return new TSError(diagnosticText, diagnosticCodes, diagnostics);
        ^
 TSError: ⨯ Unable to compile TypeScript:
 .commitlintrc.ts:3:24 - error TS7006: Parameter 'ctx' implicitly has an 'any' type.

 3 const dummyGetScope = (ctx) => 'testScope';
                         ~~~
 .commitlintrc.ts:7:30 - error TS7006: Parameter 'ctx' implicitly has an 'any' type.

 7         'scope-enum': async (ctx) => [2, 'always', [...(await dummyGetScope(ctx)), 'your', 'other', 'scopes']]
```
## How Has This Been Tested?
manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
