### PR TITLE
docs: use RuleConfigSeverity in config docs

### DIFF
--- a/docs/reference-configuration.md
+++ b/docs/reference-configuration.md
@@ -72,6 +72,7 @@ module.exports = Configuration;
 
 ```ts
 import type {UserConfig} from '@commitlint/types';
+import { RuleConfigSeverity } from "@commitlint/types";
 
 const Configuration: UserConfig = {
   /*
@@ -93,7 +94,7 @@ const Configuration: UserConfig = {
    * Any rules defined here will override rules from @commitlint/config-conventional
    */
   rules: {
-    'type-enum': [2, 'always', ['foo']],
+    'type-enum': [RuleConfigSeverity.Error, 'always', ['foo']],
   },
   /*
    * Functions that return true if commitlint should ignore the given message.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is the following enum for checking rule config severity in `commitlint/@commitlint/types/src/rules` that we should use in typescript plugins instead of 0, 1, and 2 numbers to make the code clearer.

```
export enum RuleConfigSeverity {
	Disabled = 0,
	Warning = 1,
	Error = 2,
}
```
<!--- Describe your changes in detail -->

## Motivation and Context
To make the docs clearer.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
It has been used in our local plugins.
<!--- Please describe in detail how you tested your changes. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
