### PR TITLE
chore: update commit type config

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     ],
     "extends": [
       "config:base",
-      ":semanticCommitType(chore)",
+      ":semanticCommitTypeAll(chore)",
       ":semanticCommitScopeDisabled"
     ],
     "ignoreDeps": [


### PR DESCRIPTION
- Fix commit type
   According [to the docs](https://docs.renovatebot.com/semantic-commits/#changing-the-semantic-commit-type) the parameter needs an "All"? On the other hand [the current param seems valid](https://docs.renovatebot.com/configuration-options/#semanticcommittype)?
- `package.json`-config option [is deprected](https://docs.renovatebot.com/configuration-options/) and should be changed (will do next). Maybe this is alreayd the case?