### PR TITLE
fix(parse): allow setting fieldPattern in parserOpts

### DIFF
--- a/@commitlint/parse/src/index.test.ts
+++ b/@commitlint/parse/src/index.test.ts
@@ -169,18 +169,18 @@ test('registers inline #', async () => {
 });
 
 test('keep -side notes- in the body section', async () => {
-	const header = "type(some/scope): subject"
-	const body = 
-		"CI on master branch caught this:\n\n" +
-		"```\n" +
-		"Unhandled Exception:\n" +
+	const header = 'type(some/scope): subject';
+	const body =
+		'CI on master branch caught this:\n\n' +
+		'```\n' +
+		'Unhandled Exception:\n' +
 		"System.AggregateException: One or more errors occurred. (Some problem when connecting to 'api.mycryptoapi.com/eth')\n\n" +
-		"--- End of stack trace from previous location where exception was thrown ---\n\n" +
-		"at GWallet.Backend.FSharpUtil.ReRaise (System.Exception ex) [0x00000] in /Users/runner/work/geewallet/geewallet/src/GWallet.Backend/FSharpUtil.fs:206\n" +
-		"...\n" +
-		"```";
+		'--- End of stack trace from previous location where exception was thrown ---\n\n' +
+		'at GWallet.Backend.FSharpUtil.ReRaise (System.Exception ex) [0x00000] in /Users/runner/work/geewallet/geewallet/src/GWallet.Backend/FSharpUtil.fs:206\n' +
+		'...\n' +
+		'```';
 
-	const message = header + "\n\n" + body
+	const message = header + '\n\n' + body;
 
 	const actual = await parse(message);
 

--- a/@commitlint/parse/src/index.test.ts
+++ b/@commitlint/parse/src/index.test.ts
@@ -187,6 +187,20 @@ test('keep -side notes- in the body section', async () => {
 	expect(actual.body).toBe(body);
 });
 
+test('allows separating -side nodes- by setting parserOpts.fieldPattern', async () => {
+	const message =
+		'type(scope): subject\n\nbody text\n-authorName-\nrenovate[bot]';
+	const changelogOpts = {
+		parserOpts: {
+			fieldPattern: /^-(.*)-$/,
+		},
+	};
+	const actual = await parse(message, undefined, changelogOpts.parserOpts);
+
+	expect(actual.body).toBe('body text');
+	expect(actual).toHaveProperty('authorName', 'renovate[bot]');
+});
+
 test('parses references leading subject', async () => {
 	const message = '#1 some subject';
 	const opts = await require('conventional-changelog-angular');

--- a/@commitlint/parse/src/index.ts
+++ b/@commitlint/parse/src/index.ts
@@ -11,8 +11,8 @@ export default async function parse(
 	const defaultOpts = (await defaultChangelogOpts).parserOpts;
 	const opts = {
 		...defaultOpts,
+		fieldPattern: null,
 		...(parserOpts || {}),
-		fieldPattern: null
 	};
 	const parsed = parser(message, opts) as Commit;
 	parsed.raw = message;

--- a/@commitlint/types/src/parse.ts
+++ b/@commitlint/types/src/parse.ts
@@ -34,6 +34,7 @@ export type Parser = (
 
 export interface ParserOptions {
 	commentChar?: string;
+	fieldPattern?: RegExp;
 	headerCorrespondence?: string[];
 	headerPattern?: RegExp;
 	issuePrefixes?: string[];


### PR DESCRIPTION
## Description

This allows the [`fieldPattern` option for `conventional-commits-parser`](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/README.md#fieldpattern) to be set via `parserOpts` in user config.

## Motivation and Context

This is related to the discussion at https://github.com/conventional-changelog/commitlint/pull/3476#issuecomment-1420160206. That PR accidentally prevented any user from being able to set a custom `fieldPattern` option.

I've also added `fieldPattern` to the `ParserOptions` type definitions. Either it was missed when the types were first created, or the option was later added to `conventional-commits-parser` (I'm not sure which).

## How Has This Been Tested?

1. Unit tests.
2. Manual testing in a separate project. It had previously relied on the implicit default parsing behaviour of `-fieldNames-` in the body, and started failing with commitlint `17.4.0`. Using this PR and adding `parserOpts: { fieldPattern: /^-(.*?)-$/ }` in the config allowed it start working again.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
