### PR TITLE
fix(docs): checkout requires fetch-depth: 0

### DIFF
--- a/docs/guides-ci-setup.md
+++ b/docs/guides-ci-setup.md
@@ -19,7 +19,9 @@ jobs:
   commitlint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Install required dependencies
         run: |
           apt update


### PR DESCRIPTION
## Description

Fixes the documentation to advise using fetch-depth: 0, which is needed for `commitlint --from` to check against the history of commits.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
