### PR TITLE
Support typescript 5.0

### DIFF
--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -57,7 +57,7 @@
     "lodash.uniq": "^4.5.0",
     "resolve-from": "^5.0.0",
     "ts-node": "^10.8.1",
-    "typescript": "^4.6.4"
+    "typescript": "^4.6.4 || ^5.0.0"
   },
   "gitHead": "70f7f4688b51774e7ac5e40e896cdaa3f132b2bc"
 }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
     "lerna": "^6.0.0",
     "lint-staged": "13.1.2",
     "prettier": "^2.0.5",
-    "typescript": "^4.9.3"
+    "typescript": "^5.0.2"
   }
 }

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -15,7 +15,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "forceConsistentCasingInFileNames": true,
-    "keyofStringsOnly": true,
     "noFallthroughCasesInSwitch": true,
     "isolatedModules": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8500,10 +8500,15 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@^3 || ^4", typescript@^4.6.4, typescript@^4.9.3:
+"typescript@^3 || ^4":
   version "4.9.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+
+"typescript@^4.6.4 || ^5.0.0", typescript@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Have `@commitlint/load` support both `^4.6.4` and `^5.0.0` as supported versions and update the base typescript version used in the repo to the current latest version `^5.0.2`.

Also removed the now deprecated `keyofStringsOnly` setting from `tsconfig.shared.json`.

Fixes #3562

## Motivation and Context

Allows `commitlint` to be used in a `typescript@^5` repository.

## How Has This Been Tested?

Ran the tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
