### PR TITLE
Upgrade package to overcome Vulnerability

### DIFF
--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -46,7 +46,7 @@
     "@commitlint/top-level": "^17.4.0",
     "@commitlint/types": "^17.4.4",
     "fs-extra": "^11.0.0",
-    "git-raw-commits": "^2.0.0",
+    "git-raw-commits": "^2.0.11",
     "minimist": "^1.2.6"
   },
   "gitHead": "70f7f4688b51774e7ac5e40e896cdaa3f132b2bc"


### PR DESCRIPTION
Upgrade git-raw-commits to 2.0.11 due Vulnerability  https://github.com/advisories/GHSA-7p7h-4mm5-852v
