### PR TITLE
fix: lerna package.json resolution

### DIFF
--- a/@commitlint/config-lerna-scopes/index.js
+++ b/@commitlint/config-lerna-scopes/index.js
@@ -1,7 +1,6 @@
 const glob = require('glob');
 const Path = require('path');
 const importFrom = require('import-from');
-const resolvePkg = require('resolve-pkg');
 const semver = require('semver');
 
 module.exports = {
@@ -54,5 +53,15 @@ function getPackages(context) {
 }
 
 function getLernaVersion(cwd) {
-	return require(Path.join(resolvePkg('lerna', {cwd}), 'package.json')).version;
+	const moduleEntrypoint = require.resolve('lerna', {
+		paths: [cwd],
+	});
+	const moduleDir = Path.join(
+		moduleEntrypoint.slice(0, moduleEntrypoint.lastIndexOf('node_modules')),
+		'node_modules',
+		'lerna'
+	);
+	const modulePackageJson = Path.join(moduleDir, 'package.json');
+
+	return require(modulePackageJson).version;
 }

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "glob": "^8.0.3",
     "import-from": "4.0.0",
-    "resolve-pkg": "2.0.0",
     "semver": "7.3.8"
   },
   "devDependencies": {


### PR DESCRIPTION
This changes allows `@commitlint/config-lerna-scopes` to resolve the path to Lerna's `package.json`.

## Description

When Lerna added `exports` to its `package.json`, `resolve-pkg` stopped working: https://github.com/lerna/lerna/issues/3579

See https://github.com/sindresorhus/resolve-pkg/issues/9 for additional details.

## Motivation and Context

This fixes `@commitlint/config-lerna-scopes` not working with recent versions of Lerna.

An alternative approach changing Lerna's `exports` was understandably rejected: https://github.com/lerna/lerna/pull/3670

## Usage examples

```js
// commitlint.config.js
module.exports = { extends: ['@commitlint/config-lerna-scopes'] };
```

```sh
echo "your commit message here" | commitlint # fails
```

## How Has This Been Tested?

I used @gvdp's example repo linked in https://github.com/lerna/lerna/issues/3579 and edited `@commitlint/config-lerna-scopes` in there.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
