### PR TITLE
Add named export to @commitlint/parse

### DIFF
--- a/@commitlint/parse/src/index.ts
+++ b/@commitlint/parse/src/index.ts
@@ -3,7 +3,7 @@ import {Commit, Parser, ParserOptions} from '@commitlint/types';
 const {sync} = require('conventional-commits-parser');
 const defaultChangelogOpts = require('conventional-changelog-angular');
 
-export default async function parse(
+export async function parse(
 	message: string,
 	parser: Parser = sync,
 	parserOpts?: ParserOptions
@@ -18,3 +18,5 @@ export default async function parse(
 	parsed.raw = message;
 	return parsed;
 }
+
+export default parse;


### PR DESCRIPTION
## Description

This PR adds a named export alongside a default export, which fixes imports in an ESM context.

## Motivation and Context

- When working on https://github.com/TanStack/query/pull/5486, I came the following issue trying to run `scripts/publish.mjs`: `TypeError: parseCommit is not a function`
- The script uses `import parseCommit from '@commitlint/parse'` then later calls `const parsed = await parseCommit(d.subject)`, and no typechecking errors are raised (using `@ts-check`)
- However, if I instead call `const parsed = await parseCommit.default(d.subject)` I get a type error, but the script works without issues (see [here](https://github.com/TanStack/query/commit/d1b001a46f7959441283b59709a4e0b59a019dae))
- This seems to be some weird ESM/CJS incompatibility ([this](https://github.com/evanw/esbuild/issues/1719) might be relevant?), which can be solved by using a named export

## Usage examples

CJS: `const parse = require('@commitlint/parse')`
ESM: `import { parse } from '@commitlint/parse'`

## How Has This Been Tested?

I tried the build output in the Tanstack Query codebase and it worked 👍 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
