### PR TITLE
docs: add instructions to use the package installed locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ yarn husky install
 npx husky add .husky/commit-msg  'npx --no -- commitlint --edit ${1}'
 ```
 
+**Or use installed package instead** 
+```
+npm pkg set scripts.commitlint="commitlint --edit"
+npx husky add .husky/commit-msg 'npm run commitlint ${1}'
+```
+
+
 Check the [husky documentation](https://typicode.github.io/husky/#/?id=manual) on how you can automatically have Git hooks enabled after install for different `yarn` versions.
 
 **Detailed Setup instructions**

--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -43,6 +43,12 @@ yarn husky install
 npx husky add .husky/commit-msg  'npx --no -- commitlint --edit ${1}'
 ```
 
+**Or use installed package instead** 
+```
+npm pkg set scripts.commitlint="commitlint --edit"
+npx husky add .husky/commit-msg 'npm run commitlint ${1}'
+```
+
 **Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)**\
 Check the [husky documentation](https://typicode.github.io/husky/#/?id=manual) on how you can automatically have Git hooks enabled after install for different `yarn` versions.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The instructions regarding local setup wee a bit confusing, particularly in the "Add hook" section where npx was used to run `commitlint` instead of the locally installed package.

I have updated the instructions to provide greater clarity and accommodate those who prefer a 100% local setup. The revised steps now include guidance on utilizing the locally installed `commitlint` package.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When I read the documentation to use `commitlint` I was confused by the local setup using `npx` to run the command instead of the package installed locally 

## Usage examples

<!--- Provide examples of intended usage -->

```sh
npm pkg set scripts.commitlint="commitlint --edit"
npx husky add .husky/commit-msg 'npm run commitlint ${1}'
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Follow the instructions on the doc, section `Add hooks`:
```sh
npm pkg set scripts.commitlint="commitlint --edit"
npx husky add .husky/commit-msg 'npm run commitlint ${1}'
```

Everything is working as before.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
