### PR TITLE
Support .git symlinks

### DIFF
--- a/@commitlint/read/src/get-edit-file-path.ts
+++ b/@commitlint/read/src/get-edit-file-path.ts
@@ -12,7 +12,7 @@ export async function getEditFilePath(
 	}
 
 	const dotgitPath = path.join(top, '.git');
-	const dotgitStats: Stats = await fs.lstat(dotgitPath);
+	const dotgitStats: Stats = await fs.stat(dotgitPath);
 
 	if (dotgitStats.isDirectory()) {
 		return path.join(top, '.git/COMMIT_EDITMSG');


### PR DESCRIPTION
For large projects that use google's 'repo' tool, .git is actually a symlink to somewhere else. lstat() only reads the symlink itself, not the target of the symlink, leading to errors like EISDIR: illegal operation on a directory, read

<!--- Provide a general summary of your changes in the Title above -->

## Description

That's about it. Not a lot of details here.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes commitlint usage for repo-based projects (eg, yocto builds)

## Usage examples

<!--- Provide examples of intended usage -->

Clone a set of yocto layers using repo, try to use commitlint.

## How Has This Been Tested?

Patched the module locally, commitlint started working.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
