### PR TITLE
docs: clarify subject-case [resolves #3638]

### DIFF
--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -278,7 +278,7 @@ Infinity
 
 #### subject-case
 
-- **condition**: `subject` is in one of the cases `['sentence-case', 'start-case', 'pascal-case', 'upper-case']`
+- **condition**: `subject` is in case `value`
 - **rule**: `always`
 - **value**
 

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -290,7 +290,7 @@ Infinity
 
 ```js
 [
-  'lower-case',    // default
+  'lower-case',    // lower case
   'upper-case',    // UPPERCASE
   'camel-case',    // camelCase
   'kebab-case',    // kebab-case


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
resolves #3638

1. `subject-case` uses the standard `condition` language
2. `subject-case` "possible values" to use `// lower case` instead of `// default`


## Motivation and Context

- #3638

## Usage examples

N/A

## How Has This Been Tested?

- It hasn't. See #3639

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
    - I didn't run the tests, after hitting #3639. Does not change anything that would affect tests.
