### PR TITLE
fix: remove build on any branches except main and tags

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -3,9 +3,6 @@ on:
   push:
     tags:
       - '**'
-    branches:
-      - '**'
-      - '!master'
   schedule:
     - cron: '0 0 * * *'
 jobs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Build and push only releases and master branch (via cron).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Right now every branch that is created in the repo triggers build in the repository. This includes branches created by Renovate. We don't want it - only master (via cron) and releases should be built 

## Usage examples

<!--- Provide examples of intended usage -->

N/A

## How Has This Been Tested?

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
