### PR TITLE
feat: lazy load cosmiconfig-typescript-loader

### DIFF
--- a/@commitlint/load/src/utils/load-config.ts
+++ b/@commitlint/load/src/utils/load-config.ts
@@ -1,4 +1,4 @@
-import {cosmiconfig} from 'cosmiconfig';
+import {cosmiconfig, type Loader} from 'cosmiconfig';
 import {TypeScriptLoader} from 'cosmiconfig-typescript-loader';
 import path from 'path';
 
@@ -13,7 +13,15 @@ export async function loadConfig(
 	configPath?: string
 ): Promise<LoadConfigResult | null> {
 	const moduleName = 'commitlint';
-	const tsLoader = TypeScriptLoader();
+
+	let tsLoaderInstance: Loader | undefined;
+	const tsLoader: Loader = (...args) => {
+		if (!tsLoaderInstance) {
+			tsLoaderInstance = TypeScriptLoader();
+		}
+		return tsLoaderInstance(...args);
+	};
+
 	const explorer = cosmiconfig(moduleName, {
 		searchPlaces: [
 			// cosmiconfig overrides default searchPlaces if any new search place is added (For e.g. `*.ts` files),


### PR DESCRIPTION
## Description

Lazy load `cosmiconfig-typescript-loader`

## Motivation and Context

To avoid loading `cosmiconfig-typescript-loader` (and consequently ts-node/jiti) when not required (i.e. when the user has no typescript-based config file). Refer https://github.com/conventional-changelog/commitlint/issues/3256#issuecomment-1762790855. This unblocks the users facing #3256 and improves perf.

## How Has This Been Tested?

Manually tested on my project with the patch. The CI already has tests for TS-based config.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
