### PR TITLE
chore: switch ci to test matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,77 +8,25 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  v18:
-    runs-on: ubuntu-22.04
-    container:
-      image: 'ubuntu:22.04'
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-2022]
+        node: [18, 20]
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Install required dependencies
-        run: |
-          apt update
-          apt install --yes sudo
-          sudo apt install --yes git
-          sudo apt install --yes curl
-          curl --location https://deb.nodesource.com/setup_18.x | sudo --preserve-env bash -
-          sudo DEBIAN_FRONTEND=noninteractive apt install --yes nodejs
       - uses: actions/checkout@v4
-      # workaround for https://github.com/actions/runner/issues/2033
-      - name: ownership workaround
-        run: git config --global --add safe.directory '*'
-      - name: Install yarn
-        run: |
-          npm install --global yarn
-          node --version
-          yarn global add yarn@latest
-      - name: Install dependencies
-        run: yarn install --ignore-engines --frozen-lockfile
-      - name: Build packages
-        run: yarn build
-      - name: Test
-        run: yarn test-ci
 
-  v20:
-    runs-on: ubuntu-22.04
-    container:
-      image: 'ubuntu:22.04'
-    steps:
-      - name: Install required dependencies
-        run: |
-          apt update
-          apt install --yes sudo
-          sudo apt install --yes git
-          sudo apt install --yes curl
-          curl --location https://deb.nodesource.com/setup_20.x | sudo --preserve-env bash -
-          sudo DEBIAN_FRONTEND=noninteractive apt install --yes nodejs
-      - uses: actions/checkout@v4
-      # workaround for https://github.com/actions/runner/issues/2033
-      - name: ownership workaround
-        run: git config --global --add safe.directory '*'
-      - name: Install yarn
-        run: |
-          npm install --global yarn
-          node --version
-          yarn global add yarn@latest
-      - name: Install dependencies
-        run: yarn install --ignore-engines --frozen-lockfile
-      - name: Build packages
-        run: yarn build
-      - name: Test
-        run: yarn test-ci
-
-  windows:
-    runs-on: windows-2022
-    steps:
-      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
-          max_attempts: 3
-      - name: Update yarn
-        run: |
-          node --version
-          yarn global add yarn@latest
+          node-version: ${{ matrix.node }}
+          cache: yarn
+
       - name: Install dependencies
         run: yarn install --ignore-engines --frozen-lockfile
+
       - name: Build packages
         run: yarn build
+
       - name: Test
         run: yarn test-ci


### PR DESCRIPTION
Use a test matrix in the CI file.

## Description

Switch to using a test matrix instead of separate build jobs. Also switch to using the setup-node action, which allows for pulling specific major/minor/patch versions of node.

## Motivation and Context

Simplifies the CI configuration and allows for specific versions of node to run the pipeline.

## Usage examples

N/A

## How Has This Been Tested?

If the CI checks all pass (and there are 4 of them - node 18/20 + ubuntu/windows).

## Types of changes

N/A

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
