### PR TITLE
fix(@commitlint/load): Remove unused `@types/node` dependency

### DIFF
--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -48,7 +48,6 @@
     "@commitlint/execute-rule": "^18.4.3",
     "@commitlint/resolve-extends": "^18.4.3",
     "@commitlint/types": "^18.4.3",
-    "@types/node": "^18.11.9",
     "chalk": "^4.1.0",
     "cosmiconfig": "^8.3.6",
     "cosmiconfig-typescript-loader": "^5.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`@commitlint/load` has both a regular and dev dependency on `@types/node`. Only one of these should be needed, and it seems that the regular dependency is not required since the package's API does not rely on these types, so I have removed it. The dev dependency needs to stay as `node:path` is used in this package.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `@types/node` dependency could result in multiple major versions of `@types/node` in a consumer's `node_modules`, e.g. if a consumer also depends on `@types/node@20`. This isn't a huge deal, but IMO it's still worth fixing if possible.

## Usage examples

<!--- Provide examples of intended usage -->

N/A

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

The build output (specifically `.d.ts` files) before and after this change is identical.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
