### PR TITLE
fix(read): remove fs-extra usage and use fs/promises

### DIFF
--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@commitlint/test": "^18.0.0",
     "@commitlint/utils": "^18.4.3",
-    "@types/fs-extra": "^11.0.3",
     "@types/git-raw-commits": "^2.0.3",
     "@types/minimist": "^1.2.4",
     "execa": "^5.0.0"
@@ -45,7 +44,6 @@
   "dependencies": {
     "@commitlint/top-level": "^18.4.3",
     "@commitlint/types": "^18.4.3",
-    "fs-extra": "^11.0.0",
     "git-raw-commits": "^2.0.11",
     "minimist": "^1.2.6"
   },

--- a/@commitlint/read/src/get-edit-commit.ts
+++ b/@commitlint/read/src/get-edit-commit.ts
@@ -1,5 +1,5 @@
 import toplevel from '@commitlint/top-level';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import {getEditFilePath} from './get-edit-file-path';
 
 // Get recently edited commit message

--- a/@commitlint/read/src/get-edit-file-path.ts
+++ b/@commitlint/read/src/get-edit-file-path.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import {Stats} from 'fs';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 
 // Get path to recently edited commit message file
 export async function getEditFilePath(

--- a/@commitlint/read/src/read.test.ts
+++ b/@commitlint/read/src/read.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import {git} from '@commitlint/test';
 import execa from 'execa';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 
 import read from './read';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
removes fs-extra usage and the dependency on `fs-extra` and uses the node.js `fs/promises` module

## Description
- removes usage of the `fs-extra` module from `@commitlint/read`
- removes dependency `fs-extra` and devDependency `@types/fs-extra` from the `@commitlint/read` package
<!--- Describe your changes in detail -->

## Motivation and Context
remove a unnecessary dependency
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
