### PR TITLE
Update README.md to improve husky setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ yarn husky install
 ```
 
 ### Add hook
-
+> [!WARNING]  
+> It's necessary that you use **commit-msg** as the name for hook file.
+> Read Git hooks [documentation](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) for more info.
 ```
 npx husky add .husky/commit-msg  'npx --no -- commitlint --edit ${1}'
 ```


### PR DESCRIPTION
Explicitly mention that the hook file name must be commit-msg for husky

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a warning block in docs to make it clear that the name for husky hook file must be **commit-msg**.

## Motivation and Context
A lot of people using this library with husky don't know about git hooks in general. So it's assumed that changing the name for hook file won't cause any problems. This change in documentation makes it clear that the name is actually really important.

[Issue 3780](https://github.com/conventional-changelog/commitlint/issues/3780)

## Usage examples

No usage

## How Has This Been Tested?

No test required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documenation

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
