### PR TITLE
feat: add rule for `BREAKING CHANGE:` in subject

### DIFF
--- a/@commitlint/rules/src/index.ts
+++ b/@commitlint/rules/src/index.ts
@@ -21,6 +21,7 @@ import {scopeEnum} from './scope-enum';
 import {scopeMaxLength} from './scope-max-length';
 import {scopeMinLength} from './scope-min-length';
 import {signedOffBy} from './signed-off-by';
+import {subjectBreaking} from './subject-breaking';
 import {subjectCase} from './subject-case';
 import {subjectEmpty} from './subject-empty';
 import {subjectFullStop} from './subject-full-stop';
@@ -58,6 +59,7 @@ export default {
 	'scope-max-length': scopeMaxLength,
 	'scope-min-length': scopeMinLength,
 	'signed-off-by': signedOffBy,
+	'subject-breaking': subjectBreaking,
 	'subject-case': subjectCase,
 	'subject-empty': subjectEmpty,
 	'subject-full-stop': subjectFullStop,

--- a/@commitlint/rules/src/subject-breaking.test.ts
+++ b/@commitlint/rules/src/subject-breaking.test.ts
@@ -1,0 +1,24 @@
+import parse from '@commitlint/parse';
+import {subjectBreaking} from './subject-breaking';
+
+const messages = {
+	empty: 'test: \nbody',
+	filled: 'BREAKING CHANGE: this one',
+};
+
+const parsed = {
+	empty: parse(messages.empty),
+	filled: parse(messages.filled),
+};
+
+test('without subject should succeed', async () => {
+	const [actual] = subjectBreaking(await parsed.empty);
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('subject fail with BREAKING CHANGE:', async () => {
+	const [actual] = subjectBreaking(await parsed.filled);
+	const expected = false;
+	expect(actual).toEqual(expected);
+});

--- a/@commitlint/rules/src/subject-breaking.ts
+++ b/@commitlint/rules/src/subject-breaking.ts
@@ -1,0 +1,7 @@
+import {SyncRule} from '@commitlint/types';
+
+export const subjectBreaking: SyncRule = (parsed) => {
+	const result = parsed.subject?.startsWith('BREAKING CHANGE:');
+
+	return [!result, 'move BREAKING CHANGE: to footer'];
+};


### PR DESCRIPTION
## Description

`BREAKING CHANGE:` is a footer thing

Fixed https://github.com/conventional-changelog/commitlint/issues/3810

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

```sh
echo "BREAKING CHANGE: no" | yarn run commitlint
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
