### PR TITLE
GitHubCI: no need to just run in master branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - '**'
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
When a contributor wants to create a PR for commitlint, the normal thing for him to do first is fork the repo and create a branch with a different name than master. Then, if he pushes his commits, he should be able to see the CI status of his fixes before he opens the PR.