### PR TITLE
fix: avoid slicing header if not long enough

### DIFF
--- a/@commitlint/rules/src/subject-full-stop.ts
+++ b/@commitlint/rules/src/subject-full-stop.ts
@@ -15,7 +15,8 @@ export const subjectFullStop: SyncRule<string> = (
 
 	const negated = when === 'never';
 	let hasStop = input[input.length - 1] === value;
-	if (input.slice(-3) === '...') {
+	let ellipsis = '...';
+	if (input.length > ellipsis.length && input.slice(-ellipsis.length) === ellipsis) {
 		hasStop = false;
 	}
 


### PR DESCRIPTION
Recent PR[1] didn't take in account very small subjects in subject-full-stop rule.

[1] https://github.com/conventional-changelog/commitlint/pull/3839
