### PR TITLE
feat(cli): print-config now can be configured to print a json in stdout

### DIFF
--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -38,9 +38,9 @@ const cli = yargs
 			type: 'string',
 		},
 		'print-config': {
-			type: 'boolean',
-			default: false,
+			choices: ['', 'text', 'json'],
 			description: 'print resolved config',
+			type: 'string',
 		},
 		cwd: {
 			alias: 'd',
@@ -175,13 +175,22 @@ async function main(args: MainArgs): Promise<void> {
 	const raw = options._;
 	const flags = normalizeFlags(options);
 
-	if (flags['print-config']) {
+	if (typeof options['print-config'] === 'string') {
 		const loaded = await load(getSeed(flags), {
 			cwd: flags.cwd,
 			file: flags.config,
 		});
-		console.log(util.inspect(loaded, false, null, options.color));
-		return;
+
+		switch (options['print-config']) {
+			case 'json':
+				console.log(JSON.stringify(loaded));
+				return;
+
+			case 'text':
+			default:
+				console.log(util.inspect(loaded, false, null, options.color));
+				return;
+		}
 	}
 
 	const fromStdin = checkFromStdin(raw, flags);

--- a/@commitlint/cli/src/types.ts
+++ b/@commitlint/cli/src/types.ts
@@ -15,7 +15,8 @@ export interface CliFlags {
 	to?: string;
 	version?: boolean;
 	verbose?: boolean;
-	'print-config'?: boolean;
+	/** @type {'' | 'text' | 'json'} */
+	'print-config'?: string;
 	strict?: boolean;
 	_: (string | number)[];
 	$0: string;

--- a/docs/reference-cli.md
+++ b/docs/reference-cli.md
@@ -10,7 +10,8 @@
 Options:
   -c, --color          toggle colored output           [boolean] [default: true]
   -g, --config         path to the config file                          [string]
-      --print-config   print resolved config          [boolean] [default: false]
+      --print-config   print resolved config
+                                          [string] [choices: "", "text", "json"]
   -d, --cwd            directory to execute in
                                          [string] [default: (Working Directory)]
   -e, --edit           read last commit message from the specified file or


### PR DESCRIPTION
fixes #3819

## Description

Now `print-config` cli option accept 3 possible parameters:
- `''` (empty) - same behaviour of current implementation
- `text` - same behaviour of current implementation
- `json` - prints a raw json

## Motivation and Context

Parse the configuration from stdout

## Usage examples

```sh
npx commitlint --print-config
npx commitlint --print-config=text

npx commitlint --print-config=json
```

## How Has This Been Tested?

Unit tests have been added to `@commitlint/cli/src/cli.test.ts` to test all 3 scenarios. 
`--help` test has been updated to match the new behaviour of `print-config`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
