### PR TITLE
refactor: use enum instead of hardcoding

### DIFF
--- a/@commitlint/config-nx-scopes/index.js
+++ b/@commitlint/config-nx-scopes/index.js
@@ -1,3 +1,4 @@
+import {RuleConfigSeverity} from '@commitlint/types';
 const {
 	getProjects: getNXProjects,
 } = require('nx/src/generators/utils/project-configuration');
@@ -6,7 +7,7 @@ const {FsTree} = require('nx/src/generators/tree');
 module.exports = {
 	utils: {getProjects},
 	rules: {
-		'scope-enum': (ctx) => Promise.resolve([2, 'always', getProjects(ctx)]),
+		'scope-enum': (ctx) => Promise.resolve([RuleConfigSeverity.Error, 'always', getProjects(ctx)]),
 	},
 };
 

--- a/@commitlint/config-validator/src/validate.test.ts
+++ b/@commitlint/config-validator/src/validate.test.ts
@@ -1,5 +1,5 @@
 import {validateConfig} from './validate';
-import {UserConfig} from '@commitlint/types';
+import {RuleConfigSeverity, UserConfig} from '@commitlint/types';
 
 const validSchemas: Record<string, UserConfig> = {
 	empty: {},
@@ -9,7 +9,7 @@ const validSchemas: Record<string, UserConfig> = {
 	withMultipleExtends: {extends: ['test', 'test2']},
 	withFormatter: {formatter: ''},
 	withHelpUrl: {helpUrl: ''},
-	withRules: {rules: {a: [0], b: [1, 'never'], c: [2, 'never', true]}},
+	withRules: {rules: {a: [RuleConfigSeverity.Disabled], b: [RuleConfigSeverity.Warning, 'never'], c: [RuleConfigSeverity.Error, 'never', true]}},
 	withParserPresetString: {parserPreset: 'test'},
 	withParserPresetObject: {parserPreset: {}},
 	withParserPresetObject2: {parserPreset: {name: 'string', path: 'string'}},

--- a/@commitlint/cz-commitlint/src/Process.test.ts
+++ b/@commitlint/cz-commitlint/src/Process.test.ts
@@ -1,4 +1,4 @@
-import {QualifiedRules, UserPromptConfig} from '@commitlint/types';
+import {QualifiedRules, RuleConfigSeverity, UserPromptConfig} from '@commitlint/types';
 import {Answers, DistinctQuestion} from 'inquirer';
 import isFunction from 'lodash.isfunction';
 import process from './Process';
@@ -68,22 +68,22 @@ afterEach(() => {
 describe('conventional-changlog', () => {
 	beforeEach(() => {
 		rules = {
-			'body-leading-blank': [1, 'always'],
-			'body-max-line-length': [2, 'always', 100],
-			'footer-leading-blank': [1, 'always'],
-			'footer-max-line-length': [2, 'always', 100],
-			'header-max-length': [2, 'always', 100],
+			'body-leading-blank': [RuleConfigSeverity.Warning, 'always'],
+			'body-max-line-length': [RuleConfigSeverity.Error, 'always', 100],
+			'footer-leading-blank': [RuleConfigSeverity.Warning, 'always'],
+			'footer-max-line-length': [RuleConfigSeverity.Error, 'always', 100],
+			'header-max-length': [RuleConfigSeverity.Error, 'always', 100],
 			'subject-case': [
-				2,
+				RuleConfigSeverity.Error,
 				'never',
 				['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
 			],
-			'subject-empty': [2, 'never'],
-			'subject-full-stop': [2, 'never', '.'],
-			'type-case': [2, 'always', 'lower-case'],
-			'type-empty': [2, 'never'],
+			'subject-empty': [RuleConfigSeverity.Error, 'never'],
+			'subject-full-stop': [RuleConfigSeverity.Error, 'never', '.'],
+			'type-case': [RuleConfigSeverity.Error, 'always', 'lower-case'],
+			'type-empty': [RuleConfigSeverity.Error, 'never'],
 			'type-enum': [
-				2,
+				RuleConfigSeverity.Error,
 				'always',
 				[
 					'build',

--- a/@commitlint/cz-commitlint/src/store/rules.test.ts
+++ b/@commitlint/cz-commitlint/src/store/rules.test.ts
@@ -1,4 +1,4 @@
-import {QualifiedRules} from '@commitlint/types';
+import {QualifiedRules, RuleConfigSeverity} from '@commitlint/types';
 import {GetRuleMethod, SetRulesMethod} from './rules';
 
 let getRule: GetRuleMethod;
@@ -11,9 +11,9 @@ beforeEach(() => {
 describe('getRule', () => {
 	test('should get rule when prefix and property strict match', () => {
 		const rules: QualifiedRules = {
-			'body-max-length': [2, 'always', 100],
-			'footer-max-line-length': [2, 'always', 100],
-			'subject-empty': [2, 'never'],
+			'body-max-length': [RuleConfigSeverity.Error, 'always', 100],
+			'footer-max-line-length': [RuleConfigSeverity.Error, 'always', 100],
+			'subject-empty': [RuleConfigSeverity.Error, 'never'],
 		};
 		setRules(rules);
 
@@ -26,7 +26,7 @@ describe('getRule', () => {
 
 	test('should not get rule when prefix is invalid', () => {
 		const rules: QualifiedRules = {
-			'body-max-length': [2, 'always', 100],
+			'body-max-length': [RuleConfigSeverity.Error, 'always', 100],
 		};
 		setRules(rules);
 
@@ -37,8 +37,8 @@ describe('getRule', () => {
 
 	test('should not get rule when property is partial match', () => {
 		const rules: QualifiedRules = {
-			'body-max-length': [2, 'always', 100],
-			'body-leading-blank': [1, 'always'],
+			'body-max-length': [RuleConfigSeverity.Error, 'always', 100],
+			'body-leading-blank': [RuleConfigSeverity.Warning, 'always'],
 		};
 		setRules(rules);
 
@@ -52,13 +52,13 @@ describe('setRule', () => {
 		expect(getRule('body', 'max-length')).toBeUndefined();
 
 		let rules: QualifiedRules = {
-			'body-max-length': [2, 'always', 100],
+			'body-max-length': [RuleConfigSeverity.Error, 'always', 100],
 		};
 		setRules(rules);
 		expect(getRule('body', 'max-length')).toBe(rules['body-max-length']);
 
 		rules = {
-			'footer-max-length': [2, 'always', 100],
+			'footer-max-length': [RuleConfigSeverity.Error, 'always', 100],
 		};
 		setRules(rules);
 		expect(getRule('body', 'max-length')).toBeUndefined();

--- a/@commitlint/cz-commitlint/src/utils/rules.test.ts
+++ b/@commitlint/cz-commitlint/src/utils/rules.test.ts
@@ -59,8 +59,8 @@ test('getMaxLength', () => {
 	expect(getMaxLength([RuleConfigSeverity.Error] as any)).toBe(Infinity);
 
 	const rules: any = {
-		'body-max-line-length': [2, 'always', 100],
-		'header-max-length': [2, 'always', 100],
+		'body-max-line-length': [RuleConfigSeverity.Error, 'always', 100],
+		'header-max-length': [RuleConfigSeverity.Error, 'always', 100],
 		'test-max-length': [RuleConfigSeverity.Disabled, 'always', 100],
 	};
 	let lengthRule = rules['header-max-length'];
@@ -83,8 +83,8 @@ test('getMinLength', () => {
 	expect(getMinLength([RuleConfigSeverity.Error] as any)).toBe(0);
 
 	const rules: any = {
-		'body-min-length': [2, 'always', 10],
-		'footer-min-length': [2, 'always', 20],
+		'body-min-length': [RuleConfigSeverity.Error, 'always', 10],
+		'footer-min-length': [RuleConfigSeverity.Error, 'always', 20],
 		'test-min-length': [RuleConfigSeverity.Disabled, 'always', 100],
 	};
 	let lengthRule = rules['header-min-length'];

--- a/@commitlint/lint/src/lint.test.ts
+++ b/@commitlint/lint/src/lint.test.ts
@@ -1,4 +1,5 @@
 import lint from './lint';
+import {RuleConfigSeverity} from '@commitlint/types';
 
 test('throws without params', async () => {
 	const error = (lint as any)();
@@ -20,21 +21,21 @@ test('positive on stub message and no rule', async () => {
 
 test('positive on stub message and adhered rule', async () => {
 	const actual = await lint('foo: bar', {
-		'type-enum': [2, 'always', ['foo']],
+		'type-enum': [RuleConfigSeverity.Error, 'always', ['foo']],
 	});
 	expect(actual.valid).toBe(true);
 });
 
 test('negative on stub message and broken rule', async () => {
 	const actual = await lint('foo: bar', {
-		'type-enum': [2, 'never', ['foo']],
+		'type-enum': [RuleConfigSeverity.Error, 'never', ['foo']],
 	});
 	expect(actual.valid).toBe(false);
 });
 
 test('positive on ignored message and broken rule', async () => {
 	const actual = await lint('Revert "some bogus commit"', {
-		'type-empty': [2, 'never'],
+		'type-empty': [RuleConfigSeverity.Error, 'never'],
 	});
 	expect(actual.valid).toBe(true);
 	expect(actual.input).toBe('Revert "some bogus commit"');
@@ -44,7 +45,7 @@ test('negative on ignored message, disabled ignored messages and broken rule', a
 	const actual = await lint(
 		'Revert "some bogus commit"',
 		{
-			'type-empty': [2, 'never'],
+			'type-empty': [RuleConfigSeverity.Error, 'never'],
 		},
 		{
 			defaultIgnores: false,
@@ -58,7 +59,7 @@ test('positive on custom ignored message and broken rule', async () => {
 	const actual = await lint(
 		ignoredMessage,
 		{
-			'type-empty': [2, 'never'],
+			'type-empty': [RuleConfigSeverity.Error, 'never'],
 		},
 		{
 			ignores: [(c) => c === ignoredMessage],
@@ -72,8 +73,8 @@ test('positive on stub message and opts', async () => {
 	const actual = await lint(
 		'foo-bar',
 		{
-			'type-enum': [2, 'always', ['foo']],
-			'type-empty': [2, 'never'],
+			'type-enum': [RuleConfigSeverity.Error, 'always', ['foo']],
+			'type-empty': [RuleConfigSeverity.Error, 'never'],
 		},
 		{
 			parserOpts: {
@@ -85,7 +86,7 @@ test('positive on stub message and opts', async () => {
 });
 
 test('throws for invalid rule names', async () => {
-	const error = lint('foo', {foo: [2, 'always'], bar: [1, 'never']});
+	const error = lint('foo', {foo: [RuleConfigSeverity.Error, 'always'], bar: [RuleConfigSeverity.Warning, 'never']});
 
 	await expect(error).rejects.toThrow(/^Found invalid rule names: foo, bar/);
 });
@@ -150,8 +151,8 @@ test('throws for rule with invalid condition', async () => {
 
 test('throws for rule with out of range condition', async () => {
 	const error = lint('type(scope): foo', {
-		'type-enum': [1, 'foo'] as any,
-		'header-max-length': [1, 'bar'] as any,
+		'type-enum': [RuleConfigSeverity.Warning, 'foo'] as any,
+		'header-max-length': [RuleConfigSeverity.Warning, 'bar'] as any,
 	});
 
 	await expect(error).rejects.toThrow('type-enum must be "always" or "never"');
@@ -162,7 +163,7 @@ test('throws for rule with out of range condition', async () => {
 
 test('succeds for issue', async () => {
 	const report = await lint('somehting #1', {
-		'references-empty': [2, 'never'],
+		'references-empty': [RuleConfigSeverity.Error, 'never'],
 	});
 
 	expect(report.valid).toBe(true);
@@ -170,7 +171,7 @@ test('succeds for issue', async () => {
 
 test('fails for issue', async () => {
 	const report = await lint('somehting #1', {
-		'references-empty': [2, 'always'],
+		'references-empty': [RuleConfigSeverity.Error, 'always'],
 	});
 
 	expect(report.valid).toBe(false);
@@ -180,7 +181,7 @@ test('succeds for custom issue prefix', async () => {
 	const report = await lint(
 		'somehting REF-1',
 		{
-			'references-empty': [2, 'never'],
+			'references-empty': [RuleConfigSeverity.Error, 'never'],
 		},
 		{
 			parserOpts: {
@@ -196,7 +197,7 @@ test('fails for custom issue prefix', async () => {
 	const report = await lint(
 		'somehting #1',
 		{
-			'references-empty': [2, 'never'],
+			'references-empty': [RuleConfigSeverity.Error, 'never'],
 		},
 		{
 			parserOpts: {
@@ -212,7 +213,7 @@ test('fails for custom plugin rule', async () => {
 	const report = await lint(
 		'somehting #1',
 		{
-			'plugin-rule': [2, 'never'],
+			'plugin-rule': [RuleConfigSeverity.Error, 'never'],
 		},
 		{
 			plugins: {
@@ -232,7 +233,7 @@ test('passes for custom plugin rule', async () => {
 	const report = await lint(
 		'somehting #1',
 		{
-			'plugin-rule': [2, 'never'],
+			'plugin-rule': [RuleConfigSeverity.Error, 'never'],
 		},
 		{
 			plugins: {
@@ -275,7 +276,7 @@ test('returns original message with commit header, body and footer, parsing comm
 	const report = await lint(
 		message,
 		{
-			'references-empty': [2, 'never'],
+			'references-empty': [RuleConfigSeverity.Error, 'never'],
 		},
 		{
 			parserOpts: {
@@ -291,7 +292,7 @@ test('passes for async rule', async () => {
 	const report = await lint(
 		'somehting #1',
 		{
-			'async-rule': [2, 'never'],
+			'async-rule': [RuleConfigSeverity.Error, 'never'],
 		},
 		{
 			plugins: {

--- a/@commitlint/load/src/load.test.ts
+++ b/@commitlint/load/src/load.test.ts
@@ -1,3 +1,5 @@
+import {RuleConfigSeverity} from '@commitlint/types';
+
 const plugin = jest.fn();
 const scopedPlugin = jest.fn();
 
@@ -28,47 +30,47 @@ test('extends-empty should have no rules', async () => {
 
 test('uses seed as configured', async () => {
 	const cwd = await gitBootstrap('fixtures/extends-empty');
-	const rules = {'body-case': [1, 'never', 'camel-case'] as any};
+	const rules = {'body-case': [RuleConfigSeverity.Warning, 'never', 'camel-case'] as any};
 
 	const actual = await load({rules}, {cwd});
 
-	expect(actual.rules['body-case']).toStrictEqual([1, 'never', 'camel-case']);
+	expect(actual.rules['body-case']).toStrictEqual([RuleConfigSeverity.Warning, 'never', 'camel-case']);
 });
 
 test('rules should be loaded from local', async () => {
 	const actual = await load({
 		rules: {
-			direct: [1, 'never', 'foo'],
-			func: () => [1, 'never', 'foo'],
-			async: async () => [1, 'never', 'foo'],
-			promise: () => Promise.resolve([1, 'never', 'foo']),
+			direct: [RuleConfigSeverity.Warning, 'never', 'foo'],
+			func: () => [RuleConfigSeverity.Warning, 'never', 'foo'],
+			async: async () => [RuleConfigSeverity.Warning, 'never', 'foo'],
+			promise: () => Promise.resolve([RuleConfigSeverity.Warning, 'never', 'foo']),
 		},
 	});
 
-	expect(actual.rules['direct']).toStrictEqual([1, 'never', 'foo']);
-	expect(actual.rules['func']).toStrictEqual([1, 'never', 'foo']);
-	expect(actual.rules['async']).toStrictEqual([1, 'never', 'foo']);
-	expect(actual.rules['promise']).toStrictEqual([1, 'never', 'foo']);
+	expect(actual.rules['direct']).toStrictEqual([RuleConfigSeverity.Warning, 'never', 'foo']);
+	expect(actual.rules['func']).toStrictEqual([RuleConfigSeverity.Warning, 'never', 'foo']);
+	expect(actual.rules['async']).toStrictEqual([RuleConfigSeverity.Warning, 'never', 'foo']);
+	expect(actual.rules['promise']).toStrictEqual([RuleConfigSeverity.Warning, 'never', 'foo']);
 });
 
 test('rules should be loaded from relative config file', async () => {
 	const file = 'config/commitlint.config.js';
 	const cwd = await gitBootstrap('fixtures/specify-config-file');
-	const rules = {'body-case': [1, 'never', 'camel-case'] as any};
+	const rules = {'body-case': [RuleConfigSeverity.Warning, 'never', 'camel-case'] as any};
 
 	const actual = await load({rules}, {cwd, file});
 
-	expect(actual.rules['body-case']).toStrictEqual([1, 'never', 'camel-case']);
+	expect(actual.rules['body-case']).toStrictEqual([RuleConfigSeverity.Warning, 'never', 'camel-case']);
 });
 
 test('rules should be loaded from absolute config file', async () => {
 	const cwd = await gitBootstrap('fixtures/specify-config-file');
 	const file = path.resolve(cwd, 'config/commitlint.config.js');
-	const rules = {'body-case': [1, 'never', 'camel-case'] as any};
+	const rules = {'body-case': [RuleConfigSeverity.Warning, 'never', 'camel-case'] as any};
 
 	const actual = await load({rules}, {cwd: process.cwd(), file});
 
-	expect(actual.rules['body-case']).toStrictEqual([1, 'never', 'camel-case']);
+	expect(actual.rules['body-case']).toStrictEqual([RuleConfigSeverity.Warning, 'never', 'camel-case']);
 });
 
 test('plugins should be loaded from seed', async () => {
@@ -182,8 +184,8 @@ test('respects cwd option', async () => {
 		extends: ['./second-extended'],
 		plugins: {},
 		rules: {
-			one: [1, 'always'],
-			two: [2, 'never'],
+			one: [RuleConfigSeverity.Warning, 'always'],
+			two: [RuleConfigSeverity.Error, 'never'],
 		},
 	});
 });
@@ -285,9 +287,9 @@ describe.each([['basic'], ['extends']])('%s config', (template) => {
 			extends: isExtendsTemplate ? ['./first-extended'] : [],
 			plugins: {},
 			rules: {
-				zero: [0, 'never'],
-				one: [1, 'always'],
-				two: [2, 'never'],
+				zero: [RuleConfigSeverity.Disabled, 'never'],
+				one: [RuleConfigSeverity.Warning, 'always'],
+				two: [RuleConfigSeverity.Error, 'never'],
 			},
 		});
 	});
@@ -302,9 +304,9 @@ test('recursive extends with ts file', async () => {
 		extends: ['./first-extended/index.ts'],
 		plugins: {},
 		rules: {
-			zero: [0, 'never', 'zero'],
-			one: [1, 'never', 'one'],
-			two: [2, 'never', 'two'],
+			zero: [RuleConfigSeverity.Disabled, 'never', 'zero'],
+			one: [RuleConfigSeverity.Warning, 'never', 'one'],
+			two: [RuleConfigSeverity.Error, 'never', 'two'],
 		},
 	});
 });
@@ -340,8 +342,8 @@ test('ignores unknown keys', async () => {
 		extends: [],
 		plugins: {},
 		rules: {
-			foo: [1, 'always', 'bar'],
-			baz: [1, 'always', 'bar'],
+			foo: [RuleConfigSeverity.Warning, 'always', 'bar'],
+			baz: [RuleConfigSeverity.Warning, 'always', 'bar'],
 		},
 	});
 });
@@ -355,8 +357,8 @@ test('ignores unknown keys recursively', async () => {
 		extends: ['./one'],
 		plugins: {},
 		rules: {
-			zero: [0, 'always', 'zero'],
-			one: [1, 'always', 'one'],
+			zero: [RuleConfigSeverity.Disabled, 'always', 'zero'],
+			one: [RuleConfigSeverity.Warning, 'always', 'one'],
 		},
 	});
 });
@@ -372,9 +374,9 @@ test('find up from given cwd', async () => {
 		extends: [],
 		plugins: {},
 		rules: {
-			child: [2, 'always', true],
-			inner: [2, 'always', false],
-			outer: [2, 'always', false],
+			child: [RuleConfigSeverity.Error, 'always', true],
+			inner: [RuleConfigSeverity.Error, 'always', false],
+			outer: [RuleConfigSeverity.Error, 'always', false],
 		},
 	});
 });
@@ -389,9 +391,9 @@ test('find up config from outside current git repo', async () => {
 		extends: [],
 		plugins: {},
 		rules: {
-			child: [1, 'never', false],
-			inner: [1, 'never', false],
-			outer: [1, 'never', true],
+			child: [RuleConfigSeverity.Warning, 'never', false],
+			inner: [RuleConfigSeverity.Warning, 'never', false],
+			outer: [RuleConfigSeverity.Warning, 'never', true],
 		},
 	});
 });
@@ -435,7 +437,7 @@ test('returns formatter name when unable to resolve from config directory', asyn
 test('does not mutate config module reference', async () => {
 	const file = 'config/commitlint.config.js';
 	const cwd = await gitBootstrap('fixtures/specify-config-file');
-	const rules = {'body-case': [1, 'never', 'camel-case'] as any};
+	const rules = {'body-case': [RuleConfigSeverity.Warning, 'never', 'camel-case'] as any};
 
 	const configPath = path.join(cwd, file);
 	const before = JSON.stringify(require(configPath));

--- a/@commitlint/prompt/src/library/utils.test.ts
+++ b/@commitlint/prompt/src/library/utils.test.ts
@@ -70,8 +70,8 @@ test('getMaxLength', () => {
 	);
 
 	const rules: any = {
-		'body-max-line-length': [2, 'always', 100],
-		'header-max-length': [2, 'always', 100],
+		'body-max-line-length': [RuleConfigSeverity.Error, 'always', 100],
+		'header-max-length': [RuleConfigSeverity.Error, 'always', 100],
 		'test-max-length': [RuleConfigSeverity.Disabled, 'always', 100],
 	};
 	let lengthRule = getRules('header', rules).find(getHasName('max-length'));
@@ -97,7 +97,7 @@ test('check enum rule filters', () => {
 		.find(enumRuleIsActive);
 	expect(enumRule).toEqual([
 		'type-enum',
-		[2, 'always', ['build', 'chore', 'ci']],
+		[RuleConfigSeverity.Error, 'always', ['build', 'chore', 'ci']],
 	]);
 
 	enumRule = getRules('string', rules)
@@ -108,7 +108,7 @@ test('check enum rule filters', () => {
 	enumRule = getRules('enum', rules)
 		.filter(getHasName('string'))
 		.find(enumRuleIsActive);
-	expect(enumRule).toEqual(['enum-string', [1, 'always', ['1', '2', '3']]]);
+	expect(enumRule).toEqual(['enum-string', [RuleConfigSeverity.Warning, 'always', ['1', '2', '3']]]);
 
 	enumRule = getRules('bar', rules)
 		.filter(getHasName('enum'))

--- a/@commitlint/resolve-extends/src/index.test.ts
+++ b/@commitlint/resolve-extends/src/index.test.ts
@@ -1,5 +1,5 @@
 import resolveExtends, {ResolveExtendsContext} from '.';
-import {UserConfig} from '@commitlint/types';
+import {RuleConfigSeverity, UserConfig} from '@commitlint/types';
 
 const id = (id: unknown) => id;
 
@@ -221,10 +221,10 @@ test('propagates contents recursively with overlap', () => {
 			case 'extender-name':
 				return {
 					extends: ['recursive-extender-name'],
-					rules: {rule: [1, 'always']},
+					rules: {rule: [RuleConfigSeverity.Warning, 'always']},
 				};
 			case 'recursive-extender-name':
-				return {rules: {rule: [2, 'never', 'four']}};
+				return {rules: {rule: [RuleConfigSeverity.Error, 'never', 'four']}};
 			default:
 				return {};
 		}
@@ -237,7 +237,7 @@ test('propagates contents recursively with overlap', () => {
 	const expected: UserConfig = {
 		extends: ['extender-name'],
 		rules: {
-			rule: [1, 'always'],
+			rule: [RuleConfigSeverity.Warning, 'always'],
 		},
 	};
 
@@ -250,9 +250,9 @@ test('extends rules from left to right with overlap', () => {
 	const require = (id: string): UserConfig => {
 		switch (id) {
 			case 'left':
-				return {rules: {a: [0, 'never', true]}};
+				return {rules: {a: [RuleConfigSeverity.Disabled, 'never', true]}};
 			case 'right':
-				return {rules: {a: [0, 'never', false], b: [0, 'never', true]}};
+				return {rules: {a: [RuleConfigSeverity.Disabled, 'never', false], b: [RuleConfigSeverity.Disabled, 'never', true]}};
 			default:
 				return {};
 		}
@@ -265,8 +265,8 @@ test('extends rules from left to right with overlap', () => {
 	const expected: UserConfig = {
 		extends: ['left', 'right'],
 		rules: {
-			a: [0, 'never', false],
-			b: [0, 'never', true],
+			a: [RuleConfigSeverity.Disabled, 'never', false],
+			b: [RuleConfigSeverity.Disabled, 'never', true],
 		},
 	};
 
@@ -381,7 +381,7 @@ test('plugins should be merged correctly', () => {
 test('rules should be merged correctly', () => {
 	const input: UserConfig = {
 		extends: ['extender-name'],
-		rules: {test1: [1, 'never', 'base']},
+		rules: {test1: [RuleConfigSeverity.Warning, 'never', 'base']},
 	};
 
 	const require = (id: string): UserConfig => {
@@ -389,15 +389,15 @@ test('rules should be merged correctly', () => {
 			case 'extender-name':
 				return {
 					extends: ['recursive-extender-name'],
-					rules: {test2: [2, 'never', id]},
+					rules: {test2: [RuleConfigSeverity.Error, 'never', id]},
 				};
 			case 'recursive-extender-name':
 				return {
 					extends: ['second-recursive-extender-name'],
-					rules: {test1: [0, 'never', id]},
+					rules: {test1: [RuleConfigSeverity.Disabled, 'never', id]},
 				};
 			case 'second-recursive-extender-name':
-				return {rules: {test2: [1, 'never', id]}};
+				return {rules: {test2: [RuleConfigSeverity.Warning, 'never', id]}};
 			default:
 				return {};
 		}
@@ -410,8 +410,8 @@ test('rules should be merged correctly', () => {
 	const expected: UserConfig = {
 		extends: ['extender-name'],
 		rules: {
-			test1: [1, 'never', 'base'],
-			test2: [2, 'never', 'extender-name'],
+			test1: [RuleConfigSeverity.Warning, 'never', 'base'],
+			test2: [RuleConfigSeverity.Error, 'never', 'extender-name'],
 		},
 	};
 
@@ -508,16 +508,16 @@ test('should correctly merge nested configs', () => {
 			case 'extender-2':
 				return {extends: ['extender-4']};
 			case 'extender-3':
-				return {rules: {test: [1, 'never', 3]}};
+				return {rules: {test: [RuleConfigSeverity.Warning, 'never', 3]}};
 			case 'extender-4':
 				return {
 					extends: ['extender-5', 'extender-6'],
-					rules: {test: [1, 'never', 4]},
+					rules: {test: [RuleConfigSeverity.Warning, 'never', 4]},
 				};
 			case 'extender-5':
-				return {rules: {test: [1, 'never', 5]}};
+				return {rules: {test: [RuleConfigSeverity.Warning, 'never', 5]}};
 			case 'extender-6':
-				return {rules: {test: [1, 'never', 6]}};
+				return {rules: {test: [RuleConfigSeverity.Warning, 'never', 6]}};
 			default:
 				return {};
 		}
@@ -530,7 +530,7 @@ test('should correctly merge nested configs', () => {
 	const expected = {
 		extends: ['extender-1'],
 		rules: {
-			test: [1, 'never', 4],
+			test: [RuleConfigSeverity.Warning, 'never', 4],
 		},
 	};
 


### PR DESCRIPTION
Same energy as b3007ee37e26722a5f468ed24ca0012628149ea0.
