### PR TITLE
feat(rules): add header-trim rule

### DIFF
--- a/@commitlint/config-conventional/index.js
+++ b/@commitlint/config-conventional/index.js
@@ -6,6 +6,7 @@ module.exports = {
 		'footer-leading-blank': [1, 'always'],
 		'footer-max-line-length': [2, 'always', 100],
 		'header-max-length': [2, 'always', 100],
+		'header-trim': [2, 'always'],
 		'subject-case': [
 			2,
 			'never',

--- a/@commitlint/rules/src/header-trim.test.ts
+++ b/@commitlint/rules/src/header-trim.test.ts
@@ -1,0 +1,77 @@
+import parse from '@commitlint/parse';
+import {Commit} from '@commitlint/types';
+import {headerTrim} from './header-trim';
+
+const messages = {
+	correct: 'test: subject',
+
+	whitespaceStart: ' test: subject',
+	whitespaceEnd: 'test: subject  ',
+	whitespaceSurround: ' test: subject ',
+
+	tabStart: '\t\ttest: subject',
+	tabEnd: 'test: subject\t\t',
+	tabSurround: '\t\ttest: subject\t',
+
+	mixStart: '\t\ttest: subject',
+	mixEnd: 'test: subject\t\t',
+	mixSurround: '\t \ttest: subject \t  \t',
+};
+
+const parsed = Object.entries(messages).reduce((_parsed, [key, message]) => {
+	_parsed[key] = parse(message);
+	return _parsed;
+}, {}) as Record<keyof typeof messages, Promise<Commit>>;
+
+test('should succeed when header is not surrounded by whitespace', async () => {
+	const result = headerTrim(await parsed.correct);
+	expect(result).toEqual(expect.arrayContaining([true]));
+});
+
+(
+	[
+		['mixed whitespace', parsed.mixStart],
+		['whitespace', parsed.whitespaceStart],
+		['tab', parsed.tabStart],
+	] as const
+).forEach(([desc, commit]) => {
+	test(`should fail with ${desc}`, async () => {
+		const result = headerTrim(await commit);
+		expect(result).toEqual(
+			expect.arrayContaining([false, 'header must not start with whitespace'])
+		);
+	});
+});
+
+(
+	[
+		['mixed whitespace', parsed.mixEnd],
+		['whitespace', parsed.whitespaceEnd],
+		['tab', parsed.tabEnd],
+	] as const
+).forEach(([desc, commit]) => {
+	test(`should fail when ends with ${desc}`, async () => {
+		const result = headerTrim(await commit);
+		expect(result).toEqual(
+			expect.arrayContaining([false, 'header must not end with whitespace'])
+		);
+	});
+});
+
+(
+	[
+		['mixed whitespace', parsed.mixSurround],
+		['whitespace', parsed.whitespaceSurround],
+		['tab', parsed.tabSurround],
+	] as const
+).forEach(([desc, commit]) => {
+	test(`should fail when surrounded by ${desc}`, async () => {
+		const result = headerTrim(await commit);
+		expect(result).toEqual(
+			expect.arrayContaining([
+				false,
+				'header must not be surrounded by whitespace',
+			])
+		);
+	});
+});

--- a/@commitlint/rules/src/header-trim.ts
+++ b/@commitlint/rules/src/header-trim.ts
@@ -1,0 +1,26 @@
+import message from '@commitlint/message';
+import {SyncRule} from '@commitlint/types';
+
+export const headerTrim: SyncRule = (parsed) => {
+	const {header} = parsed;
+
+	const startsWithWhiteSpace = header !== header.trimStart();
+	const endsWithWhiteSpace = header !== header.trimEnd();
+
+	switch (true) {
+		case startsWithWhiteSpace && endsWithWhiteSpace:
+			return [
+				false,
+				message(['header', 'must not be surrounded by whitespace']),
+			];
+
+		case startsWithWhiteSpace:
+			return [false, message(['header', 'must not start with whitespace'])];
+
+		case endsWithWhiteSpace:
+			return [false, message(['header', 'must not end with whitespace'])];
+
+		default:
+			return [true];
+	}
+};

--- a/@commitlint/rules/src/index.ts
+++ b/@commitlint/rules/src/index.ts
@@ -12,6 +12,7 @@ import {footerMaxLineLength} from './footer-max-line-length';
 import {footerMinLength} from './footer-min-length';
 import {headerCase} from './header-case';
 import {headerFullStop} from './header-full-stop';
+import {headerTrim} from './header-trim';
 import {headerMaxLength} from './header-max-length';
 import {headerMinLength} from './header-min-length';
 import {referencesEmpty} from './references-empty';
@@ -51,6 +52,7 @@ export default {
 	'header-full-stop': headerFullStop,
 	'header-max-length': headerMaxLength,
 	'header-min-length': headerMinLength,
+	'header-trim': headerTrim,
 	'references-empty': referencesEmpty,
 	'scope-case': scopeCase,
 	'scope-empty': scopeEmpty,

--- a/@commitlint/types/src/rules.ts
+++ b/@commitlint/types/src/rules.ts
@@ -105,6 +105,7 @@ export type RulesConfig<V = RuleConfigQuality.User> = {
 	'header-full-stop': RuleConfig<V, string>;
 	'header-max-length': LengthRuleConfig<V>;
 	'header-min-length': LengthRuleConfig<V>;
+	'header-trim': RuleConfig<V>;
 	'references-empty': RuleConfig<V>;
 	'scope-case': CaseRuleConfig<V>;
 	'scope-empty': RuleConfig<V>;

--- a/docs/reference-rules.md
+++ b/docs/reference-rules.md
@@ -212,6 +212,11 @@ Infinity
 0
 ```
 
+#### header-trim
+
+- **condition**: `header` must not have initial and / or trailing whitespaces
+- **rule**: `always`
+
 #### references-empty
 
 - **condition**: `references` has at least one entry


### PR DESCRIPTION
## Description

Followup  of https://github.com/conventional-changelog/commitlint/issues/3199#issuecomment-1531415980:

> Currently when having a leading space, the error message says that the subject is empty.
> I suggest that the error message instead says that there is leading whitespace.
> This is due to identifying extra unwanted leading whitespace is hard in a commit message.

I have added a rule to check that header do not start or end with whitespace characters: `header-trim`
The rule logs a different status message for each scenario (start / end / mixed).

I added the new rule to `@commitlint/config-conventional` config. 
Let me know if you prefer that the user manually opt-it or it I have to add it to other configurations.

## Motivation and Context

#3199

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  rules: {
    'header-trim': [2, 'always'],
  }
};
```


```sh
# fails
echo " feat: test commit" | yarn run commitlint
echo "feat: test commit " | yarn run commitlint
echo " feat: test commit " | yarn run commitlint

# passes
echo "feat: test commit " | yarn run commitlint
```

<img width="792" alt="Screenshot 2024-01-25 at 05 02 59" src="https://github.com/conventional-changelog/commitlint/assets/24919330/45a8a6a3-d58b-43da-b08d-cd1d9864b804">

## How Has This Been Tested?

```sh
yarn test
```

The new rule has been tested in `@commitlint/rules/src/header-trim.test.ts`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
