### PR TITLE
 docs: update husky to v9

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,3 +60,93 @@ To make your life easier commitlint is commitizen-friendly and provides the npm 
 - present tense
 - maximum of 100 characters
 - message format of `$type($scope): $message`
+
+## Testing
+
+From the project root directory, use the following commands to run the test suite
+
+```sh
+yarn clean
+yarn install
+yarn build
+yarn test
+```
+
+## Package dependency overview
+
+![commitlint-dependencies](https://user-images.githubusercontent.com/4248851/58385093-34b79780-7feb-11e9-8f27-bffc4aca3eba.png)
+
+(Partly outdated)
+
+## Publishing a release
+
+```sh
+npm login
+nvm use (if you have nvm installed)
+```
+
+- [nvm](https://github.com/nvm-sh/nvm)
+- [asdf](https://asdf-vm.com/) is supported as well
+
+```sh
+yarn clean
+yarn install
+yarn build
+yarn test
+yarn run publish --otp <one-time password>
+```
+
+If something in between fails (like a new package was added and needs to be published for the
+first time but you forgot) you can use `lerna publish from-package` to publish anything that
+has not been published yet.
+
+### Create GitHub release
+
+1. Copy changelog entry for the new version
+1. Create release for the new tag: https://github.com/conventional-changelog/commitlint/releases
+1. Post in the [commitlint Slack-channel][12]
+
+### Publish a `next` release (or i.e. patch release)
+
+```sh
+npm login
+nvm use (if you have nvm installed)
+```
+
+```sh
+yarn clean
+yarn install
+yarn build
+yarn test
+npx lerna publish --conventional-commits --dist-tag [`next` | `[PATCH_RELEASE_VERSION]`] --otp <one-time password>
+```
+
+If for some reason this stops in between, you can manually publish missing packages like this:
+
+```sh
+npm publish <package-name> --tag [`next` | `[PATCH_RELEASE_VERSION]`] --otp <one-time password>
+```
+
+#### Publishing (new) packages for the first time
+
+```sh
+npm publish [PACKAGE_NAME] --access public
+```
+
+From within the folder first i.e. `cd @commitlint/new-packages`.
+
+#### Move `next` to `latest`
+
+```sh
+npm login
+```
+
+```sh
+npx lerna exec --no-bail --no-private --no-sort --stream -- '[ -n "$(npm v . dist-tags.next)" ] && npm dist-tag add ${LERNA_PACKAGE_NAME}@$(npm v . dist-tags.next) latest --otp <one-time password>'
+```
+
+Remove next:
+
+```sh
+npx lerna exec --no-bail --no-private --no-sort --stream -- '[ -n "$(npm v . dist-tags.next)" ] && npm dist-tag rm ${LERNA_PACKAGE_NAME} next --otp <one-time password>'
+```

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 node @commitlint/cli/lib/cli.js --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 yarn lint-staged
+
+# be sure to build with up to date source
+# before running pre-commit hook which is using `@commitlint/cli/lib/cli.js`
+yarn build

--- a/README.md
+++ b/README.md
@@ -18,21 +18,24 @@
 
 ## Contents
 
-- [What is commitlint](#what-is-commitlint)
-  - [Benefits of using commitlint](#benefits-using-commitlint)
-- [Getting started](#getting-started)
-- [CLI](#cli)
-- [Config](#config)
-- [Shared configuration](#shared-configuration)
-- [API](#api)
-- [Tools](#tools)
-- [Version Support and Releases](#version-support-and-releases)
-- [Related projects](#related-projects)
-- [License](#license)
-- [Development](#development)
-  - [Install and run](#install-and-run)
-  - [Testing](#testing)
-  - [Publishing a release](#publishing-a-release)
+- [Get Started | Website](#get-started--website)
+  - [Contents](#contents)
+  - [What is commitlint](#what-is-commitlint)
+    - [Benefits of using commitlint](#benefits-of-using-commitlint)
+  - [Getting started](#getting-started)
+  - [CLI](#cli)
+  - [Config](#config)
+  - [Shared configuration](#shared-configuration)
+  - [Documentation](#documentation)
+  - [API](#api)
+  - [Tools](#tools)
+  - [Roadmap](#roadmap)
+  - [Version Support and Releases](#version-support-and-releases)
+    - [Releases](#releases)
+  - [Related projects](#related-projects)
+  - [License](#license)
+  - [Development](#development)
+    - [Install and run](#install-and-run)
 
 ---
 
@@ -48,15 +51,15 @@ type(scope?): subject  #scope is optional; multiple scopes are supported (curren
 
 Real world examples can look like this:
 
-```
+```text
 chore: run tests on travis ci
 ```
 
-```
+```text
 fix(server): send cors headers
 ```
 
-```
+```text
 feat(blog): add comment section
 ```
 
@@ -82,51 +85,6 @@ These can be modified by [your own configuration](#config).
 - ["The perks of committing with conventions" (Talk slides)](https://slides.com/marionebl/the-perks-of-committing-with-conventions#/)
 
 ## Getting started
-
-```sh
-# Install commitlint cli and conventional config
-npm install --save-dev @commitlint/{config-conventional,cli}
-# For Windows:
-npm install --save-dev @commitlint/config-conventional @commitlint/cli
-
-# Configure commitlint to use conventional config
-echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
-```
-
-To lint commits before they are created you can use Husky's `commit-msg` hook:
-
-```sh
-# Install Husky v6
-npm install husky --save-dev
-# or
-yarn add husky --dev
-
-# Activate hooks
-npx husky install
-# or
-yarn husky install
-```
-
-### Add hook
-
-> [!WARNING]  
-> It's necessary that you use **commit-msg** as the name for hook file.
-> Read Git hooks [documentation](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) for more info.
-
-```
-npx husky add .husky/commit-msg  'npx --no -- commitlint --edit ${1}'
-```
-
-**Or use installed package instead**
-
-```
-npm pkg set scripts.commitlint="commitlint --edit"
-npx husky add .husky/commit-msg 'npm run commitlint ${1}'
-```
-
-Check the [husky documentation](https://typicode.github.io/husky/#/?id=manual) on how you can automatically have Git hooks enabled after install for different `yarn` versions.
-
-**Detailed Setup instructions**
 
 - [Local setup](https://conventional-changelog.github.io/commitlint/#/guides-local-setup) - Lint messages on commit with husky
 - [CI setup](https://conventional-changelog.github.io/commitlint/#/guides-ci-setup) - Lint messages during CI builds
@@ -254,96 +212,6 @@ yarn run commitlint # run CLI
 ```
 
 For more information on how to contribute please take a look at our [contribution guide](./.github/CONTRIBUTING.md).
-
-### Testing
-
-From the project root directory, use the following commands to run the test suite
-
-```sh
-yarn clean
-yarn install
-yarn build
-yarn test
-```
-
-### Package dependency overview
-
-![commitlint-dependencies](https://user-images.githubusercontent.com/4248851/58385093-34b79780-7feb-11e9-8f27-bffc4aca3eba.png)
-
-(Partly outdated)
-
-### Publishing a release
-
-```sh
-npm login
-nvm use (if you have nvm installed)
-```
-
-- [nvm](https://github.com/nvm-sh/nvm)
-- [asdf](https://asdf-vm.com/) is supported as well
-
-```sh
-yarn clean
-yarn install
-yarn build
-yarn test
-yarn run publish --otp <one-time password>
-```
-
-If something in between fails (like a new package was added and needs to be published for the
-first time but you forgot) you can use `lerna publish from-package` to publish anything that
-has not been published yet.
-
-#### Create GitHub release
-
-1. Copy changelog entry for the new version
-1. Create release for the new tag: https://github.com/conventional-changelog/commitlint/releases
-1. Post in the [commitlint Slack-channel][12]
-
-#### Publish a `next` release (or i.e. patch release)
-
-```sh
-npm login
-nvm use (if you have nvm installed)
-```
-
-```sh
-yarn clean
-yarn install
-yarn build
-yarn test
-npx lerna publish --conventional-commits --dist-tag [`next` | `[PATCH_RELEASE_VERSION]`] --otp <one-time password>
-```
-
-If for some reason this stops in between, you can manually publish missing packages like this:
-
-```sh
-npm publish <package-name> --tag [`next` | `[PATCH_RELEASE_VERSION]`] --otp <one-time password>
-```
-
-##### Publishing (new) packages for the first time
-
-```sh
-npm publish [PACKAGE_NAME] --access public
-```
-
-From within the folder first i.e. `cd @commitlint/new-packages`.
-
-##### Move `next` to `latest`
-
-```sh
-npm login
-```
-
-```sh
-npx lerna exec --no-bail --no-private --no-sort --stream -- '[ -n "$(npm v . dist-tags.next)" ] && npm dist-tag add ${LERNA_PACKAGE_NAME}@$(npm v . dist-tags.next) latest --otp <one-time password>'
-```
-
-Remove next:
-
-```sh
-npx lerna exec --no-bail --no-private --no-sort --stream -- '[ -n "$(npm v . dist-tags.next)" ] && npm dist-tag rm ${LERNA_PACKAGE_NAME} next --otp <one-time password>'
-```
 
 [0]: https://img.shields.io/badge/stability-stable-green.svg?style=flat-square
 [1]: https://nodejs.org/api/documentation.html#documentation_stability_index

--- a/docs/guides-local-setup.md
+++ b/docs/guides-local-setup.md
@@ -9,49 +9,128 @@ This guide demonstrates how to achieve this via git hooks.
 Install `commitlint` and a `commitlint-config-*` of your choice as devDependency and
 configure `commitlint` to use it.
 
-```bash
+---
+
+<details open>
+<summary>NPM</summary>
+
+```sh
 # Install and configure if needed
 npm install --save-dev @commitlint/{cli,config-conventional}
 # For Windows:
 npm install --save-dev @commitlint/config-conventional @commitlint/cli
+```
 
+</details>
+
+---
+
+<details>
+<summary>YARN</summary>
+
+```sh
+# Install and configure if needed
+yarn add --dev @commitlint/{cli,config-conventional}
+```
+
+</details>
+
+## Configuration
+
+```sh
 # Configure commitlint to use conventional config
 echo "module.exports = { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
 ```
 
-Alternatively the configuration can be defined in a `commitlint.config.js`, `.commitlintrc.js`, `.commitlintrc`, `.commitlintrc.json`, `.commitlintrc.yml` file or a `commitlint` field in `package.json`.
+Configuration can be defined in the following files:
 
-## Install husky
+- `.commitlintrc`
+- `.commitlintrc.json`
+- `.commitlintrc.yaml`
+- `.commitlintrc.yml`
+- `.commitlintrc.js`
+- `.commitlintrc.cjs`
+- `.commitlintrc.mjs`
+- `.commitlintrc.ts`
+- `.commitlintrc.cts`
+- `commitlint.config.js`
+- `commitlint.config.cjs`
+- `commitlint.config.mjs`
+- `commitlint.config.ts`
+- `commitlint.config.cts`
 
-Install `husky` as devDependency, a handy git hook helper available on npm.
+Alternatively you can add `commitlint` field in `package.json`
+
+Refer to [configuration documentation](reference-configuration.md) for more information.
+
+## Add hook
+
+To use commitlint you need to setup `commit-msg` hook
+
+### Using a git hooks manager
+
+To lint commits before they are created you can use [Husky](https://typicode.github.io/husky/)'s `commit-msg` hook.
+
+You can find complete setup instructions on the [official documentation](https://typicode.github.io/husky/get-started.html).
+
+> The following instructions are meant to `husky@v9` if you are using a different version
+> consult the official documentation of your version.
+
+---
+
+<details open>
+<summary>NPM</summary>
 
 ```sh
-# Install Husky v6
-npm install husky --save-dev
-# or
-yarn add husky --dev
+npm install --save-dev husky
 
-# Activate hooks
-npx husky install
-# or
-yarn husky install
+npx husky init
+
+# Add commit message linting to commit-msg hook
+echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
 ```
 
-### Add hook
+As an alternative you can create a script inside `package.json`
 
-```
-npx husky add .husky/commit-msg  'npx --no -- commitlint --edit ${1}'
-```
-
-**Or use installed package instead**
-
-```
+```sh
 npm pkg set scripts.commitlint="commitlint --edit"
-npx husky add .husky/commit-msg 'npm run commitlint ${1}'
+echo "npm run commitlint \${1}" > .husky/commit-msg
 ```
 
-**Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)**\
-Check the [husky documentation](https://typicode.github.io/husky/#/?id=manual) on how you can automatically have Git hooks enabled after install for different `yarn` versions.
+</details>
+
+---
+
+<details>
+<summary>YARN</summary>
+
+```sh
+yarn add --dev husky
+
+yarn husky init
+
+# Add commit message linting to commit-msg hook
+echo "yarn commitlint --edit \$1" > .husky/commit-msg
+```
+
+As an alternative you can create a script inside `package.json`
+
+```sh
+npm pkg set scripts.commitlint="commitlint --edit"
+echo "yarn commitlint \${1}" > .husky/commit-msg
+```
+
+Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)
+
+</details>
+
+---
+
+### Using git hooks
+
+Info about git hooks can be found on [Git documentation](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).
+
+> It's necessary that you use **commit-msg** as the name for hook file.
 
 ## Test
 
@@ -71,7 +150,7 @@ You can test the hook by simply committing. You should see something like this i
 
 ```bash
 git commit -m "foo: this will fail"
-husky > commit-msg (node v10.1.0)
+#  husky > commit-msg
 No staged files match any of provided globs.
 ⧗   input: foo: this will fail
 ✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]
@@ -79,7 +158,7 @@ No staged files match any of provided globs.
 ✖   found 1 problems, 0 warnings
 ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
 
-husky > commit-msg hook failed (add --no-verify to bypass)
+husky - commit-msg script failed (code 1)
 ```
 
 Since [v8.0.0](https://github.com/conventional-changelog/commitlint/releases/tag/v8.0.0) `commitlint` won't output anything if there are no problems with your commit.\
@@ -87,9 +166,9 @@ Since [v8.0.0](https://github.com/conventional-changelog/commitlint/releases/tag
 
 ```bash
 git commit -m "chore: lint on commitmsg"
-husky > pre-commit (node v10.1.0)
+# husky > pre-commit
 No staged files match any of provided globs.
-husky > commit-msg (node v10.1.0)
+# husky > commit-msg
 ```
 
 ?> Local linting is fine for fast feedback but can easily be tinkered with. To ensure all commits are linted you'll want to check commits on an automated CI Server too. Learn how to in the [CI Setup guide](guides-ci-setup.md).

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "yarn watch",
     "test": "cross-env HOME=$PWD NODE_OPTIONS=--experimental-vm-modules jest",
     "test-ci": "yarn test --runInBand",
-    "postinstall": "yarn husky install"
+    "prepare": "husky"
   },
   "commitlint": {
     "extends": [
@@ -95,7 +95,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-jest": "^27.2.3",
-    "husky": "^8.0.0",
+    "husky": "^9.0.6",
     "jest": "^29.6.2",
     "lerna": "^6.0.0",
     "lint-staged": "15.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4841,10 +4841,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^8.0.0:
-  version "8.0.3"
-  resolved "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+husky@^9.0.6:
+  version "9.0.6"
+  resolved "https://registry.npmjs.org/husky/-/husky-9.0.6.tgz#cee0245d60480b12279cf492ec6cfc1aeb7fa759"
+  integrity sha512-EEuw/rfTiMjOfuL7pGO/i9otg1u36TXxqjIA6D9qxVjd/UXoDOsLor/BSFf5hTK50shwzCU3aVVwdXDp/lp7RA==
 
 iconv-lite@^0.4.24:
   version "0.4.24"


### PR DESCRIPTION
## Description

`husky` has been updated to `v9`.

Closes #3873

### `husky` update

[husky migration guide instructions](https://github.com/typicode/husky/releases/tag/v9.0.1)

- `package.json` script `postinstall` has been removed and replaced by `"prepare": "husky"` as per new setup instructions
- husky hooks have been recreated using the new procedure `echo "{...}" > .husky/{...}`

### README updates

- Release procedure information has been moved to `.github/CONTRIBUTING.md` 
- "Getting started" is very similar to the one in the website so I think that is better to simply create a link to the website.
  By doing so setup maintenance effort should be reduced.

### Documentation updates

Local setup instructions have been updated.
For shell instructions I created an accordion item for each single package manager. 
I added just `npm` and `yarn` but let me know if I need to add also `bun` or `pnpm`.

<img width="1114" alt="image" src="https://github.com/conventional-changelog/commitlint/assets/24919330/2db5df0a-ce15-4c35-bae7-e37a9d1575bd">

## Motivation and Context

- #3870
- #3873

## Usage examples

N/A

## How Has This Been Tested?

```sh
yarn test
yarn docs
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
