### PR TITLE
CI: add an Ubuntu LTS job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,3 +30,30 @@ jobs:
 
       - name: Test
         run: yarn test-ci
+
+  nodeJsBaselineAptCompatibility:
+    name: NodeJS installed from stock Ubuntu-LTS packages (not external sources)
+    runs-on: ubuntu-22.04
+    container:
+      image: "ubuntu:24.04"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          apt update --yes
+          apt upgrade --yes
+
+          # NOTE: do not change the below with an `actions/setup-node` step! or it
+          # would make this CI job entirely pointless
+          apt install --yes npm
+
+          npm install --global yarn
+          yarn install
+
+      - name: Build
+        run: yarn build
+
+      - name: Run Tests
+        run: yarn test-ci
+


### PR DESCRIPTION
This way we will make sure that any dependency upgrades don't make commitlint lose compatibility with the default version shipped with an LTS version of Ubuntu, starting with 24.04.

This is, IMO, important, because AFAIU commitlint lost, some months ago, compatibility with the NodeJS version shipped with Ubuntu 22.04, and thus it requires its users to install NodeJS from external sources, which is a potential security risk (and stability risk because of needing to rely on more bleeding edge versions).