### PR TITLE
docs: fix github actions ci example

### DIFF
--- a/docs/guides-ci-setup.md
+++ b/docs/guides-ci-setup.md
@@ -17,28 +17,18 @@ on: [push, pull_request]
 
 jobs:
   commitlint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install required dependencies
-        run: |
-          apt update
-          apt install -y sudo
-          sudo apt install -y git curl
-          curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
-      - name: Print versions
-        run: |
-          git --version
-          node --version
-          npm --version
-          npx commitlint --version
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
       - name: Install commitlint
-        run: |
-          npm install conventional-changelog-conventionalcommits
-          npm install commitlint@latest
+        run: npm i -g @commitlint/{cli,config-conventional}
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'

--- a/docs/guides-ci-setup.md
+++ b/docs/guides-ci-setup.md
@@ -17,18 +17,23 @@ on: [push, pull_request]
 
 jobs:
   commitlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '20'
+
+      - name: Install required dependencies
+        run: |
+          apt update
+          apt install -y sudo
+          sudo apt install -y git curl
+          curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
 
       - name: Install commitlint
-        run: npm i -g @commitlint/{cli,config-conventional}
+        run: npm install --global @commitlint/{cli,config-conventional}
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the github actions CI example. The previous one doesn't works by itself and has some unnecessary steps, so these changes turns the example CI more solid and developer friendly.

<!--- Describe your changes in detail -->

## Motivation and Context
When I try to run the provided github CI example in a personal project it always returns the following error:

```
Run npx commitlint --from HEAD~1 --to HEAD --verbose
/home/runner/work/eslint-config/eslint-config/node_modules/commitlint/node_modules/@commitlint/cli/lib/cli.js:123
        throw err;
        ^

Error: fatal: ambiguous argument 'HEAD~1..HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

    at Transform._transform (/home/runner/work/eslint-config/eslint-config/node_modules/git-raw-commits/index.js:8[4](https://github.com/pitagoras-educacao/eslint-config/actions/runs/7746930452/job/21126268440#step:5:5):30)
    at Transform._read (/home/runner/work/eslint-config/eslint-config/node_modules/readable-stream/lib/_stream_transform.js:166:10)
    at Transform._write (/home/runner/work/eslint-config/eslint-config/node_modules/readable-stream/lib/_stream_transform.js:1[5](https://github.com/pitagoras-educacao/eslint-config/actions/runs/7746930452/job/21126268440#step:5:6)5:83)
    at doWrite (/home/runner/work/eslint-config/eslint-config/node_modules/readable-stream/lib/_stream_writable.js:390:139)
    at writeOrBuffer (/home/runner/work/eslint-config/eslint-config/node_modules/readable-stream/lib/_stream_writable.js:381:5)
    at Transform.Writable.write (/home/runner/work/eslint-config/eslint-config/node_modules/readable-stream/lib/_stream_writable.js:302:11)
    at Socket.ondata (internal/streams/readable.js:731:22)
    at Socket.emit (events.js:412:35)
    at addChunk (internal/streams/readable.js:293:12)
    at readableAddChunk (internal/streams/readable.js:2[6](https://github.com/pitagoras-educacao/eslint-config/actions/runs/7746930452/job/21126268440#step:5:7)3:[11](https://github.com/pitagoras-educacao/eslint-config/actions/runs/7746930452/job/21126268440#step:5:12))
Error: Process completed with exit code 1.
```

This happens because we have to manually checkout the repository with the **ref** tag on **actions/checkout** actions. Otherwise, there is going to be no HEAD in the container running our pipeline. This is the main change.

- Upgrade default container image to ubuntu-latest
- Upgrade actions/checkout from v3 to v4
- Avoid unnecessary steps using actions/setup-node github action
- Install commitlint globally and use the scoped distribution

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I've used the exact same implementation on a personal project and it worked

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x ] Documentation improvements

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
