### PR TITLE
chore(@commitlint/config-nx-scopes): add support for nx 18

### DIFF
--- a/@commitlint/config-nx-scopes/package.json
+++ b/@commitlint/config-nx-scopes/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "peerDependencies": {
-    "nx": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+    "nx": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "nx": {


### PR DESCRIPTION

## Description

[Nx version 18](https://github.com/nrwl/nx/releases/tag/18.0.0) has been released and it does not break `@commitlint/config-nx-scopes` support.

## Motivation and Context

After updating Nx to version 18 package managers throws a warning for unmet peer-dependencies for `@commitlint/config-nx-scopes`.

## How Has This Been Tested?

@commitlint/config-nx-scopes still works as expected after updating Nx to version 18.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
