### PR TITLE
feat(cli): introduce new --last flag, to stop recommending HEAD~1

### DIFF
--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -52,6 +52,16 @@ test('should produce success output with --verbose flag', async () => {
 	expect(actual.stderr).toEqual('');
 });
 
+test('should produce last commit and success output with --verbose flag', async () => {
+	const cwd = await gitBootstrap('fixtures/simple');
+	await execa('git', ['add', 'commitlint.config.js'], {cwd});
+	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
+	const actual = await cli(['--last', '--verbose'], {cwd})();
+	expect(actual.stdout).toContain('0 problems, 0 warnings');
+	expect(actual.stdout).toContain('test: this should work');
+	expect(actual.stderr).toEqual('');
+});
+
 test('should produce no output with --quiet flag', async () => {
 	const cwd = await gitBootstrap('fixtures/default');
 	const actual = await cli(['--quiet'], {cwd})('foo: bar');

--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -539,6 +539,7 @@ test('should print help', async () => {
 		  -H, --help-url       help url in error message  [string]
 		  -f, --from           lower end of the commit range to lint; applies if edit=false  [string]
 		      --git-log-args   additional git log arguments as space separated string, example '--first-parent --cherry-pick'  [string]
+		  -l, --last           just analyze the last commit; applies if edit=false  [boolean]
 		  -o, --format         output format of the results  [string]
 		  -p, --parser-preset  configuration preset to use for conventional-commits-parser  [string]
 		  -q, --quiet          toggle console output  [boolean] [default: false]

--- a/@commitlint/cli/src/types.ts
+++ b/@commitlint/cli/src/types.ts
@@ -9,6 +9,7 @@ export interface CliFlags {
 	'help-url'?: string;
 	from?: string;
 	'git-log-args'?: string;
+	last?: boolean;
 	format?: string;
 	'parser-preset'?: string;
 	quiet: boolean;

--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -39,14 +39,14 @@
     "@commitlint/test": "^19.0.0",
     "@commitlint/utils": "^19.0.0",
     "@types/git-raw-commits": "^2.0.3",
-    "@types/minimist": "^1.2.4",
-    "execa": "^8.0.1"
+    "@types/minimist": "^1.2.4"
   },
   "dependencies": {
     "@commitlint/top-level": "^19.0.0",
     "@commitlint/types": "^19.0.3",
     "git-raw-commits": "^4.0.0",
-    "minimist": "^1.2.8"
+    "minimist": "^1.2.8",
+    "execa": "^8.0.1"
   },
   "gitHead": "70f7f4688b51774e7ac5e40e896cdaa3f132b2bc"
 }

--- a/@commitlint/read/src/read.ts
+++ b/@commitlint/read/src/read.ts
@@ -4,10 +4,13 @@ import type {GitOptions} from 'git-raw-commits';
 import {getHistoryCommits} from './get-history-commits.js';
 import {getEditCommit} from './get-edit-commit.js';
 
+import {execa} from 'execa';
+
 interface GetCommitMessageOptions {
 	cwd?: string;
 	from?: string;
 	to?: string;
+	last?: boolean;
 	edit?: boolean | string;
 	gitLogArgs?: string;
 }
@@ -16,10 +19,15 @@ interface GetCommitMessageOptions {
 export default async function getCommitMessages(
 	settings: GetCommitMessageOptions
 ): Promise<string[]> {
-	const {cwd, from, to, edit, gitLogArgs} = settings;
+	const {cwd, from, to, last, edit, gitLogArgs} = settings;
 
 	if (edit) {
 		return getEditCommit(cwd, edit);
+	}
+
+	if (last) {
+		const executeGitCommand = await execa('git', ['log', '-1', '--pretty=%B']);
+		return [executeGitCommand.stdout];
 	}
 
 	let gitOptions: GitOptions = {from, to};

--- a/@commitlint/read/src/read.ts
+++ b/@commitlint/read/src/read.ts
@@ -26,7 +26,11 @@ export default async function getCommitMessages(
 	}
 
 	if (last) {
-		const executeGitCommand = await execa('git', ['log', '-1', '--pretty=%B']);
+		const executeGitCommand = await execa('git', [
+			'log',
+			'-1',
+			'--pretty=format:"%B"',
+		]);
 		return [executeGitCommand.stdout];
 	}
 

--- a/docs/guides/ci-setup.md
+++ b/docs/guides/ci-setup.md
@@ -42,7 +42,7 @@ jobs:
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
-        run: npx commitlint --from HEAD~1 --to HEAD --verbose
+        run: npx commitlint --last --verbose
 
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'

--- a/tsconfig.shared.json
+++ b/tsconfig.shared.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
-    "lib": ["es2017"],
+    "target": "ES2022",
+    "lib": ["es2022"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
HEAD~1 is brittle because it would fail in single-commit scenarios.

Closes https://github.com/conventional-changelog/commitlint/pull/3892