### PR TITLE
ci: add codeQuality job to run lint and format task

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,27 @@ jobs:
       - name: Test
         run: yarn test
 
+  codeQuality:
+    name: Code quality
+    needs: [build]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --ignore-engines --frozen-lockfile
+
+      - name: Check format
+        run: yarn format
+
+      - name: Lint
+        run: yarn lint
+
   nodeJsBaselineAptCompatibility:
     name: NodeJS installed from stock Ubuntu-LTS packages (not external sources)
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description

Add a new `codeQuality` job inside `CI` workflow.
The new job runs before `build` and `nodeJsBaselineAptCompatibility`.

Executed task are:
1. `yarn build`
2. `yarn format`
3. `yarn lint`

This should avoid lints error addition if someone forgets to run `yarn lint`.

## Motivation and Context

During #3850 I noticed that a lint issue fix was performed with a separate [commit](https://github.com/conventional-changelog/commitlint/pull/3850/commits/6aaa6c1526735489e7dcf80518da6fd6526b1376).

Basically `config-nx-scopes` was missing `@commitlint/types` dependency and running `yarn lint` shows that error.

You can see the same fix also on the [fix lodash PR](https://github.com/conventional-changelog/commitlint/pull/3901/commits/e72eba4433ead94efd9c628d4330b81e1a0cbe82)

## Usage examples

N/A

## How Has This Been Tested?

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Github actions
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
