### PR TITLE
add troubleshoot on documentation  and some lint minor refactors

### DIFF
--- a/@commitlint/lint/src/lint.test.ts
+++ b/@commitlint/lint/src/lint.test.ts
@@ -93,7 +93,9 @@ test('throws for invalid rule names', async () => {
 		bar: [RuleConfigSeverity.Warning, 'never'],
 	});
 
-	await expect(error).rejects.toThrow(/^Found invalid rule names: foo, bar/);
+	await expect(error).rejects.toThrow(
+		/^Found rules without implementation: foo, bar/
+	);
 });
 
 test('throws for invalid rule config', async () => {

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -79,9 +79,10 @@ export default async function lint(
 	if (missing.length > 0) {
 		const names = [...allRules.keys()];
 		throw new RangeError(
-			`Found invalid rule names: ${missing.join(
-				', '
-			)}. Supported rule names are: ${names.join(', ')}`
+			[
+				`Found rules without implementation: ${missing.join(', ')}.`,
+				`Supported rules are: ${names.join(', ')}.`,
+			].join('\n')
 		);
 	}
 

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -181,10 +181,10 @@ export default async function lint(
 	);
 
 	const errors = results.filter(
-		(result) => result.level === 2 && !result.valid
+		(result) => result.level === RuleConfigSeverity.Error && !result.valid
 	);
 	const warnings = results.filter(
-		(result) => result.level === 1 && !result.valid
+		(result) => result.level === RuleConfigSeverity.Warning && !result.valid
 	);
 
 	const valid = errors.length === 0;

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
 				base: '/support',
 				collapsed: true,
 				items: [
+					{text: 'Troubleshooting', link: '/troubleshooting'},
 					{text: 'Releases', link: '/releases'},
 					{text: 'Upgrade commitlint', link: '/upgrade'},
 				],

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -1,0 +1,26 @@
+# Troubleshooting
+
+## Getting `Range error: Found invalid rule names: [...]` after update {#range-error-invalid-rule}
+
+After updating one or more `@commitlint` packages you might encounter an error like:
+
+```text
+Found invalid rule names: header-trim.
+Supported rule names are: body-case, body-empty, ...
+```
+
+The source of this error is likely a mismatch of version between `@commitlint` packages in `node_modules`.
+
+E.g.: you might have a config requesting a rule that is not included in `@commitlint/rules`.
+
+> [!TIP]
+> If you are relying on a config which depends on an earlier version of `@commitlint/config-conventional` be sure to update them:
+>
+> ```sh
+> npm update @commitlint/config-conventional
+> ```
+
+---
+
+> [!NOTE]
+> Detailed explanation about the error can be found in this [comment](https://github.com/conventional-changelog/commitlint/pull/3871#issuecomment-1911455325).


### PR DESCRIPTION
## Description

Closes #3894.

I added a new section in the documentation with the step to troubleshoot error similar to the one described on #3894.

I also made two additional changes:
- I changed the error message to be more simple IMHO.
- I used `RuleConfigSeverity` enum to compute outcome `warnings` and `errors`. 
  (The enum was already imported)

## Motivation and Context

 #3894

## Usage examples

N/A

## How Has This Been Tested?

`yarn test`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
