### PR TITLE
chore: reorder 2 BUG_REPORT.yml elements

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -8,11 +8,14 @@ body:
       value: |
         Provide a general summary of the issue in the Title above
   - type: textarea
-    id: expected-behavior
+    id: steps-to-reproduce
     attributes:
-      label: 'Expected Behavior'
-      description: Tell us what should happen
-      placeholder: Short and explicit description of your incident...
+      label: 'Steps to Reproduce'
+      description: Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include code to reproduce, if relevant
+      value: |
+        1. First step
+        2. Second step
+      render: bash
     validations:
       required: true
   - type: textarea
@@ -22,6 +25,14 @@ body:
       description: Tell us what happens instead of the expected behavior
     validations:
       required: false
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: 'Expected Behavior'
+      description: Tell us what should happen
+      placeholder: Short and explicit description of your incident...
+    validations:
+      required: true
   - type: checkboxes
     id: affected-packages
     attributes:
@@ -38,17 +49,6 @@ body:
       description: Not obligatory, but suggest a fix/reason for the bug, or ideas how to implement the addition or change
     validations:
       required: false
-  - type: textarea
-    id: steps-to-reproduce
-    attributes:
-      label: 'Steps to Reproduce'
-      description: Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include code to reproduce, if relevant
-      value: |
-        1. First step
-        2. Second step
-      render: bash
-    validations:
-      required: true
   - type: textarea
     id: context
     attributes:


### PR DESCRIPTION
* Moved 'Steps to reproduce' section before Current/Expected behaviour.
* Moved 'Current behaviour' before 'Expected behaviour'.

This way it feels more natural.
