### PR TITLE
fix: add `main` and `types` keys in package.json

### DIFF
--- a/@commitlint/config-angular-type-enum/package.json
+++ b/@commitlint/config-angular-type-enum/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "19.0.0",
   "description": "Shareable commitlint config enforcing the angular commit convention types",
+  "main": "index.js",
   "files": [
     "index.js"
   ],

--- a/@commitlint/config-nx-scopes/package.json
+++ b/@commitlint/config-nx-scopes/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "19.0.3",
   "description": "Shareable commitlint config enforcing nx project names as scopes",
+  "main": "index.js",
   "files": [
     "index.js"
   ],

--- a/@commitlint/config-patternplate/package.json
+++ b/@commitlint/config-patternplate/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "19.0.3",
   "description": "Lint your commits, patternplate-style",
+  "main": "index.js",
   "files": [
     "index.js"
   ],

--- a/@commitlint/config-pnpm-scopes/package.json
+++ b/@commitlint/config-pnpm-scopes/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "19.0.0",
   "description": "Shareable commitlint config enforcing pnpm workspaces names as scopes",
+  "main": "index.js",
   "files": [
     "index.js"
   ],

--- a/@commitlint/config-rush-scopes/package.json
+++ b/@commitlint/config-rush-scopes/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "19.0.0",
   "description": "Shareable commitlint config enforcing rush package and workspace names as scopes",
+  "main": "index.js",
   "files": [
     "index.js"
   ],

--- a/@commitlint/prompt-cli/package.json
+++ b/@commitlint/prompt-cli/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "19.0.3",
   "description": "commit prompt using commitlint.config.js",
+  "main": "cli.js",
   "files": [
     "cli.js"
   ],

--- a/@commitlint/travis-cli/package.json
+++ b/@commitlint/travis-cli/package.json
@@ -3,6 +3,8 @@
   "type": "module",
   "version": "19.0.3",
   "description": "Lint all relevant commits for a change or PR on Travis CI",
+  "main": "lib/cli.js",
+  "types": "lib/cli.d.ts",
   "files": [
     "lib/",
     "cli.js"


### PR DESCRIPTION
## Description

Fixes #3948
Fixes #3952

## Motivation and Context

Some packages `package.json` do not have the `main` key to define their default export.

I added  the `main` key and when necessary the `types` key.

## Usage examples

N/A

## How Has This Been Tested?

yarn test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
