### PR TITLE
fix: add missing `conditions` param for `moduleResolve`

### DIFF
--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -177,7 +177,7 @@ function resolveConfig(
 	raw: string,
 	context: ResolveExtendsContext = {}
 ): string {
-	const resolve = context.resolve || tryResolveId;
+	const resolve = context.resolve || resolveId;
 	const id = getId(raw, context.prefix);
 
 	let resolved: string;
@@ -192,20 +192,6 @@ function resolveConfig(
 	}
 
 	return resolved;
-}
-
-function tryResolveId(id: string, context: ResolveExtendsContext) {
-	const cwd = context.cwd || process.cwd();
-
-	for (const suffix of ['', '.js', '.json', '/index.js', '/index.json']) {
-		try {
-			return fileURLToPath(
-				moduleResolve(id + suffix, pathToFileURL(path.join(cwd, id)))
-			);
-		} catch {}
-	}
-
-	return resolveId(id, context);
 }
 
 function resolveId(

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -26,6 +26,8 @@ const pathSuffixes = [
 
 const specifierSuffixes = ['', '.js', '.json', '/index.js', '/index.json'];
 
+const conditions = new Set(['import', 'node']);
+
 /**
  * @see moduleResolve
  */
@@ -51,7 +53,7 @@ export const resolveFrom = (lookup: string, parent?: string): string => {
 
 	for (const suffix of specifierSuffixes) {
 		try {
-			return fileURLToPath(moduleResolve(lookup + suffix, base));
+			return fileURLToPath(moduleResolve(lookup + suffix, base, conditions));
 		} catch (err) {
 			if (!resolveError) {
 				resolveError = err as Error;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

related https://github.com/wooorm/import-meta-resolve/issues/24

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It fixes a possible issue when using a dual-package config, without this change, commonjs entry could be resolved, with this change, ESM entry will be preferred correctly.

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
