### PR TITLE
fix: add missing cjs entry in package

### DIFF
--- a/@commitlint/cz-commitlint/index.cjs
+++ b/@commitlint/cz-commitlint/index.cjs
@@ -1,0 +1,4 @@
+/** @type {Awaited<typeof import('./lib/index.js')>['prompter']} */
+exports.prompter = async (...args) => {
+	(await import('./lib/index.js')).prompter(...args);
+};

--- a/@commitlint/cz-commitlint/package.json
+++ b/@commitlint/cz-commitlint/package.json
@@ -6,9 +6,10 @@
   "main": "./lib/index.js",
   "exports": {
     "import": "./lib/index.js",
-    "require": "./lib/index.cjs"
+    "require": "./index.cjs"
   },
   "files": [
+    "index.cjs",
     "lib"
   ],
   "keywords": [

--- a/@commitlint/cz-commitlint/src/index.cjs
+++ b/@commitlint/cz-commitlint/src/index.cjs
@@ -1,4 +1,0 @@
-/** @type {Awaited<typeof import('./index.js')>['prompter']} */
-exports.prompter = async (...args) => {
-	(await import('./index.js')).prompter(...args);
-};


### PR DESCRIPTION
Follow up #3963, fixes the missing cjs entry for `@commitlint/cz-commitlint`

https://github.com/conventional-changelog/commitlint/pull/3963#issuecomment-1987544876