### PR TITLE
fix(config-nx-scopes): include file extension in nx imports

### DIFF
--- a/@commitlint/config-nx-scopes/index.js
+++ b/@commitlint/config-nx-scopes/index.js
@@ -1,6 +1,6 @@
 import {RuleConfigSeverity} from '@commitlint/types';
-import {getProjects as getNXProjects} from 'nx/src/generators/utils/project-configuration';
-import {FsTree} from 'nx/src/generators/tree';
+import {getProjects as getNXProjects} from 'nx/src/generators/utils/project-configuration.js';
+import {FsTree} from 'nx/src/generators/tree.js';
 
 export default {
 	utils: {getProjects},


### PR DESCRIPTION
As the package is now pure ESM, we need to add the file extension to imports from nx as they are not coming from a package.json export field (https://nodejs.org/api/esm.html#esm_mandatory_file_extension).

## Description

By adding the file extensions, the modules get resolved again.

## Motivation and Context

Fixes https://github.com/conventional-changelog/commitlint/issues/3978


## How Has This Been Tested?

Verified on https://github.com/timonmasberg/commitlint-nx-bug, which is a reporduction for the bug.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
