### PR TITLE
Fix regression when using --last flag

### DIFF
--- a/@commitlint/cli/fixtures/last-flag-regression/commitlint.config.js
+++ b/@commitlint/cli/fixtures/last-flag-regression/commitlint.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    rules: {
+        'subject-empty': [2, 'never'],
+    	'type-empty': [2, 'never'],
+        'type-enum': [2, 'always', [
+            'test'
+        ]]
+    }
+};

--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -62,6 +62,16 @@ test('should produce last commit and success output with --verbose flag', async 
 	expect(actual.stderr).toEqual('');
 });
 
+test('regression test for running with --last flag', async () => {
+	const cwd = await gitBootstrap('fixtures/last-flag-regression');
+	await execa('git', ['add', 'commitlint.config.js'], {cwd});
+	await execa('git', ['commit', '-m', '"test: this should work"'], {cwd});
+	const actual = await cli(['--last', '--verbose'], {cwd})();
+	expect(actual.stdout).toContain('0 problems, 0 warnings');
+	expect(actual.stdout).toContain('test: this should work');
+	expect(actual.stderr).toEqual('');
+});
+
 test('should produce no output with --quiet flag', async () => {
 	const cwd = await gitBootstrap('fixtures/default');
 	const actual = await cli(['--quiet'], {cwd})('foo: bar');

--- a/@commitlint/read/src/read.ts
+++ b/@commitlint/read/src/read.ts
@@ -26,12 +26,16 @@ export default async function getCommitMessages(
 	}
 
 	if (last) {
-		const executeGitCommand = await execa('git', [
+		const gitCommandResult = await execa('git', [
 			'log',
 			'-1',
-			'--pretty=format:"%B"',
+			'--pretty=format:%B',
 		]);
-		return [executeGitCommand.stdout];
+		let output = gitCommandResult.stdout;
+		// strip output of extra quotation marks ("")
+		if (output[0] == '"' && output[output.length - 1] == '"')
+			output = output.slice(1, -1);
+		return [output];
 	}
 
 	let gitOptions: GitOptions = {from, to};


### PR DESCRIPTION
Fix regression when running commitlint with `--last` flag. Add regression test for it.

Fixes https://github.com/conventional-changelog/commitlint/issues/3981