### PR TITLE
fix(is-ignored): ignore "amend!" commits

### DIFF
--- a/@commitlint/is-ignored/src/defaults.ts
+++ b/@commitlint/is-ignored/src/defaults.ts
@@ -20,7 +20,7 @@ export const wildcards: Matcher[] = [
 	),
 	test(/^(Merge tag (.*?))(?:\r?\n)*$/m),
 	test(/^(R|r)evert (.*)/),
-	test(/^(fixup|squash)!/),
+	test(/^(amend|fixup|squash)!/),
 	isSemver,
 	test(/^(Merged (.*?)(in|into) (.*)|Merged PR (.*): (.*))/),
 	test(/^Merge remote-tracking branch(\s*)(.*)/),

--- a/@commitlint/is-ignored/src/is-ignored.test.ts
+++ b/@commitlint/is-ignored/src/is-ignored.test.ts
@@ -124,6 +124,10 @@ test('should ignore npm semver commits with footers', () => {
 	);
 });
 
+test('should return true amend commits', () => {
+	expect(isIgnored('amend! initial commit')).toBe(true);
+});
+
 test('should return true fixup commits', () => {
 	expect(isIgnored('fixup! initial commit')).toBe(true);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This PR allows a commit whose subject is prefixed with "amend!" to be ignored. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`git-commit` supports the `--fixup=[(amend|reword):]<commit>` option, which creates a commit whose subject is prefixed with "amend!". commitlint should ignore this, but currently, it does not.

For more information about the `--fixup=[(amend|reword):]<commit>` option, please see the [git-commit documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt).

## Usage examples

<!--- Provide examples of intended usage -->

n/a

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

According to the contribution guide.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
