### PR TITLE
feat(format): print full commit message for valid commits if -V

### DIFF
--- a/@commitlint/format/src/format.test.ts
+++ b/@commitlint/format/src/format.test.ts
@@ -35,6 +35,29 @@ test('returns empty summary if verbose', () => {
 	expect(actual).toContain('0 problems, 0 warnings');
 });
 
+test('returns empty summary with full commit message if verbose', () => {
+	const actual = format(
+		{
+			results: [
+				{
+					errors: [],
+					warnings: [],
+					input:
+						'feat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester',
+				},
+			],
+		},
+		{
+			verbose: true,
+			color: false,
+		}
+	);
+
+	expect(actual).toStrictEqual(
+		'⧗   input: feat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester\n✔   found 0 problems, 0 warnings'
+	);
+});
+
 test('returns a correct summary of empty .errors and .warnings', () => {
 	const actualError = format({
 		results: [

--- a/@commitlint/format/src/format.ts
+++ b/@commitlint/format/src/format.ts
@@ -42,9 +42,8 @@ function formatInput(
 
 	const sign = '⧗';
 	const decoration = enabled ? chalk.gray(sign) : sign;
-	const commitText = errors.length > 0 ? input : input.split('\n')[0];
 
-	const decoratedInput = enabled ? chalk.bold(commitText) : commitText;
+	const decoratedInput = enabled ? chalk.bold(input) : input;
 	const hasProblems = errors.length > 0 || warnings.length > 0;
 
 	return options.verbose || hasProblems


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Change the CLI to print full commit message including title, body and footer when the commit message is valid and `--verbose`.

## Description


<!--- Describe your changes in detail -->

## Motivation and Context

This addressed the issue mentioned in #3830.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?

Test steps:

1. create an valid commit with message title, body and footer
2. run `npx commitlint --from=HEAD~1 --verbose` and validate that the full commit message is printed to the console. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
