### PR TITLE
docs: :memo: add pnpm to the getting started and local setup guides

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -18,6 +18,10 @@ yarn add --dev @commitlint/{cli,config-conventional}
 npm install --save-dev @commitlint/config-conventional @commitlint/cli
 ```
 
+```sh [pnpm]
+pnpm add --save-dev @commitlint/{cli,config-conventional}
+```
+
 :::
 
 ## Configuration

--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -62,6 +62,24 @@ echo "yarn commitlint \${1}" > .husky/commit-msg
 > [!WARNING]
 > Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn > v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)
 
+== pnpm
+
+```sh
+pnpm add --save-dev husky
+
+pnpm husky init
+
+# Add commit message linting to commit-msg hook
+echo "pnpm dlx commitlint --edit \$1" > .husky/commit-msg
+```
+
+As an alternative you can create a script inside `package.json`
+
+```sh
+npm pkg set scripts.commitlint="commitlint --edit"
+echo "pnpm commitlint \${1}" > .husky/commit-msg
+```
+
 :::
 
 ---


### PR DESCRIPTION
## Description

Added `pnpm` to the `getting started` and `local setup` guides in the documentation

## Motivation and Context

I hope these changes will help other developers that use pnpm easily set up commitlint

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
