### PR TITLE
fix(prompt): prompt does not respect [body-leading-blank] setting

### DIFF
--- a/@commitlint/prompt/src/input.test.ts
+++ b/@commitlint/prompt/src/input.test.ts
@@ -1,15 +1,27 @@
 /// <reference path="./inquirer/inquirer.d.ts" />
 
-import {test, expect, vi} from 'vitest';
+import {expect, test, vi} from 'vitest';
 // @ts-expect-error -- no typings
 import config from '@commitlint/config-angular';
 import chalk from 'chalk';
-import {Answers, DistinctQuestion, PromptModule} from 'inquirer';
+import {
+	Answers,
+	DistinctQuestion,
+	InputCustomOptions,
+	PromptModule,
+} from 'inquirer';
 
 import {input} from './input.js';
 
+const testConfig = {
+	parserPreset: config.parserPreset,
+	rules: {
+		...config.rules,
+	},
+};
+
 vi.mock('@commitlint/load', () => ({
-	default: () => config,
+	default: () => testConfig,
 }));
 
 test('should work with all fields filled', async () => {
@@ -23,7 +35,27 @@ test('should work with all fields filled', async () => {
 		},
 	});
 	const message = await input(prompt);
+	expect(message).toEqual('fix(test): subject\n' + '\nbody\n' + '\nfooter');
+});
+
+test('should not add leading blank line to body and footer if rules are disabled', async () => {
+	testConfig.rules['body-leading-blank'] = ['1', 'never'];
+	testConfig.rules['footer-leading-blank'] = ['1', 'never'];
+	const prompt = stub({
+		'input-custom': {
+			type: 'fix',
+			scope: 'test',
+			subject: 'subject',
+			body: 'body',
+			footer: 'footer',
+		},
+	});
+	const message = await input(prompt);
 	expect(message).toEqual('fix(test): subject\n' + 'body\n' + 'footer');
+	// reset config mock
+	testConfig.rules['body-leading-blank'] = config.rules['body-leading-blank'];
+	testConfig.rules['footer-leading-blank'] =
+		config.rules['footer-leading-blank'];
 });
 
 test('should work without scope', async () => {
@@ -37,7 +69,7 @@ test('should work without scope', async () => {
 		},
 	});
 	const message = await input(prompt);
-	expect(message).toEqual('fix: subject\n' + 'body\n' + 'footer');
+	expect(message).toEqual('fix: subject\n' + '\nbody\n' + '\nfooter');
 });
 
 test('should fail without type', async () => {
@@ -72,7 +104,7 @@ function stub(config: Record<string, Record<string, unknown>>): PromptModule {
 			if (!questions) {
 				throw new Error(`Unexpected config type: ${configType}`);
 			}
-			const answer = questions[promptConfig.name!];
+			let answer = questions[promptConfig.name!];
 			if (answer == null) {
 				throw new Error(`Unexpected config name: ${promptConfig.name}`);
 			}
@@ -83,7 +115,11 @@ function stub(config: Record<string, Record<string, unknown>>): PromptModule {
 					throw new Error(validationResult || undefined);
 				}
 			}
-
+			const forceLeadingBlankFn = (promptConfig as InputCustomOptions)
+				.forceLeadingBlankFn;
+			if (forceLeadingBlankFn) {
+				answer = forceLeadingBlankFn(answer as string);
+			}
 			result[promptConfig.name!] = answer;
 		}
 		return result;

--- a/@commitlint/prompt/src/inquirer/InputCustomPrompt.ts
+++ b/@commitlint/prompt/src/inquirer/InputCustomPrompt.ts
@@ -46,6 +46,8 @@ export default class InputCustomPrompt<
 
 	onEnd(state: SuccessfulPromptStateData): void {
 		this.lineSubscription.unsubscribe();
+		// Add or remove leading blank if rule is active.
+		state.value = this.opt.forceLeadingBlankFn(state.value);
 		super.onEnd(state);
 	}
 

--- a/@commitlint/prompt/src/inquirer/inquirer.d.ts
+++ b/@commitlint/prompt/src/inquirer/inquirer.d.ts
@@ -15,6 +15,7 @@ declare module 'inquirer' {
 		log?(answers?: T): string;
 		tabCompletion?: InputCustomCompletionOption[];
 		maxLength(answers?: T): number;
+		forceLeadingBlankFn(input: string): string;
 	}
 
 	interface QuestionMap<T extends Answers = Answers> {

--- a/@commitlint/prompt/src/library/get-prompt.ts
+++ b/@commitlint/prompt/src/library/get-prompt.ts
@@ -119,5 +119,6 @@ export default function getPrompt(
 		transformer(value: string) {
 			return forceCaseFn(value);
 		},
+		forceLeadingBlankFn,
 	};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

My attempt to fix the prompt not respecting `body-leading-blank` setting issue in #3826 .

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
