### PR TITLE
ci: rm unneeded apt upgrade

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Install dependencies
         run: |
           apt update --yes
-          apt upgrade --yes
 
           # NOTE: do not change the below with an `actions/setup-node` step! or it
           # would make this CI job entirely pointless

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,6 +72,9 @@ jobs:
           npm install --global yarn
           yarn install
 
+      - name: Print versions
+        run: node --version && npm --version && yarn --version
+
       - name: Build
         run: yarn build
 


### PR DESCRIPTION
Now that 24.04 has been released, 'apt upgrade' is not needed anymore for this job.