### PR TITLE
ci: add schedule&workflow_dispatch triggers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ on:
 
   # to execute once a day (more info see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule )
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
 
 jobs:
   build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+  workflow_dispatch:
+
+  # to execute once a day (more info see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule )
+  schedule:
+    - cron: "0 0 * * *"
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
         run: yarn install --ignore-engines --frozen-lockfile
 
       - name: Check format
-        run: yarn format
+        run: yarn format || (yarn format-fix; git diff --exit-code)
 
       - name: Lint
         run: yarn lint

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs-preview": "vitepress preview docs",
     "lint": "eslint . --ext .js,.ts",
     "lint-fix": "eslint . --ext .js,.ts --fix",
-    "format": "prettier **/*.{ts,js,json,yml,md} -l",
+    "format": "prettier **/*.{ts,js,json,yml,md} --check",
     "format-fix": "prettier **/*.{ts,js,json,yml,md} --write",
     "publish": "lerna publish --conventional-commits",
     "reinstall": "yarn clean && yarn install",


### PR DESCRIPTION
The schedule trigger will run CI everyday to make
sure we catch any breakage caused by external
reasons. The workflow_dispatch one is so that the
repo owner can launch CI jobs manually.
