### PR TITLE
feat!: show input from a new line

### DIFF
--- a/@commitlint/format/src/format.test.ts
+++ b/@commitlint/format/src/format.test.ts
@@ -54,7 +54,7 @@ test('returns empty summary with full commit message if verbose', () => {
 	);
 
 	expect(actual).toStrictEqual(
-		'⧗   input: feat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester\n✔   found 0 problems, 0 warnings'
+		'⧗   --- input ---\nfeat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester\n✔   found 0 problems, 0 warnings'
 	);
 });
 

--- a/@commitlint/format/src/format.ts
+++ b/@commitlint/format/src/format.ts
@@ -47,7 +47,7 @@ function formatInput(
 	const hasProblems = errors.length > 0 || warnings.length > 0;
 
 	return options.verbose || hasProblems
-		? [`${decoration}   input: ${decoratedInput}`]
+		? [`${decoration}   --- input ---\n${decoratedInput}`]
 		: [];
 }
 


### PR DESCRIPTION
This will be less confusing to read, and also easier to test and copy/paste (for example for #4101).

This error log is confusing for people not familiar with `commitlint`.
```
⧗   input: fix: ingest - do not double strip /doc/ prefix
It is already stripped here
https://gitlab.com/gitlab-community/modelops/applied-ml/code-suggestions/ai-assist/-/blob/22bb9cf2b996dc2ec347bad761abb12fd11bcf75/scripts/ingest/gitlab-docs/steps/parse.rb#L16
✖   body's lines must not be longer than 100 characters [body-max-line-length]
✖   found 1 warnings
```

This one should be more clear.

```
⧗   --- input ---
fix: ingest - do not double strip /doc/ prefix

It is already stripped here
https://gitlab.com/gitlab-community/modelops/applied-ml/code-suggestions/ai-assist/-/blob/22bb9cf2b996dc2ec347bad761abb12fd11bcf75/scripts/ingest/gitlab-docs/steps/parse.rb#L16
✖   body's lines must not be longer than 100 characters [body-max-line-length]
✖   found 1 warnings
```

Or maybe even this one.

```
⧗   commit message:
fix: ingest - do not double strip /doc/ prefix

It is already stripped here
https://gitlab.com/gitlab-community/modelops/applied-ml/code-suggestions/ai-assist/-/blob/22bb9cf2b996dc2ec347bad761abb12fd11bcf75/scripts/ingest/gitlab-docs/steps/parse.rb#L16
✖   body's lines must not be longer than 100 characters [body-max-line-length]
✖   found 1 warnings
```

## Motivation and Context

Error output should not mess up original commit message, because it is hard to understand what is wrong. 

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
