### PR TITLE
docs: remove GitLab clone depth limitation

### DIFF
--- a/docs/guides/ci-setup.md
+++ b/docs/guides/ci-setup.md
@@ -127,7 +127,6 @@ workflows:
 ```yaml
 lint:commit:
   image: registry.hub.docker.com/library/node:alpine
-  stage: lint
   variables:
     GIT_DEPTH: 0
   before_script:

--- a/docs/guides/ci-setup.md
+++ b/docs/guides/ci-setup.md
@@ -125,16 +125,21 @@ workflows:
 ## GitLab CI
 
 ```yaml
-stages: ['lint', 'build', 'test']
 lint:commit:
   image: registry.hub.docker.com/library/node:alpine
   stage: lint
+  variables:
+    GIT_DEPTH: 0
   before_script:
     - apk add --no-cache git
     - npm install --save-dev @commitlint/config-conventional @commitlint/cli
   script:
     - echo "${CI_COMMIT_MESSAGE}" | npx commitlint
 ```
+
+GitLab limits `git clone` depth to
+[20 commits by default](https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone).
+Setting `GIT_DEPTH: 0` removes this limitation, so `commitlint` can check larger MRs.
 
 ## GitLab CI with pre-build container
 
@@ -189,4 +194,4 @@ workflows:
 
 > [!TIP]
 > Help yourself adopting a commit convention by using an interactive commit prompt.
-> Learn how to use `@commitlint/prompt-cli` in the [Use prompt guide](/> guides/use-prompt)
+> Learn how to use `@commitlint/prompt-cli` in the [Use prompt guide](/guides/use-prompt).


### PR DESCRIPTION
See https://github.com/conventional-changelog/commitlint/issues/4103

## Description

I removed `stages` key, because copy/pasting the block may break stages that people have defined already.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
