### PR TITLE
Support command line options from a file

### DIFF
--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -556,6 +556,7 @@ test('should print help', async () => {
 		  -t, --to             upper end of the commit range to lint; applies if edit=false  [string]
 		  -V, --verbose        enable verbose output for reports without problems  [boolean]
 		  -s, --strict         enable strict mode; result code 2 for warnings, 3 for errors  [boolean]
+		      --options        path to a JSON file or Common.js module containing CLI options
 		  -v, --version        display version information  [boolean]
 		  -h, --help           Show help  [boolean]"
 	`);

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -143,6 +143,11 @@ const cli = yargs(process.argv.slice(2))
 	.alias('v', 'version')
 	.help('help')
 	.alias('h', 'help')
+	.config(
+		'options',
+		'path to a JSON file or Common.js module containing CLI options',
+		require
+	)
 	.usage(`${pkg.name}@${pkg.version} - ${pkg.description}\n`)
 	.usage(
 		`[input] reads from stdin if --edit, --env, --from and --to are omitted`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,7 +3,7 @@
 ```sh
 ❯ npx commitlint --help
 
-@commitlint/cli@11.0.0 - Lint your commit messages
+@commitlint/cli@19.3.0 - Lint your commit messages
 
 [input] reads from stdin if --edit, --env, --from and --to are omitted
 
@@ -22,6 +22,10 @@ Options:
   -H, --help-url       help url in error message                        [string]
   -f, --from           lower end of the commit range to lint; applies if
                        edit=false                                       [string]
+      --git-log-args   additional git log arguments as space separated string,
+                       example '--first-parent --cherry-pick'           [string]
+  -l, --last           just analyze the last commit; applies if edit=false
+                                                                       [boolean]
   -o, --format         output format of the results                     [string]
   -p, --parser-preset  configuration preset to use for
                        conventional-commits-parser                      [string]
@@ -30,6 +34,8 @@ Options:
                        edit=false                                       [string]
   -V, --verbose        enable verbose output for reports without problems
                                                                        [boolean]
+  -s, --strict         enable strict mode; result code 2 for warnings, 3 for
+                       errors                                          [boolean]
   -v, --version        display version information                     [boolean]
   -h, --help           Show help                                       [boolean]
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,6 +36,8 @@ Options:
                                                                        [boolean]
   -s, --strict         enable strict mode; result code 2 for warnings, 3 for
                        errors                                          [boolean]
+      --options        path to a JSON file or Common.js module containing CLI
+                       options
   -v, --version        display version information                     [boolean]
   -h, --help           Show help                                       [boolean]
 ```


### PR DESCRIPTION
## Description

This PR enables yargs' first-class support for a [command line options file](https://yargs.js.org/docs/#api-reference-configkey-description-parsefn). It works out of the box and costs very little.

Also updated the CLI options docs while I was here.

## Motivation and Context

The commitlint CLI has many arguments now; I counted 20. Composing and encoding all the required arguments for a project at the terminal or in a package script can get hard to maintain. The ability to move those options to a regular JavaScript or JSON module makes them far easier to manage. It is more human readable and writable.

## Usage examples

This fabricated example is deliberately verbose and a bit unrealistic to make the point:

```diff
{
-   "commit:lint": "commitlint --from $GIT_LAST_TAG --format @some/formatter --parser-preset @some/preset --extends @some/shared-config-1 @some/shared-config-2 --strict --cwd ../project --git-log-args \"--first-parent\""
+   "commit:lint": "commitlint --options ./commitlint.options.cjs"
}
```

```js
// commitlint.options.cjs
module.exports = {
    from: process.env.GIT_LAST_TAG,
    format: '@some/formatter',
    parserPreset: '@some/preset',

    // Explanatory code comment for this option could go here.
    extends: ['@some/shared-config-1', '@some/shared-config-2'],

    strict: true,
    cwd: '../project',
    gitLogArgs: '--first-parent'
};
```
## How Has This Been Tested?

Added some temporary options files and ran them directly on this repo. Firstly a Common.js module:

```js
// commitlint.options.cjs
module.exports = {
    from: "v19.3.1",
    verbose: true
};
```

```sh
yarn run commitlint --options ./commitlint.options.cjs
```

<details><summary>CJS Options Output</summary>

<img width="1071" alt="cjs-ouput" src="https://github.com/user-attachments/assets/22106888-ec04-456f-ab8a-253779df53e5">

</details>

And then a JSON file:

```json
{
    "from": "v19.3.1",
    "verbose": true
}
```

```sh
yarn run commitlint --options ./commitlint.options.json
```

<details><summary>JSON Options Output</summary>

<img width="1027" alt="json-output" src="https://github.com/user-attachments/assets/6af340c9-0622-4593-be55-03317ac0dbde">

</details>

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
