### PR TITLE
Support linting from the last tag

### DIFF
--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -548,6 +548,7 @@ test('should print help', async () => {
 		  -x, --extends        array of shareable configurations to extend  [array]
 		  -H, --help-url       help url in error message  [string]
 		  -f, --from           lower end of the commit range to lint; applies if edit=false  [string]
+		      --from-last-tag  uses the last tag as the lower end of the commit range to lint; applies if edit=false and from is not set  [boolean]
 		      --git-log-args   additional git log arguments as space separated string, example '--first-parent --cherry-pick'  [string]
 		  -l, --last           just analyze the last commit; applies if edit=false  [boolean]
 		  -o, --format         output format of the results  [string]

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -90,6 +90,11 @@ const cli = yargs(process.argv.slice(2))
 				'lower end of the commit range to lint; applies if edit=false',
 			type: 'string',
 		},
+		'from-last-tag': {
+			description:
+				'uses the last tag as the lower end of the commit range to lint; applies if edit=false and from is not set',
+			type: 'boolean',
+		},
 		'git-log-args': {
 			description:
 				"additional git log arguments as space separated string, example '--first-parent --cherry-pick'",
@@ -242,6 +247,7 @@ async function main(args: MainArgs): Promise<void> {
 		: read({
 				to: flags.to,
 				from: flags.from,
+				fromLastTag: flags['from-last-tag'],
 				last: flags.last,
 				edit: flags.edit,
 				cwd: flags.cwd,
@@ -400,6 +406,7 @@ function checkFromEdit(flags: CliFlags): boolean {
 function checkFromHistory(flags: CliFlags): boolean {
 	return (
 		typeof flags.from === 'string' ||
+		typeof flags['from-last-tag'] === 'boolean' ||
 		typeof flags.to === 'string' ||
 		typeof flags.last === 'boolean'
 	);

--- a/@commitlint/cli/src/types.ts
+++ b/@commitlint/cli/src/types.ts
@@ -8,6 +8,7 @@ export interface CliFlags {
 	help?: boolean;
 	'help-url'?: string;
 	from?: string;
+	'from-last-tag'?: boolean;
 	'git-log-args'?: string;
 	last?: boolean;
 	format?: string;

--- a/@commitlint/read/src/read.test.ts
+++ b/@commitlint/read/src/read.test.ts
@@ -72,3 +72,15 @@ test('get edit commit message while skipping first commit', async () => {
 	const actual = await read({from: 'HEAD~2', cwd, gitLogArgs: '--skip 1'});
 	expect(actual).toEqual(expected);
 });
+
+test('should only read the last commit', async () => {
+	const cwd: string = await git.bootstrap();
+
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit Z'], {cwd});
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit Y'], {cwd});
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit X'], {cwd});
+
+	const result = await read({cwd, last: true});
+
+	expect(result).toEqual(['commit X']);
+});

--- a/@commitlint/read/src/read.test.ts
+++ b/@commitlint/read/src/read.test.ts
@@ -84,3 +84,49 @@ test('should only read the last commit', async () => {
 
 	expect(result).toEqual(['commit X']);
 });
+
+test('should read commits from the last annotated tag', async () => {
+	const cwd: string = await git.bootstrap();
+
+	await execa(
+		'git',
+		['commit', '--allow-empty', '-m', 'chore: release v1.0.0'],
+		{cwd}
+	);
+	await execa('git', ['tag', 'v1.0.0', '--annotate', '-m', 'v1.0.0'], {cwd});
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit 1'], {cwd});
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit 2'], {cwd});
+
+	const result = await read({cwd, fromLastTag: true});
+
+	expect(result).toEqual(['commit 2\n\n', 'commit 1\n\n']);
+});
+
+test('should read commits from the last lightweight tag', async () => {
+	const cwd: string = await git.bootstrap();
+
+	await execa(
+		'git',
+		['commit', '--allow-empty', '-m', 'chore: release v9.9.9-alpha.1'],
+		{cwd}
+	);
+	await execa('git', ['tag', 'v9.9.9-alpha.1'], {cwd});
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit A'], {cwd});
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit B'], {cwd});
+
+	const result = await read({cwd, fromLastTag: true});
+
+	expect(result).toEqual(['commit B\n\n', 'commit A\n\n']);
+});
+
+test('should not read any commits when there are no tags', async () => {
+	const cwd: string = await git.bootstrap();
+
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit 7'], {cwd});
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit 8'], {cwd});
+	await execa('git', ['commit', '--allow-empty', '-m', 'commit 9'], {cwd});
+
+	const result = await read({cwd, fromLastTag: true});
+
+	expect(result).toHaveLength(0);
+});

--- a/@commitlint/read/src/read.ts
+++ b/@commitlint/read/src/read.ts
@@ -26,11 +26,11 @@ export default async function getCommitMessages(
 	}
 
 	if (last) {
-		const gitCommandResult = await execa('git', [
-			'log',
-			'-1',
-			'--pretty=format:%B',
-		]);
+		const gitCommandResult = await execa(
+			'git',
+			['log', '-1', '--pretty=format:%B'],
+			{cwd}
+		);
 		let output = gitCommandResult.stdout;
 		// strip output of extra quotation marks ("")
 		if (output[0] == '"' && output[output.length - 1] == '"')

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -22,6 +22,8 @@ Options:
   -H, --help-url       help url in error message                        [string]
   -f, --from           lower end of the commit range to lint; applies if
                        edit=false                                       [string]
+      --from-last-tag  uses the last tag as the lower end of the commit range to
+                       lint; applies if edit=false and from is not set [boolean]
       --git-log-args   additional git log arguments as space separated string,
                        example '--first-parent --cherry-pick'           [string]
   -l, --last           just analyze the last commit; applies if edit=false


### PR DESCRIPTION
## Description

Resolves #2507, which has the full problem statement. Also fixed a bug with the `--last` option.

~In draft mode to get the discussion going. Will open it up for real after more thorough testing.~ Testing complete (see below) and this is now ready to review.

## Motivation and Context

See #2507.

Note that if there are no tags, such as in a brand new repo, commitlint will always pass. The idea is that it should be possible to add `commitlint --from-last-tag` to CI at the very beginning of a repo and never remove it. There is no need to document special steps, like adding an initial tag.

## Usage examples

```sh
commitlint --from-last-tag
```

## How Has This Been Tested?

Unit tests and locally against this repo:

```sh
yarn run commitlint --from-last-tag --verbose
```

<details><summary>Output</summary>

![from-last-tag](https://github.com/user-attachments/assets/2a4dc44b-ae05-47c9-8421-c46df78eb995)

</details>

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
