### PR TITLE
Improve regex in @commitlint/load

### DIFF
--- a/@commitlint/load/src/utils/plugin-naming.ts
+++ b/@commitlint/load/src/utils/plugin-naming.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 // largely adapted from eslint's plugin system
-const NAMESPACE_REGEX = /^@.*\//iu;
+const NAMESPACE_REGEX = /^@.*\//u;
 // In eslint this is a parameter - we don't need to support the extra options
 const prefix = 'commitlint-plugin';
 
@@ -40,7 +40,7 @@ export function normalizePackageName(name: string) {
 				`^(@[^/]+)(?:/(?:${prefix})?)?$`,
 				'u'
 			),
-			scopedPackageNameRegex = new RegExp(`^${prefix}(-|$)`, 'u');
+			scopedPackageNameRegex = new RegExp(`^${prefix}(?:-|$)`, 'u');
 
 		if (scopedPackageShortcutRegex.test(normalizedName)) {
 			normalizedName = normalizedName.replace(
@@ -94,7 +94,7 @@ export function getShorthandName(fullname: string) {
  * @returns {string} The namepace of the term if it has one.
  */
 export function getNamespaceFromTerm(term: string) {
-	const match = term.match(NAMESPACE_REGEX);
+	const match = NAMESPACE_REGEX.exec(term);
 
 	return match ? match[0] : '';
 }


### PR DESCRIPTION
## Description

1. Removed unnecessary case insensitivity flag
2. Removed unnecessary capturing group
3. Replaced String.match with RegExp.exec https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-regexp-exec.html#regexp-prefer-regexp-exec

## Motivation and Context

It slightly improves performance and removes redundancy

## How Has This Been Tested?

It's a pretty local change, I just looked at it

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
