### PR TITLE
fix(rules): handle blank commit message in `signed-off-by` rule

### DIFF
--- a/@commitlint/rules/src/signed-off-by.ts
+++ b/@commitlint/rules/src/signed-off-by.ts
@@ -18,7 +18,9 @@ export const signedOffBy: SyncRule<string> = (
 	const last = lines[lines.length - 1];
 
 	const negated = when === 'never';
-	const hasSignedOffBy = last.startsWith(value);
+	const hasSignedOffBy =
+		// empty commit message
+		last ? last.startsWith(value) : false;
 
 	return [
 		negated ? !hasSignedOffBy : hasSignedOffBy,


### PR DESCRIPTION
Check for an empty commit message for rule `signed-off-by`.

## Description

On a minimal environment with only `commitlint` installed and the `signed-off-by` rule set, writing an empty commit message would result in a runtime exception.

## Motivation and Context

Previously this rule caused a runtime exception trying to validate an empty commit message as it was trying to access the `startsWith` string method on an undefined value which was supposed to store the last line of the commit message. Now it does a check to see if the last line is `undefined` or not.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
