### PR TITLE
feat: support using delimiter in `scope-enum`

### DIFF
--- a/@commitlint/rules/src/scope-enum.test.ts
+++ b/@commitlint/rules/src/scope-enum.test.ts
@@ -11,6 +11,7 @@ const messagesByScope = {
 	multiple: {
 		multiple: 'foo(bar,baz): qux',
 		multipleCommaSpace: 'foo(bar, baz): qux',
+		multipleSlash: 'foo(bar/baz): qux',
 	},
 	none: {
 		empty: 'foo: baz',
@@ -143,6 +144,16 @@ describe('Scope Enum Validation', () => {
 					expect(message).toEqual('scope must be one of [bar]');
 				});
 			});
+
+			test(`Succeeds with a 'multipleSlash' message when the scopes are included in enum`, async () => {
+				const [actual, message] = scopeEnum(
+					await parse(messages['multipleSlash']),
+					'always',
+					['bar/baz']
+				);
+				expect(actual).toBeTruthy();
+				expect(message).toEqual('scope must be one of [bar/baz]');
+			});
 		});
 	});
 
@@ -180,6 +191,16 @@ describe('Scope Enum Validation', () => {
 					expect(actual).toBeFalsy();
 					expect(message).toEqual('scope must not be one of [bar, baz]');
 				});
+			});
+
+			test(`Fails with a 'multipleSlash' message when the scopes are included in enum`, async () => {
+				const [actual, message] = scopeEnum(
+					await parse(messages['multipleSlash']),
+					'never',
+					['bar/baz']
+				);
+				expect(actual).toBeFalsy();
+				expect(message).toEqual('scope must not be one of [bar/baz]');
 			});
 		});
 	});

--- a/@commitlint/rules/src/scope-enum.ts
+++ b/@commitlint/rules/src/scope-enum.ts
@@ -20,10 +20,10 @@ export const scopeEnum: SyncRule<string[]> = (
 	let isValid;
 
 	if (when === 'never') {
-		isValid = !messageScopes.some(isScopeInEnum);
+		isValid = !messageScopes.some(isScopeInEnum) && !isScopeInEnum(scope);
 		errorMessage.splice(1, 0, 'not');
 	} else {
-		isValid = messageScopes.every(isScopeInEnum);
+		isValid = messageScopes.every(isScopeInEnum) || isScopeInEnum(scope);
 	}
 
 	return [isValid, message(errorMessage)];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Currently, if the scope in message has delimiters(`/`, `,` or `\`), it is considered as multiple scopes and is tested separately.

I add extra checks to see if the scope matches the enum **directly** to allow `'scope-enum'` to have delimiter.

## Motivation and Context

Scope should be able to have delimiter like `/`. And tests should pass when `'scope-enum'` is configured to have delimiter.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  rules: {
    'scope-enum': [
      RuleConfigSeverity.Error,
      'always',
      [
        'foo/bar',
      ],
    ],
  },
};
```

```sh
echo "fix(foo/bar): qux" | commitlint # fails

⧗   input: fix(foo/bar): qux
✖   scope must be one of [foo/bar] [scope-enum]
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

1. A `multipleSlash` test case is added.
2. Check if adding `foo/bar` to `scope-enum` would work.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
