### PR TITLE
ci: don't run container/deploy jobs in forks

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -10,6 +10,7 @@ on:
       - 'Dockerfile.ci'
 jobs:
   container-build:
+    if: github.repository == 'conventional-changelog/commitlint'
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.repository == 'conventional-changelog/commitlint'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,6 +50,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.repository == 'conventional-changelog/commitlint'
     environment:
       name: docs
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION

Otherwise they might fail with errors like:

```
Run actions/configure-pages@v5
Error: Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the `enablement` parameter for this action. Error: Not Found - https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site
Error: HttpError: Not Found - https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site
```

Or:

```
Run docker/login-action@v3
Error: Username and password required
```