### PR TITLE
docs: remove commitlint-config-jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ A number of shared configurations are available to install and use with `commitl
 - [@commitlint/config-patternplate](./@commitlint/config-patternplate)
 - [conventional-changelog-lint-config-atom](https://github.com/erikmueller/conventional-changelog-lint-config-atom)
 - [conventional-changelog-lint-config-canonical](https://github.com/gajus/conventional-changelog-lint-config-canonical)
-- [commitlint-config-jira](https://github.com/Gherciu/commitlint-jira)
 
 > ⚠️ If you want to publish your own shareable config then make sure it has a name aligning with the pattern `commitlint-config-emoji-log` or `commitlint-config-your-config-name` — then in extend all you have to write is `emoji-log` or `your-config-name`.
 


### PR DESCRIPTION
`commitlint-config-jira` has been deprecated:

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/671aad0e-db8c-46e9-8410-010afa367384">

Also, the repository and GitHub user who authored and maintained this project has been deleted:
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/708a0fe8-be84-4523-af6a-3675b38d82de">

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [N/A] I have added tests to cover my changes.
- [N/A] All new and existing tests passed.
