### PR TITLE
feat(is-ignored): ignore reapply commits

### DIFF
--- a/@commitlint/is-ignored/src/defaults.ts
+++ b/@commitlint/is-ignored/src/defaults.ts
@@ -20,6 +20,7 @@ export const wildcards: Matcher[] = [
 	),
 	test(/^(Merge tag (.*?))(?:\r?\n)*$/m),
 	test(/^(R|r)evert (.*)/),
+	test(/^(R|r)eapply (.*)/),
 	test(/^(amend|fixup|squash)!/),
 	isSemver,
 	test(/^(Merged (.*?)(in|into) (.*)|Merged PR (.*): (.*))/),


### PR DESCRIPTION
In Git 2.43, the double-revert commits have commit messages starting with `Reapply`.
This PR ignores `Reapply` commits by default.

https://github.blog/open-source/git/highlights-from-git-2-43/#split-repositories-with-object-filters:~:text=HEAD%20%2D%3E%20main)-,Reapply,-%22fix%20bug%22