### PR TITLE
build: fix install git in container

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -26,6 +26,7 @@ RUN yarn install --frozen-lockfile --network-timeout 100000 && \
     npm pack @commitlint/config-conventional
 
 FROM docker.io/library/node:18-alpine
+RUN apk add --no-cache git
 COPY --from=builder /src/*.tgz ./
 RUN npm config set fetch-retry-mintimeout 20000 && \
     npm config set fetch-retry-maxtimeout 120000 && \


### PR DESCRIPTION
Install git in container.

## Description

git is not copied from the builder layer to the final layer, so we have to install it again.

## Motivation and Context

With the switch to Alpine in #4185, `--from-last-tag` (and possibly other arguments relying on git) no longer works. 
This is because git is no longer available in the container.
See #4196 

## How Has This Been Tested?

Tested locally by using the new image in combinat

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] All new and existing tests passed.
