### PR TITLE
docs: use ` to escape dollar signs in Windows

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -35,6 +35,8 @@ npx husky init
 
 # Add commit message linting to commit-msg hook
 echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
+# Windows users should use ` to escape dollar signs
+echo "npx --no commitlint --edit `$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`
@@ -53,6 +55,8 @@ yarn husky init
 
 # Add commit message linting to commit-msg hook
 echo "yarn commitlint --edit \$1" > .husky/commit-msg
+# Windows users should use ` to escape dollar signs
+echo "yarn commitlint --edit `$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`
@@ -74,6 +78,8 @@ pnpm husky init
 
 # Add commit message linting to commit-msg hook
 echo "pnpm dlx commitlint --edit \$1" > .husky/commit-msg
+# Windows users should use ` to escape dollar signs
+echo "pnpm dlx commitlint --edit `$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`
@@ -92,6 +98,8 @@ deno task --eval husky init
 
 # Add commit message linting to commit-msg hook
 echo "deno task --eval commitlint --edit \$1" > .husky/commit-msg
+# Windows users should use ` to escape dollar signs
+echo "deno task --eval commitlint --edit `$1" > .husky/commit-msg
 ```
 
 :::


### PR DESCRIPTION
Windows users should use ` to escape dollar signs.

## Description

Windows users should use ` to escape dollar signs, so I add one more command in the Local Setup section.

## Motivation and Context

Windows users should use ` to escape dollar signs. The original command below will get wrong outpt

```  shell
# Original command
echo "deno task --eval commitlint --edit \$1" > .husky/commit-msg
# Result in "commit-msg"
deno task --eval commitlint --edit \

# Right command in Windows
echo "deno task --eval commitlint --edit `$1" > .husky/commit-msg
# Result in "commit-msg"
deno task --eval commitlint --edit $1
```

Related discuss in StackOverflow: https://stackoverflow.com/questions/17452401/escaping-dollar-signs-in-powershell-path-is-not-working

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
