### PR TITLE
feat: support lerna 7 and 8

### DIFF
--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "peerDependencies": {
-    "lerna": "^5.0.0 || ^6"
+    "lerna": ">=5 <9"
   },
   "peerDependenciesMeta": {
     "lerna": {


### PR DESCRIPTION
## Description

`@commitlint/config-lerna-scopes` works fine with the latest versions of lerna. Thanks to [the production dependency](https://github.com/conventional-changelog/commitlint/blob/d2f33c634c88ff6e578e0c9fe96a1517c412e24e/%40commitlint/config-lerna-scopes/package.json#L42-L43) it doesn't actually need a peer version of lerna at runtime. But we do need to be sure that using `@lerna/project@6` continues to work with the latest lerna setup. I can confirm that it does, and this PR just formalizes compatibility.

## Motivation and Context

Declaring compatibility removes peer dependency noise from package managers like yarn and pnpm when using this shared config with the latest versions of lerna.

## Usage examples

```sh
# Should produce no warnings
pnpm add -D lerna @commitlint/config-lerna-scopes
```

## How Has This Been Tested?

We've been tolerating the peer dependency warning and using this shared config together with lerna v7 and v8 across dozens of repos without issue for over a year.

## Types of changes

Calling this a feature since it technically adds formal support.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
