### PR TITLE
fix(config-nx-scopes): fix for projects without explicit targets

### DIFF
--- a/@commitlint/config-nx-scopes/index.js
+++ b/@commitlint/config-nx-scopes/index.js
@@ -30,7 +30,6 @@ function getProjects(context, selector = () => true) {
 				tags: project.tags,
 			})
 		)
-		.filter((project) => project.targets)
 		.map((project) => project.name)
 		.map((name) => (name.charAt(0) === '@' ? name.split('/')[1] : name));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR remove the filter projects by targets property
<!--- Describe your changes in detail -->

## Motivation and Context

Currently the targets property is not always explicitly defined, now most of the task are inferred using Crystal.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

N/A
<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
import { utils } from '@commitlint/config-nx-scopes';

module.exports = {
  extends: ['@commitlint/config-conventional', '@commitlint/config-nx-scopes'],
  rules: {
    'scope-enum': async (ctx) => [2, 'always', ['repo', 'deps', 'release', ...(await utils.getProjects(ctx))]],
  },
};

```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

In my own Nx 20.4.0 workspace, where next apps are created without the targets property and the project is ignored by the plugin unless I remove the line removed in this PR 
<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
