### PR TITLE
fix: allow `process.env` in `ignores`

### DIFF
--- a/@commitlint/is-ignored/src/is-ignored.test.ts
+++ b/@commitlint/is-ignored/src/is-ignored.test.ts
@@ -256,6 +256,7 @@ test('should not throw error for custom ignore functions without security risks'
 		'function(commit) { return commit.length < 10 && commit.includes("some"); }',
 		'function(commit) { return commit.length < 10 || commit.includes("fetch"); }',
 		'function(commit) { return commit.includes("exec"); }',
+		'function(commit) { return !process.env.CI && /^wip\b/.test(commit); }',
 	];
 
 	safePatterns.forEach((fnString) => {

--- a/@commitlint/is-ignored/src/validate-ignore-func.ts
+++ b/@commitlint/is-ignored/src/validate-ignore-func.ts
@@ -5,7 +5,7 @@ export function validateIgnoreFunction(fn: Matcher) {
 
 	// Check for dangerous patterns
 	const dangerousPattern =
-		/(?:process|require|import|eval|fetch|XMLHttpRequest|fs|child_process)(?:\s*\.|\s*\()|(?:exec|execFile|spawn)\s*\(/;
+		/(?:process(?!\.env)|require|import|eval|fetch|XMLHttpRequest|fs|child_process)(?:\s*\.|\s*\()|(?:exec|execFile|spawn)\s*\(/;
 	if (dangerousPattern.test(fnString)) {
 		// Find which pattern matched for a more specific error message
 		const match = fnString.match(dangerousPattern);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This adjusts the `dangerousPattern` regexp to allow `process.env` while preventing other `process` references

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes #4281

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {
  ignores: [
    commit => !process.env.CI && /^wip\b/.test(commit),
  ],
};
```

```sh
echo "wip: example" | commitlint # passes
echo "wip: example" | CI=1 commitlint # fails when the CI env is set
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

An additional test case has been added, and it has been tested in our projects

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
