### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/@alias/commitlint/cli.test.js
+++ b/@alias/commitlint/cli.test.js
@@ -1,7 +1,7 @@
 import {test, expect} from 'vitest';
-import {createRequire} from 'module';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {x} from 'tinyexec';
 import {fix} from '@commitlint/test';

--- a/@commitlint/cli/index.cjs
+++ b/@commitlint/cli/index.cjs
@@ -1,3 +1,3 @@
-const path = require('path');
+const path = require('node:path');
 
 module.exports = path.join(__dirname, 'cli.js');

--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -1,7 +1,7 @@
 import {describe, test, expect} from 'vitest';
-import {createRequire} from 'module';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {fix, git} from '@commitlint/test';
 import fs from 'fs-extra';
 import merge from 'lodash.merge';

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -1,7 +1,7 @@
-import {createRequire} from 'module';
-import path from 'path';
-import {fileURLToPath, pathToFileURL} from 'url';
-import util from 'util';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import util from 'node:util';
 
 import lint from '@commitlint/lint';
 import load, {resolveFromSilent, resolveGlobalSilent} from '@commitlint/load';

--- a/@commitlint/config-conventional/src/index.test.ts
+++ b/@commitlint/config-conventional/src/index.test.ts
@@ -1,6 +1,6 @@
 import {test, expect} from 'vitest';
-import path from 'path';
-import {pathToFileURL} from 'url';
+import path from 'node:path';
+import {pathToFileURL} from 'node:url';
 
 import lint from '@commitlint/lint';
 

--- a/@commitlint/config-lerna-scopes/index.js
+++ b/@commitlint/config-lerna-scopes/index.js
@@ -1,5 +1,5 @@
-import {createRequire} from 'module';
-import Path from 'path';
+import {createRequire} from 'node:module';
+import Path from 'node:path';
 
 import {globSync} from 'glob';
 import importFrom from 'import-from';

--- a/@commitlint/config-lerna-scopes/index.test.js
+++ b/@commitlint/config-lerna-scopes/index.test.js
@@ -1,6 +1,6 @@
 import {test, expect} from 'vitest';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {npm} from '@commitlint/test';
 

--- a/@commitlint/config-nx-scopes/index.test.js
+++ b/@commitlint/config-nx-scopes/index.test.js
@@ -1,6 +1,6 @@
 import {test, expect} from 'vitest';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {npm} from '@commitlint/test';
 

--- a/@commitlint/config-patternplate/index.js
+++ b/@commitlint/config-patternplate/index.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import configAngular from '@commitlint/config-angular';
 import {glob} from 'glob';

--- a/@commitlint/config-pnpm-scopes/index.js
+++ b/@commitlint/config-pnpm-scopes/index.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import fg from 'fast-glob';
 import readYamlFile from 'read-yaml-file';

--- a/@commitlint/config-pnpm-scopes/index.test.js
+++ b/@commitlint/config-pnpm-scopes/index.test.js
@@ -1,6 +1,6 @@
 import {test, expect} from 'vitest';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {npm} from '@commitlint/test';
 

--- a/@commitlint/config-rush-scopes/index.js
+++ b/@commitlint/config-rush-scopes/index.js
@@ -1,4 +1,4 @@
-import Path from 'path';
+import Path from 'node:path';
 import fs from 'fs/promises';
 
 import jsonc from 'jsonc';

--- a/@commitlint/config-rush-scopes/index.test.js
+++ b/@commitlint/config-rush-scopes/index.test.js
@@ -1,6 +1,6 @@
 import {test, expect} from 'vitest';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {npm} from '@commitlint/test';
 

--- a/@commitlint/config-validator/src/validate.ts
+++ b/@commitlint/config-validator/src/validate.ts
@@ -1,4 +1,4 @@
-import {createRequire} from 'module';
+import {createRequire} from 'node:module';
 
 import {UserConfig} from '@commitlint/types';
 import _Ajv from 'ajv';

--- a/@commitlint/config-workspace-scopes/index.js
+++ b/@commitlint/config-workspace-scopes/index.js
@@ -1,5 +1,5 @@
-import {createRequire} from 'module';
-import Path from 'path';
+import {createRequire} from 'node:module';
+import Path from 'node:path';
 
 import {globSync} from 'glob';
 

--- a/@commitlint/config-workspace-scopes/index.test.js
+++ b/@commitlint/config-workspace-scopes/index.test.js
@@ -1,6 +1,6 @@
 import {test, expect} from 'vitest';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {npm} from '@commitlint/test';
 

--- a/@commitlint/ensure/src/index.test.ts
+++ b/@commitlint/ensure/src/index.test.ts
@@ -1,6 +1,6 @@
 import {test, expect} from 'vitest';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {globSync} from 'glob';
 import camelCase from 'lodash.camelcase';

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -1,4 +1,4 @@
-import util from 'util';
+import util from 'node:util';
 import isIgnored from '@commitlint/is-ignored';
 import parse from '@commitlint/parse';
 import defaultRules from '@commitlint/rules';

--- a/@commitlint/load/src/load.test.ts
+++ b/@commitlint/load/src/load.test.ts
@@ -1,7 +1,7 @@
 import {describe, test, expect, vi} from 'vitest';
-import {readFileSync, writeFileSync} from 'fs';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import {readFileSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {RuleConfigSeverity} from '@commitlint/types';
 import {fix, git, npm} from '@commitlint/test';

--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import {validateConfig} from '@commitlint/config-validator';
 import executeRule from '@commitlint/execute-rule';

--- a/@commitlint/load/src/utils/load-config.ts
+++ b/@commitlint/load/src/utils/load-config.ts
@@ -1,5 +1,5 @@
-import {existsSync, readFileSync} from 'fs';
-import path from 'path';
+import {existsSync, readFileSync} from 'node:fs';
+import path from 'node:path';
 
 import {
 	cosmiconfig,

--- a/@commitlint/load/src/utils/load-plugin.ts
+++ b/@commitlint/load/src/utils/load-plugin.ts
@@ -1,6 +1,6 @@
-import {createRequire} from 'module';
-import path from 'path';
-import {fileURLToPath, pathToFileURL} from 'url';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 
 import {Plugin, PluginRecords} from '@commitlint/types';
 import chalk from 'chalk';

--- a/@commitlint/load/src/utils/plugin-naming.ts
+++ b/@commitlint/load/src/utils/plugin-naming.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 // largely adapted from eslint's plugin system
 const NAMESPACE_REGEX = /^@.*\//u;

--- a/@commitlint/prompt-cli/cli.test.js
+++ b/@commitlint/prompt-cli/cli.test.js
@@ -1,5 +1,5 @@
 import {test, expect} from 'vitest';
-import {createRequire} from 'module';
+import {createRequire} from 'node:module';
 import {git} from '@commitlint/test';
 import {x} from 'tinyexec';
 

--- a/@commitlint/prompt/src/inquirer/InputCustomPrompt.ts
+++ b/@commitlint/prompt/src/inquirer/InputCustomPrompt.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import inquirer, {type Answers, type InputCustomOptions} from 'inquirer';
 import InputPrompt from 'inquirer/lib/prompts/input.js';
 import observe from 'inquirer/lib/utils/events.js';
-import type {Interface as ReadlineInterface, Key} from 'readline';
+import type {Interface as ReadlineInterface, Key} from 'node:readline';
 import type {Subscription} from 'rxjs';
 
 import SuccessfulPromptStateData = inquirer.prompts.SuccessfulPromptStateData;

--- a/@commitlint/read/src/get-edit-file-path.ts
+++ b/@commitlint/read/src/get-edit-file-path.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import {Stats} from 'fs';
+import path from 'node:path';
+import {Stats} from 'node:fs';
 import fs from 'fs/promises';
 
 // Get path to recently edited commit message file

--- a/@commitlint/read/src/read.test.ts
+++ b/@commitlint/read/src/read.test.ts
@@ -1,6 +1,6 @@
 import {test, expect} from 'vitest';
 import fs from 'fs/promises';
-import path from 'path';
+import path from 'node:path';
 import {git} from '@commitlint/test';
 import {x} from 'tinyexec';
 

--- a/@commitlint/read/src/stream-to-promise.ts
+++ b/@commitlint/read/src/stream-to-promise.ts
@@ -1,4 +1,4 @@
-import {Readable} from 'stream';
+import {Readable} from 'node:stream';
 
 export function streamToPromise(stream: Readable): Promise<string[]> {
 	const data: string[] = [];

--- a/@commitlint/resolve-extends/src/index.test.ts
+++ b/@commitlint/resolve-extends/src/index.test.ts
@@ -1,5 +1,5 @@
 import {test, expect, vi} from 'vitest';
-import {createRequire} from 'module';
+import {createRequire} from 'node:module';
 import {RuleConfigSeverity, UserConfig} from '@commitlint/types';
 
 import resolveExtends, {ResolveExtendsContext} from './index.js';

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import path from 'path';
-import {pathToFileURL, fileURLToPath} from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import {pathToFileURL, fileURLToPath} from 'node:url';
 
 import globalDirectory from 'global-directory';
 import {moduleResolve} from 'import-meta-resolve';

--- a/@commitlint/rules/src/index.test.ts
+++ b/@commitlint/rules/src/index.test.ts
@@ -1,7 +1,7 @@
 import {test, expect} from 'vitest';
-import fs from 'fs';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {globSync} from 'glob';
 

--- a/@commitlint/rules/src/trailer-exists.ts
+++ b/@commitlint/rules/src/trailer-exists.ts
@@ -1,4 +1,4 @@
-import {spawnSync} from 'child_process';
+import {spawnSync} from 'node:child_process';
 import message from '@commitlint/message';
 import toLines from '@commitlint/to-lines';
 import {SyncRule} from '@commitlint/types';

--- a/@commitlint/top-level/src/index.ts
+++ b/@commitlint/top-level/src/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import {findUp} from 'find-up';
 
 export default toplevel;

--- a/@commitlint/travis-cli/src/cli.test.ts
+++ b/@commitlint/travis-cli/src/cli.test.ts
@@ -1,9 +1,9 @@
 import {SpawnOptions} from 'node:child_process';
 
 import {test, expect} from 'vitest';
-import {createRequire} from 'module';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {git} from '@commitlint/test';
 import {x} from 'tinyexec';

--- a/@commitlint/travis-cli/src/cli.ts
+++ b/@commitlint/travis-cli/src/cli.ts
@@ -1,6 +1,6 @@
 import {SpawnOptions} from 'node:child_process';
 
-import {createRequire} from 'module';
+import {createRequire} from 'node:module';
 
 import {x} from 'tinyexec';
 

--- a/@packages/test/src/fix.ts
+++ b/@packages/test/src/fix.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import fs from 'fs-extra';
 import {packageDirectory as pkgDir} from 'pkg-dir';

--- a/@packages/test/src/index.test.ts
+++ b/@packages/test/src/index.test.ts
@@ -1,6 +1,6 @@
 import {test, expect} from 'vitest';
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 import fs from 'fs-extra';
 
 import * as u from './index.js';

--- a/@packages/test/src/npm.ts
+++ b/@packages/test/src/npm.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import fs from 'fs-extra';
 import resolvePkg from 'resolve-pkg';

--- a/@packages/utils/dep-check.js
+++ b/@packages/utils/dep-check.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import path from 'path';
+import path from 'node:path';
 import {x} from 'tinyexec';
 
 const cwd = process.cwd();

--- a/@packages/utils/pkg-check.js
+++ b/@packages/utils/pkg-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import path from 'path';
-import fs from 'fs';
+import path from 'node:path';
+import fs from 'node:fs';
 
 import readPkg from 'read-pkg';
 import requireFromString from 'require-from-string';
@@ -8,12 +8,12 @@ import tar from 'tar-fs';
 import {x} from 'tinyexec';
 import tmp from 'tmp';
 import yargs from 'yargs';
-import zlib from 'zlib';
+import zlib from 'node:zlib';
 
 tmp.setGracefulCleanup();
 
 const PRELUDE = `
-var Module = require('module');
+var Module = require('node:module');
 var originalLoader = Module._load
 
 Module._load = function(path, parent) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds missing `node:` prefix on imports of builtin modules.

## Motivation and Context

Allows redundant `require.cache` calls to be bypassed for builtin modules, saving a few yoctoseconds.

See https://nodejs.org/api/modules.html#core-modules and [discussion in nodejs/node repo regarding why `require.cache` calls are redundant for builtins](https://github.com/nodejs/node/pull/37246/files#r588397158).

## Usage examples

N/A

## How Has This Been Tested?

Ran existing tests.

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
