### PR TITLE
feat: load config from deno.json

### DIFF
--- a/@commitlint/load/src/load.test.ts
+++ b/@commitlint/load/src/load.test.ts
@@ -117,7 +117,7 @@ test("plugins should be loaded from seed", async () => {
 	const cwd = await gitBootstrap("fixtures/extends-empty");
 	const actual = await load(
 		{ plugins: ["example", "@scope/example"] },
-		{ cwd },
+		{ cwd }
 	);
 
 	expect(actual.plugins).toMatchObject({
@@ -144,7 +144,7 @@ test("plugins should be loaded from local", async () => {
 					test: expect.any(Function),
 				},
 			},
-		}),
+		})
 	);
 });
 
@@ -180,7 +180,7 @@ test("local plugins should be loaded from shareable configs", async () => {
 					"is-positive": expect.any(Function),
 				},
 			},
-		}),
+		})
 	);
 });
 
@@ -188,7 +188,7 @@ test("uses seed with parserPreset", async () => {
 	const cwd = await gitBootstrap("fixtures/parser-preset");
 	const { parserPreset: actual } = await load(
 		{ parserPreset: "./conventional-changelog-custom" },
-		{ cwd },
+		{ cwd }
 	);
 
 	expect(actual).toBeDefined();
@@ -240,6 +240,7 @@ describe.each([["basic"], ["extends"]])("%s config", (template) => {
 		"commitlint.config.cjs",
 		"commitlint.config.js",
 		"commitlint.config.mjs",
+		"deno.json",
 		"package.json",
 		"package.yaml",
 		".commitlintrc",
@@ -257,7 +258,7 @@ describe.each([["basic"], ["extends"]])("%s config", (template) => {
 			.map((filename) => ({ filename, isEsm: false })),
 		...configFiles
 			.filter((filename) =>
-				[".mjs", ".js"].some((ext) => filename.endsWith(ext)),
+				[".mjs", ".js"].some((ext) => filename.endsWith(ext))
 			)
 			.map((filename) => ({ filename, isEsm: true })),
 	];
@@ -269,19 +270,19 @@ describe.each([["basic"], ["extends"]])("%s config", (template) => {
 		filename: string;
 		isEsm: boolean;
 	}): string | NodeJS.ArrayBufferView => {
-		if (filename === "package.json") {
+		if (filename === "package.json" || filename === "deno.json") {
 			const configPath = path.join(
 				__dirname,
-				`../fixtures/${template}-config/.commitlintrc.json`,
+				`../fixtures/${template}-config/.commitlintrc.json`
 			);
 			const commitlint = JSON.parse(
-				readFileSync(configPath, { encoding: "utf-8" }),
+				readFileSync(configPath, { encoding: "utf-8" })
 			);
 			return JSON.stringify({ commitlint });
 		} else if (filename === "package.yaml") {
 			const configPath = path.join(
 				__dirname,
-				`../fixtures/${template}-config/.commitlintrc.yaml`,
+				`../fixtures/${template}-config/.commitlintrc.yaml`
 			);
 			const yaml = readFileSync(configPath, { encoding: "utf-8" });
 			return `commitlint:\n${yaml.replace(/^/gm, "  ")}`;
@@ -300,7 +301,7 @@ describe.each([["basic"], ["extends"]])("%s config", (template) => {
 	const esmBootstrap = (cwd: string) => {
 		const packageJsonPath = path.join(cwd, "package.json");
 		const packageJSON = JSON.parse(
-			readFileSync(packageJsonPath, { encoding: "utf-8" }),
+			readFileSync(packageJsonPath, { encoding: "utf-8" })
 		);
 
 		writeFileSync(
@@ -308,7 +309,7 @@ describe.each([["basic"], ["extends"]])("%s config", (template) => {
 			JSON.stringify({
 				...packageJSON,
 				type: "module",
-			}),
+			})
 		);
 	};
 
@@ -321,7 +322,7 @@ describe.each([["basic"], ["extends"]])("%s config", (template) => {
 			// Skip ESM tests for the extends suite until resolve-extends supports ESM
 			.filter(({ isEsm }) => template !== "extends" || !isEsm)
 			// Skip ESM tests if dynamic await is not supported; Jest will crash with a seg fault error
-			.filter(({ isEsm }) => isDynamicAwaitSupported() || !isEsm),
+			.filter(({ isEsm }) => isDynamicAwaitSupported() || !isEsm)
 	)("$filename, ESM: $isEsm", async ({ filename, isEsm }) => {
 		const cwd = await gitBootstrap(`fixtures/${templateFolder}`);
 
@@ -331,7 +332,7 @@ describe.each([["basic"], ["extends"]])("%s config", (template) => {
 
 		writeFileSync(
 			path.join(cwd, filename),
-			getConfigContents({ filename, isEsm }),
+			getConfigContents({ filename, isEsm })
 		);
 
 		const actual = await load({}, { cwd });
@@ -510,11 +511,11 @@ test("resolves parser preset from conventional commits", async () => {
 
 	expect(actual.parserPreset).toBeDefined();
 	expect(actual.parserPreset!.name).toBe(
-		"conventional-changelog-conventionalcommits",
+		"conventional-changelog-conventionalcommits"
 	);
 	expect(typeof actual.parserPreset!.parserOpts).toBe("object");
 	expect((actual.parserPreset!.parserOpts as any).headerPattern).toEqual(
-		/^(\w*)(?:\((.*)\))?!?: (.*)$/,
+		/^(\w*)(?:\((.*)\))?!?: (.*)$/
 	);
 });
 
@@ -526,16 +527,16 @@ test("resolves parser preset from conventional angular", async () => {
 	expect(actual.parserPreset!.name).toBe("conventional-changelog-angular");
 	expect(typeof actual.parserPreset!.parserOpts).toBe("object");
 	expect((actual.parserPreset!.parserOpts as any).headerPattern).toEqual(
-		/^(\w*)(?:\((.*)\))?: (.*)$/,
+		/^(\w*)(?:\((.*)\))?: (.*)$/
 	);
 });
 
 test("recursive resolves parser preset from conventional atom", async () => {
 	const cwd = await gitBootstrap(
-		"fixtures/recursive-parser-preset-conventional-atom",
+		"fixtures/recursive-parser-preset-conventional-atom"
 	);
 	await npm.installModules(
-		path.resolve(cwd, "first-extended", "second-extended"),
+		path.resolve(cwd, "first-extended", "second-extended")
 	);
 
 	const actual = await load({}, { cwd });
@@ -544,23 +545,23 @@ test("recursive resolves parser preset from conventional atom", async () => {
 	expect(actual.parserPreset!.name).toBe("conventional-changelog-atom");
 	expect(typeof actual.parserPreset!.parserOpts).toBe("object");
 	expect((actual.parserPreset!.parserOpts as any).headerPattern).toEqual(
-		/^(:.*?:) (.*)$/,
+		/^(:.*?:) (.*)$/
 	);
 });
 
 test("resolves parser preset from conventional commits without factory support", async () => {
 	const cwd = await npmBootstrap(
-		"fixtures/parser-preset-conventional-without-factory",
+		"fixtures/parser-preset-conventional-without-factory"
 	);
 	const actual = await load({}, { cwd });
 
 	expect(actual.parserPreset).toBeDefined();
 	expect(actual.parserPreset!.name).toBe(
-		"conventional-changelog-conventionalcommits",
+		"conventional-changelog-conventionalcommits"
 	);
 	expect(typeof actual.parserPreset!.parserOpts).toBe("object");
 	expect((actual.parserPreset!.parserOpts as any).headerPattern).toEqual(
-		/^(\w*)(?:\((.*)\))?!?: (.*)$/,
+		/^(\w*)(?:\((.*)\))?!?: (.*)$/
 	);
 });
 
@@ -569,7 +570,7 @@ test("helpUrl should be loaded from the shareable config", async () => {
 	const actual = await load({}, { cwd });
 
 	expect(actual.helpUrl).toStrictEqual(
-		"https://github.com/conventional-changelog/commitlint",
+		"https://github.com/conventional-changelog/commitlint"
 	);
 });
 
@@ -578,6 +579,6 @@ test("default helpUrl should be loaded if not provided in shareable configs", as
 	const actual = await load({}, { cwd });
 
 	expect(actual.helpUrl).toStrictEqual(
-		"https://github.com/conventional-changelog/commitlint/#what-is-commitlint",
+		"https://github.com/conventional-changelog/commitlint/#what-is-commitlint"
 	);
 });

--- a/@commitlint/load/src/utils/load-config.ts
+++ b/@commitlint/load/src/utils/load-config.ts
@@ -20,7 +20,7 @@ const searchStrategy = "global";
 
 export async function loadConfig(
 	cwd: string,
-	configPath?: string,
+	configPath?: string
 ): Promise<LoadConfigResult | null> {
 	let tsLoaderInstance: Loader | undefined;
 	const tsLoader: Loader = (...args) => {
@@ -42,6 +42,7 @@ export async function loadConfig(
 		searchPlaces: [
 			// cosmiconfig overrides default searchPlaces if any new search place is added (For e.g. `*.ts` files),
 			// we need to manually merge default searchPlaces from https://github.com/davidtheclark/cosmiconfig#searchplaces
+			"deno.json",
 			"package.json",
 			"package.yaml",
 			`.${moduleName}rc`,
@@ -102,5 +103,8 @@ export const isEsmModule = (cwd: string) => {
 	}
 
 	const packageJSON = readFileSync(packagePath, { encoding: "utf-8" });
-	return JSON.parse(packageJSON)?.type === "module";
+	return (
+		JSON.parse(packageJSON)?.type === "module" ||
+		existsSync(path.join(cwd, "deno.json"))
+	);
 };

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ These can be modified by [your own configuration](#config).
   - `commitlint.config.mjs`
   - `commitlint.config.ts`
   - `commitlint.config.cts`
+  - `commitlint` field in `deno.json`
   - `commitlint` field in `package.json`
   - `commitlint` field in [`package.yaml`](https://github.com/pnpm/pnpm/pull/1799)
 - Packages: [cli](./@commitlint/cli), [core](./@commitlint/core)

--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -39,7 +39,7 @@ echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
 echo "npx --no commitlint --edit `$1" > .husky/commit-msg
 ```
 
-As an alternative you can create a script inside `package.json`
+As an alternative you can create a script inside `package.json` or `deno.json`
 
 ```sh
 npm pkg set scripts.commitlint="commitlint --edit"
@@ -59,7 +59,7 @@ echo "yarn commitlint --edit \$1" > .husky/commit-msg
 echo "yarn commitlint --edit `$1" > .husky/commit-msg
 ```
 
-As an alternative you can create a script inside `package.json`
+As an alternative you can create a script inside `package.json` or `deno.json`
 
 ```sh
 npm pkg set scripts.commitlint="commitlint --edit"
@@ -82,7 +82,7 @@ echo "pnpm dlx commitlint --edit \$1" > .husky/commit-msg
 echo "pnpm dlx commitlint --edit `$1" > .husky/commit-msg
 ```
 
-As an alternative you can create a script inside `package.json`
+As an alternative you can create a script inside `package.json` or `deno.json`
 
 ```sh
 npm pkg set scripts.commitlint="commitlint --edit"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,7 +29,7 @@ Configuration files are resolved using [cosmiconfig](https://github.com/cosmicon
 
 ## Config via `package.json`
 
-You can add a `commitlint` field in `package.json` (or [`package.yaml`](https://github.com/pnpm/pnpm/pull/1799)) with an object that follows the below structure.
+You can add a `commitlint` field in `package.json`, [`package.yaml`](https://github.com/pnpm/pnpm/pull/1799)) or `deno.json` with an object that follows the below structure.
 
 ## Config option CLI
 


### PR DESCRIPTION
Deno employs a dedicated configuration file named `deno.json`. This pull request introduces the capability to load commitlint configuration directly from `deno.json`, enabling developers using Deno to eliminate the need for a `package.json` file.

## Description

I am opening this pull request as a draft to share the changes I've made, as some parts of the codebase are still unclear to me. I welcome feedback from more experienced contributors who can use this as a foundation. Additionally, my commit includes formatting changes made by formatter automatically executed when committing.

I have added check whether `deno.json` exists to `isEsmModule` function as `deno.json` (JSR) packages support ESM only.

## Motivation and Context

Deno [supports](https://docs.deno.com/runtime/fundamentals/configuration/#package.json-support) loading configuration from `package.json`, which allows commitlint to function seamlessly. However, if developers prefer to use only `deno.json` for their configuration without relying on a separate config file, this is currently not feasible, as commitlint exclusively loads its configuration from `package.json`.

## How Has This Been Tested?

Currently, I am unable to pass the tests due to the modifications I've implemented.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
