### PR TITLE
docs: changed `husky init` to `husky install`

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -31,7 +31,7 @@ You can find complete setup instructions on the [official documentation](https:/
 ```sh
 npm install --save-dev husky
 
-npx husky init
+npx husky install
 
 # Add commit message linting to commit-msg hook
 echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
@@ -51,7 +51,7 @@ echo "npm run commitlint \${1}" > .husky/commit-msg
 ```sh
 yarn add --dev husky
 
-yarn husky init
+yarn husky install
 
 # Add commit message linting to commit-msg hook
 echo "yarn commitlint --edit \$1" > .husky/commit-msg
@@ -74,7 +74,7 @@ echo "yarn commitlint \${1}" > .husky/commit-msg
 ```sh
 pnpm add --save-dev husky
 
-pnpm husky init
+pnpm husky install
 
 # Add commit message linting to commit-msg hook
 echo "pnpm dlx commitlint --edit \$1" > .husky/commit-msg
@@ -94,7 +94,7 @@ echo "pnpm commitlint \${1}" > .husky/commit-msg
 ```sh
 deno add --dev husky
 
-deno task --eval husky init
+deno task --eval husky install
 
 # Add commit message linting to commit-msg hook
 echo "deno task --eval commitlint --edit \$1" > .husky/commit-msg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated documentation to match CLI commands

## Motivation and Context

Using `yarn husky init` gives this output:
```sh
Usage:
  husky install [dir] (default: .husky)
  husky uninstall
  husky set|add <file> [cmd]
```

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
