### PR TITLE
docs: add CLI instruction for Bun package manager (#4380)

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -22,6 +22,9 @@ npm install --save-dev @commitlint/config-conventional @commitlint/cli
 pnpm add --save-dev @commitlint/{cli,config-conventional}
 ```
 
+```sh [bun]
+bun add -d @commitlint/cli @commitlint/config-conventional
+
 ```sh [deno]
 deno add --dev npm:@commitlint/cli npm:@commitlint/config-conventional
 ```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -24,6 +24,7 @@ pnpm add --save-dev @commitlint/{cli,config-conventional}
 
 ```sh [bun]
 bun add -d @commitlint/cli @commitlint/config-conventional
+```
 
 ```sh [deno]
 deno add --dev npm:@commitlint/cli npm:@commitlint/config-conventional


### PR DESCRIPTION
## Description

Since Bun is becoming a relevant player within JS runtimes and package managers, it'd be nice to complement the documentation with CLI instructions using that as well (resolves #4380).

## Motivation and Context

Bun is a new byt very relevant package manager lready. There are many developers alrady adopting it as primary run time or at least as their package manager, since it has been showing great performance and developer experience.

## How Has This Been Tested?

This has been tested by running a sample o fthe documentation in local environment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] [N/A] ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.