### PR TITLE
chore: add Ubuntu 24.04 and Windows 2025 to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
         node: [18, 20]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR expands the GitHub Actions CI build strategy by updating the OS matrix in the workflow YAML to include two new target operating system versions.

### File-Level Changes

| Change | Details | Files |
| ------ | ------- | ----- |
| Expanded the OS matrix in the CI build job | <ul><li>Added ubuntu-24.04 to the matrix</li><li>Added windows-2025 to the matrix</li></ul> | `.github/workflows/CI.yml` |

## Motivation and Context

This pull request is needed because it updates the CI (Continuous Integration) matrix to include support for Ubuntu 24.04 and Windows 2025. By adding these environments, the repository ensures that its code is tested and verified to work on the latest operating systems, which improves compatibility and future-proofs the project.

## How Has This Been Tested?

My forked repo.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
