### PR TITLE
ci: add commitlint GitHub Actions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,47 @@
+name: Conventional Commitlint
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    name: Commitlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: lts/*
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build packages
+        run: yarn build
+
+      - name: Print versions
+        run: |
+          git --version
+          node --version
+          npm --version
+          yarn --version
+          yarn commitlint --version
+
+      - name: Validate current commit (last commit) with commitlint
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: yarn commitlint --last --verbose
+
+      - name: Validate PR commits with commitlint
+        if: github.event_name == 'pull_request'
+        run: yarn commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
## Description

This PR adds a new GitHub Actions workflow that enforces Conventional Commit message conventions by installing dependencies, building the code, and validating commits on pushes, pull requests, and manual triggers.

<details>
<summary>File-Level Changes</summary>

| Change | Details | Files |
| ------ | ------- | ----- |
| Define a new commitlint workflow with triggers and permissions | <ul><li>Create .github/workflows/commitlint.yml</li><li>Configure triggers for push, pull_request, and workflow_dispatch</li><li>Grant read access to repository contents</li></ul> | `.github/workflows/commitlint.yml` |
| Set up environment and build steps | <ul><li>Checkout repository with full history (fetch-depth: 0)</li><li>Install Node via actions/setup-node with yarn caching</li><li>Run yarn install and yarn build</li><li>Print versions of git, node, npm, yarn, and commitlint</li></ul> | `.github/workflows/commitlint.yml` |
| validate commits | <ul><li>Run commitlint on the last commit for pushes and manual dispatches</li><li>Run commitlint across the PR commit range for pull_request events</li></ul> | `.github/workflows/commitlint.yml` |

</details>

## Motivation and Context

Introduce a Conventional Commitlint workflow to enforce commit message conventions.
~~Why doesn't official repo check the commit message?~~

## Usage examples

```yml
name: Conventional Commitlint

on:
  push:
  pull_request:
  workflow_dispatch:

permissions:
  contents: read

jobs:
  commitlint:
    name: Commitlint
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
        with:
          fetch-depth: 0

      - name: Setup Node
        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
        with:
          node-version: lts/*
          cache: yarn

      - name: Install dependencies
        run: yarn install --frozen-lockfile

      - name: Build packages
        run: yarn build

      - name: Print versions
        run: |
          git --version
          node --version
          npm --version
          yarn --version
          yarn commitlint --version

      - name: Validate current commit (last commit) with commitlint
        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
        run: yarn commitlint --last --verbose

      - name: Validate PR commits with commitlint
        if: github.event_name == 'pull_request'
        run: yarn commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
```

<details>
<summary>Sequence Diagram for the Commit Validation Process</summary>

```mermaid
sequenceDiagram
    actor Dev as Developer
    participant GH as GitHub
    participant GHA as GitHub Actions
    participant CW as Commitlint Workflow

    Dev->>GH: Push commit(s) / Create PR / Dispatch workflow
    GH->>GHA: Trigger "Conventional Commitlint" workflow
    GHA->>CW: Start job "Commitlint"
    CW->>CW: Checkout code
    CW->>CW: Setup Node.js
    CW->>CW: Install dependencies (yarn)
    CW->>CW: Build packages (yarn)
    alt if event is 'push' or 'workflow_dispatch'
        CW->>CW: Validate last commit (commitlint --last)
    else if event is 'pull_request'
        CW->>CW: Validate PR commits (commitlint --from BASE --to HEAD)
    end
    alt Commit messages are valid
        CW-->>GHA: Report Success for "Commitlint" job
    else Commit messages are invalid
        CW-->>GHA: Report Failure for "Commitlint" job
    end
    GHA-->>GH: Update CI Status (e.g., on PR checks)
    GH-->>Dev: Display CI Status & Logs
```

</details>

## How Has This Been Tested?

My forked repo and [this commit's test](https://github.com/conventional-changelog/commitlint/actions/runs/15440028225/job/43455417910?pr=4440) were succeeded.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
