### PR TITLE
ci: use tags for immutable GitHub Actions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
           cache: yarn


### PR DESCRIPTION
## Description

Use version tags for GitHub Actions in the commitlint CI workflow instead of commit SHAs to improve immutability and maintainability.

CI:
- Pin actions/checkout to v4 instead of a specific commit SHA
- Pin actions/setup-node to v4 instead of a specific commit SHA

## Motivation and Context

Most first-party actions now use https://github.com/actions/publish-immutable-action, which negates the need for commit hashes, but this is not available for third-party actions yet.

## Usage examples

N/A

## How Has This Been Tested?

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
