### PR TITLE
feat(rules): make body-max-line-length ignore lines with URLs

### DIFF
--- a/@commitlint/ensure/src/max-line-length.ts
+++ b/@commitlint/ensure/src/max-line-length.ts
@@ -1,5 +1,13 @@
 import ensure from "./max-length.js";
 
+// Allow an exception for long lines which contain URLs.
+//
+// This is overly lenient, in order to avoid costly regexps which
+// have to worry about all the many edge cases of valid URLs.
+const URL_REGEX = /\bhttps?:\/\/\S+/;
+
 export default (value: string, max: number): boolean =>
 	typeof value === "string" &&
-	value.split(/\r?\n/).every((line) => ensure(line, max));
+	value
+		.split(/\r?\n/)
+		.every((line) => URL_REGEX.test(line) || ensure(line, max));

--- a/@commitlint/rules/src/body-max-line-length.test.ts
+++ b/@commitlint/rules/src/body-max-line-length.test.ts
@@ -19,6 +19,8 @@ const parsed = {
 	empty: parse(messages.empty),
 	short: parse(messages.short),
 	long: parse(messages.long),
+	shortMultipleLines: parse(messages.shortMultipleLines),
+	longMultipleLines: parse(messages.longMultipleLines),
 };
 
 test("with empty should succeed", async () => {
@@ -40,13 +42,21 @@ test("with long should fail", async () => {
 });
 
 test("with short with multiple lines should succeed", async () => {
-	const [actual] = bodyMaxLineLength(await parsed.short, undefined, value);
+	const [actual] = bodyMaxLineLength(
+		await parsed.shortMultipleLines,
+		undefined,
+		value
+	);
 	const expected = true;
 	expect(actual).toEqual(expected);
 });
 
 test("with long with multiple lines should fail", async () => {
-	const [actual] = bodyMaxLineLength(await parsed.long, undefined, value);
+	const [actual] = bodyMaxLineLength(
+		await parsed.longMultipleLines,
+		undefined,
+		value
+	);
 	const expected = false;
 	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/body-max-line-length.test.ts
+++ b/@commitlint/rules/src/body-max-line-length.test.ts
@@ -1,9 +1,11 @@
 import { test, expect } from "vitest";
 import parse from "@commitlint/parse";
+import type { Commit } from "conventional-commits-parser";
 import { bodyMaxLineLength } from "./body-max-line-length.js";
 
 const short = "a";
 const long = "ab";
+const url = "https://example.com/URL/with/a/very/long/path";
 
 const value = short.length;
 
@@ -13,15 +15,29 @@ const messages = {
 	long: `test: subject\n${long}`,
 	shortMultipleLines: `test:subject\n${short}\n${short}\n${short}`,
 	longMultipleLines: `test:subject\n${short}\n${long}\n${short}`,
+	urlStandalone: `test:subject\n${short}\n${url}\n${short}`,
+	urlMarkdownLinkInline: `test:subject
+
+This is a [link](${url}).`,
+	urlMarkdownLinkInList: `test:subject
+
+Link in a list:
+
+- ${url}`,
+	urlMarkdownLinkInFooter: `test:subject
+
+Finally, [link][] via footer.
+
+[link]: ${url}`,
 };
 
-const parsed = {
-	empty: parse(messages.empty),
-	short: parse(messages.short),
-	long: parse(messages.long),
-	shortMultipleLines: parse(messages.shortMultipleLines),
-	longMultipleLines: parse(messages.longMultipleLines),
-};
+const parsed = Object.entries(messages).reduce(
+	(_parsed, [key, message]) =>
+		Object.assign(_parsed, {
+			[key]: parse(message),
+		}),
+	{} as Record<keyof typeof messages, Promise<Commit>>,
+);
 
 test("with empty should succeed", async () => {
 	const [actual] = bodyMaxLineLength(await parsed.empty, undefined, value);
@@ -45,7 +61,7 @@ test("with short with multiple lines should succeed", async () => {
 	const [actual] = bodyMaxLineLength(
 		await parsed.shortMultipleLines,
 		undefined,
-		value
+		value,
 	);
 	const expected = true;
 	expect(actual).toEqual(expected);
@@ -55,8 +71,28 @@ test("with long with multiple lines should fail", async () => {
 	const [actual] = bodyMaxLineLength(
 		await parsed.longMultipleLines,
 		undefined,
-		value
+		value,
 	);
 	const expected = false;
+	expect(actual).toEqual(expected);
+});
+
+test("with multiple lines and standalone URL should succeed", async () => {
+	const [actual] = bodyMaxLineLength(
+		await parsed.urlStandalone,
+		undefined,
+		value,
+	);
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test("with multiple lines and URL in inline Markdown link should succeed", async () => {
+	const [actual] = bodyMaxLineLength(
+		await parsed.urlMarkdownLinkInline,
+		undefined,
+		30,
+	);
+	const expected = true;
 	expect(actual).toEqual(expected);
 });

--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -32,7 +32,7 @@
 
 ## body-max-line-length
 
-- **condition**: `body` lines has `value` or less characters
+- **condition**: `body` lines have `value` or less characters, or contain a URL
 - **rule**: `always`
 - **value**
 
@@ -97,7 +97,7 @@
 
 ## footer-max-line-length
 
-- **condition**: `footer` lines has `value` or less characters
+- **condition**: `footer` lines have `value` or less characters
 - **rule**: `always`
 - **value**
 


### PR DESCRIPTION
## Description

Whilst the `body-max-line-length` is almost always desirable, there is one fairly frequent scenario in which it gets in the way: when lines in the body of the commit message contain URLs exceeding the maximum line length.

In this case, the URL cannot be split across lines without breaking it, and minifying it results in obfuscation and a dependency on a third-party service, both of which are undesirable.

So make an exception in this rule for any line which contains a URL.  Allow other content on the same line, in order to support use of various rich-text formats such as Markdown, which are often used in order to render links in more elegant ways.

## Motivation and Context

After lengthy discussion in #2112 of how to handle long URLs, this PR proposes a simple fix which seems to be closest to achieving broad consensus as a solid first step.  More sophisticated refinements could potentially be layered on later, although there is not yet clear consensus what those might be.

## Usage examples

```js
// commitlint.config.js
module.exports = {};
```

```sh
cat <<EOF | yarn commitlint # passes
chore: some test commit header

This is the body, and it contains a
https://example.com/URL/with/a/very/very/very/very/very/very/very/very/very/long/path
EOF
```

## How Has This Been Tested?

Relevant unit tests have been added, and it's been tested from the CLI as shown above.

## Types of changes

Technically this is a change of existing functionality, although in practice it's so minor that it's more like a new feature.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.