### PR TITLE
docs: add setup guide for bun

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -89,6 +89,19 @@ npm pkg set scripts.commitlint="commitlint --edit"
 echo "pnpm commitlint \${1}" > .husky/commit-msg
 ```
 
+== bun
+
+```sh
+bun add --dev husky
+
+bunx husky install
+
+# Add commit message linting to commit-msg hook
+echo "bunx commitlint --edit \$1" > .husky/commit-msg
+# Windows users should use ` to escape dollar signs
+echo "bunx commitlint --edit `$1" > .husky/commit-msg
+```
+
 == deno
 
 ```sh


### PR DESCRIPTION
## Description

Add a new ‘bun’ section to the local setup guide for installing Husky and configuring a commitlint hook

Documentation:
- Introduce a ‘bun’ guide showing how to install Husky and initialize its hooks
- Show how to add a commitlint hook with bunx, including a Windows-specific command variation

## Motivation and Context

#4383 added CLI instruction for Bun package manager.
However, [the setup guide](https://commitlint.js.org/guides/local-setup.html#using-a-git-hooks-manager) didn't updated.

## Usage examples

```sh
bun add --dev husky
bunx husky install
# Add commit message linting to commit-msg hook
echo "bunx commitlint --edit \$1" > .husky/commit-msg
# Windows users should use ` to escape dollar signs
echo "bunx commitlint --edit `$1" > .husky/commit-msg
```

## How Has This Been Tested?

I have tested on my local PC.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
