### PR TITLE
docs: remove leftover double hyphen in setup guide

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -34,7 +34,7 @@ npm install --save-dev husky
 npx husky install
 
 # Add commit message linting to commit-msg hook
-echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
+echo "npx --no commitlint --edit \$1" > .husky/commit-msg
 # Windows users should use ` to escape dollar signs
 echo "npx --no commitlint --edit `$1" > .husky/commit-msg
 ```


### PR DESCRIPTION
## Description

Documentation:
- Fix the commit-msg hook example by eliminating the extra hyphen in the npx command

## Motivation and Context

This PR corrects a typo in the local setup guide by removing an unintended double hyphen from the npx commit-msg hook command, ensuring the example uses the proper syntax.

## Usage examples

```sh
npm install --save-dev husky

npx husky install

# Add commit message linting to commit-msg hook
echo "npx --no commitlint --edit \$1" > .husky/commit-msg
# Windows users should use ` to escape dollar signs
echo "npx --no commitlint --edit `$1" > .husky/commit-msg
```

## How Has This Been Tested?

I have tested on my local PC.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
