### PR TITLE
docs: add missing double hyphen to npm husky command in setup guide

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -36,7 +36,7 @@ npx husky install
 # Add commit message linting to commit-msg hook
 echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
 # Windows users should use ` to escape dollar signs
-echo "npx --no commitlint --edit `$1" > .husky/commit-msg
+echo "npx --no -- commitlint --edit `$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`


### PR DESCRIPTION
## Description

Documentation:
- Add missing `--` flag to the npx commitlint command in the husky commit-msg hook example in the local-setup guide

## Usage examples

```sh
npm install --save-dev husky

npx husky install

# Add commit message linting to commit-msg hook
echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
# Windows users should use ` to escape dollar signs
echo "npx --no -- commitlint --edit `$1" > .husky/commit-msg
```

As an alternative you can create a script inside `package.json`

```sh
npm pkg set scripts.commitlint="commitlint --edit"
echo "npm run commitlint \${1}" > .husky/commit-msg
```

## How Has This Been Tested?

I have tested on my local PC.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
