### PR TITLE
docs: changed `husky install` to `husky init` for v9

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -31,6 +31,9 @@ You can find complete setup instructions on the [official documentation](https:/
 ```sh
 npm install --save-dev husky
 
+# husky@v9
+npx husky init
+# husky@v8 or lower
 npx husky install
 
 # Add commit message linting to commit-msg hook
@@ -51,6 +54,9 @@ echo "npm run commitlint \${1}" > .husky/commit-msg
 ```sh
 yarn add --dev husky
 
+# husky@v9
+yarn husky init
+# husky@v8 or lower
 yarn husky install
 
 # Add commit message linting to commit-msg hook
@@ -74,6 +80,9 @@ echo "yarn commitlint \${1}" > .husky/commit-msg
 ```sh
 pnpm add --save-dev husky
 
+# husky@v9
+pnpm husky init
+# husky@v8 or lower
 pnpm husky install
 
 # Add commit message linting to commit-msg hook
@@ -94,6 +103,9 @@ echo "pnpm commitlint \${1}" > .husky/commit-msg
 ```sh
 deno add --dev husky
 
+# husky@v9
+deno task --eval husky init
+# husky@v8 or lower
 deno task --eval husky install
 
 # Add commit message linting to commit-msg hook


### PR DESCRIPTION
## Description

Update local setup documentation to use `husky init` for v9 installations and retain `husky install` instructions for v8 or lower across npm, yarn, pnpm, and deno workflows.

Documentation:
- Add `npx husky init`, `yarn husky init`, `pnpm husky init`, and `deno task --eval husky init` commands for husky@v9 setup
- Annotate `npx husky install`, `yarn husky install`, `pnpm husky install`, and `deno task --eval husky install` as applicable to husky@v8 or lower

## Motivation and Context

At #4356, `husky init` is replaced with `husky install`.
However, [husky@v9.0.1](https://github.com/typicode/husky/releases/tag/v9.0.1) introduced the `husky init` command.

This  is now easier than ever.
It's just a single line that does the same as above.
No need to read the docs to get started anymore.
 
## Usage examples

```sh
npx husky init
```

## How Has This Been Tested?

I have tested on my local PC.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
