### PR TITLE
chore: use customizations/vscode/extensions instead of extensions property

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,14 @@
   "service": "commitlint",
   "workspaceFolder": "/root/repo",
   "shutdownAction": "stopCompose",
-  "extensions": [
-    "editorconfig.editorconfig",
-    "ms-vsliveshare.vsliveshare-pack",
-    "ms-azuretools.vscode-docker",
-    "esbenp.prettier-vscode"
-  ]
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode",
+        "ms-azuretools.vscode-docker",
+        "ms-vsliveshare.vsliveshare-pack"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Description

Enhancements:
- Move VSCode extensions specification to the customizations.vscode.extensions section in .devcontainer/devcontainer.json

## Motivation and Context

Property `extensions` is not allowed in [the latest devcontainer.json](https://containers.dev/implementors/json_reference/#general-properties).
Then use [`customizations/vscode/extensions`](https://containers.dev/supporting#visual-studio-code) instead.

## Usage examples

```json
{
  "name": "commitlint-dev",
  "dockerComposeFile": ["../docker-compose.yml"],
  "service": "commitlint",
  "workspaceFolder": "/root/repo",
  "shutdownAction": "stopCompose",
  "customizations": {
    "vscode": {
      "extensions": [
        "editorconfig.editorconfig",
        "esbenp.prettier-vscode",
        "ms-azuretools.vscode-docker",
        "ms-vsliveshare.vsliveshare-pack"
      ]
    }
  }
}
```

## How Has This Been Tested?

I have tested it with GitHub Codespaces.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
