### PR TITLE
chore: add `syntax` parser directive to Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM docker.io/library/node:18-alpine AS builder
 WORKDIR /src
 COPY . ./

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM brainpower/node-cubicle
 
 WORKDIR /root/repo


### PR DESCRIPTION
## Description

Add [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to the first line of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).

## Motivation and Context

To declare the Dockerfile syntax version to use for the build.
If unspecified, [BuildKit](https://docs.docker.com/build/buildkit/) uses a bundled version of the Dockerfile frontend.

## Usage examples

```dockerfile
# syntax=docker/dockerfile:1
FROM brainpower/node-cubicle

WORKDIR /root/repo

ADD . ./
RUN yarn
RUN yarn build
```

## How Has This Been Tested?

I have built using changed Dockerfile.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
