### PR TITLE
docs: add `husky init` command to bun in setup guide

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -103,6 +103,9 @@ echo "pnpm commitlint \${1}" > .husky/commit-msg
 ```sh
 bun add --dev husky
 
+# husky@v9
+bunx husky init
+# husky@v8 or lower
 bunx husky install
 
 # Add commit message linting to commit-msg hook


### PR DESCRIPTION
## Description

Update local setup guide to include the `husky init` command for v9 and clarify installation commands for lower versions.

Documentation:
- Add `bunx husky init` step for Husky v9 in the local-setup guide
- Clarify using `bunx husky install` for Husky v8 or lower versions

## Motivation and Context

Follow up #4491.

## Usage examples

```sh
bun add --dev husky

# husky@v9
bunx husky init
# husky@v8 or lower
bunx husky install

# Add commit message linting to commit-msg hook
echo "bunx commitlint --edit \$1" > .husky/commit-msg
# Windows users should use ` to escape dollar signs
echo "bunx commitlint --edit `$1" > .husky/commit-msg
```

## How Has This Been Tested?

I have tested on my local PC.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
