### PR TITLE
docs: version up @commitlint/cli in CLI section

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,9 +1,14 @@
+<script setup>
+  import packageJson from "../../@commitlint/cli/package.json"
+  const commitlintVersion = packageJson.version
+</script>
+
 # CLI
 
-```sh
+```sh-vue
 ❯ npx commitlint --help
 
-@commitlint/cli@19.5.0 - Lint your commit messages
+@commitlint/cli@{{ commitlintVersion }} - Lint your commit messages
 
 [input] reads from stdin if --edit, --env, --from and --to are omitted
 


### PR DESCRIPTION
## Description

Integrate dynamic version display for the commitlint CLI in the reference docs and adjust the code block syntax

Documentation:
- Import the CLI’s package.json in a Vue script setup to inject the current version into the docs
- Update the CLI example code fence from `sh` to `sh-vue` and replace the hardcoded version with the dynamic value

## Motivation and Context

I got the below review.

> I don't think this requires to be updated for every single release, or we should have a automation tool to do this.

Then implement that.

## Usage examples

```sh
npx commitlint --help
```

## How Has This Been Tested?

```sh
yarn docs-build

yarn docs-preview
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
