### PR TITLE
docs: update cosmiconfig url to v9.0.0

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -25,7 +25,7 @@ The file is expected
 - export a configuration object
 - adhere to the schema outlined below
 
-Configuration files are resolved using [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig/tree/v8.2.0).
+Configuration files are resolved using [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig).
 
 ## Config via `package.json`
 


### PR DESCRIPTION
## Description

Update documentation to reference cosmiconfig v9.0.0 instead of v8.2.0

## Motivation and Context

According to [@commitlint/load CHANGELOG.md](https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/load/CHANGELOG.md#1920-2024-03-15) ...

> # [19.2.0](https://github.com/conventional-changelog/commitlint/compare/v19.1.0...v19.2.0) (2024-03-15)
>
> ### Features
>
> * **load:** update cosmiconfig to v9 to add support for `package.yaml` config ([#3976](https://github.com/conventional-changelog/commitlint/issues/3976)) ([94eab40](https://github.com/conventional-changelog/commitlint/commit/94eab40798e0c8d3945aa2b1e629669b231d8468))

Therefore, I updated the cosmiconfig link.

## Usage examples

N/A

## How Has This Been Tested?

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
