### PR TITLE
docs: update commitlint test code

### DIFF
--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -158,11 +158,11 @@ yarn commitlint --from HEAD~1 --to HEAD --verbose
 ```
 
 ```sh [pnpm]
-pnpm dlx commitlint --from HEAD~1 --to HEAD --verbose
+pnpm commitlint --from HEAD~1 --to HEAD --verbose
 ```
 
 ```sh [bun]
-bunx commitlint --from HEAD~1 --to HEAD --verbose
+bun commitlint --from HEAD~1 --to HEAD --verbose
 ```
 
 ```sh [deno]


### PR DESCRIPTION
## Description

Update commitlint invocation instructions in the local setup guide

Documentation:
- Use 'pnpm commitlint' instead of 'pnpm dlx commitlint' in the pnpm example
- Use 'bun commitlint' instead of 'bunx commitlint' in the bun example

Follow up #4501

## Motivation and Context

Simplified the commitlint commands in the local setup guide by removing auxiliary wrappers (dlx, bunx) and relying on the direct package manager invocations.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
