### PR TITLE
docs: fix TypeScript capitalization

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -21,7 +21,7 @@
 
 The file is expected
 
-- to contain valid JavaScript / Typescript
+- to contain valid JavaScript / TypeScript
 - export a configuration object
 - adhere to the schema outlined below
 
@@ -105,9 +105,9 @@ export default Configuration;
 > module.exports = Configuration;
 > ```
 
-### Typescript configuration
+### TypeScript configuration
 
-Configuration can also be a typescript file.
+Configuration can also be a TypeScript file.
 
 Relevant types and enums can be imported from `@commitlint/types`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Corrects `Typescript` and `typescript` in docs to be `TypeScript`.

## Motivation and Context

It's a common typo. 🙂 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
