### PR TITLE
feat(config-pnpm-scopes): allow global scope

### DIFF
--- a/@commitlint/config-pnpm-scopes/index.test.ts
+++ b/@commitlint/config-pnpm-scopes/index.test.ts
@@ -51,11 +51,11 @@ test("scope-enum has expected modifier", async () => {
 	expect(modifier).toBe("always");
 });
 
-test("returns empty value for empty pnpm repository", async () => {
+test("returns global scope for empty pnpm repository", async () => {
 	const { "scope-enum": fn } = config.rules;
 	const cwd = await npm.bootstrap("fixtures/empty", __dirname);
 	const [, , value] = await fn({ cwd });
-	expect(value).toEqual([]);
+	expect(value).toEqual(["global"]);
 });
 
 test("returns expected value for basic pnpm repository", async () => {
@@ -63,7 +63,7 @@ test("returns expected value for basic pnpm repository", async () => {
 	const cwd = await npm.bootstrap("fixtures/basic", __dirname);
 
 	const [, , value] = await fn({ cwd });
-	expect(value).toEqual(["a", "b"]);
+	expect(value).toEqual(["a", "b", "global"]);
 });
 
 test("returns expected value for scoped pnpm repository", async () => {
@@ -72,5 +72,5 @@ test("returns expected value for scoped pnpm repository", async () => {
 
 	const [, , value] = await fn({ cwd });
 
-	expect(value).toEqual(["a", "b"]);
+	expect(value).toEqual(["a", "b", "global"]);
 });

--- a/@commitlint/config-pnpm-scopes/index.ts
+++ b/@commitlint/config-pnpm-scopes/index.ts
@@ -69,16 +69,17 @@ function getProjects(context: any) {
 	const cwd = ctx.cwd || process.cwd();
 
 	return findWorkspacePackages(cwd).then((projects: any) => {
-		return projects
-			.reduce((projects: any, project: any) => {
-				const name = project.name;
+		const scopes = projects.reduce((acc: any, project: any) => {
+			const name = project.name;
 
-				if (name) {
-					projects.push(name.charAt(0) === "@" ? name.split("/")[1] : name);
-				}
+			if (name) {
+				acc.add(name.charAt(0) === "@" ? name.split("/")[1] : name);
+			}
 
-				return projects;
-			}, [])
-			.sort();
+			return acc;
+		}, new Set());
+		scopes.add("global");
+
+		return Array.from(scopes).sort();
 	});
 }


### PR DESCRIPTION
## Description

- Deduplicate resolved workspace package names and always include a `global` scope.
- Align the `@commitlint/config-pnpm-scopes` tests with the new `global` scope expectation.

When using a pnpm workspace, it’s not possible to specify a scope for file changes made directly under the root.
I used pnpm add --global as a reference and named the scope global.
https://pnpm.io/ja/cli/add#--global--g

## Motivation and Context

The pnpm workspace root often needs commits that touch shared files. Without a shared scope option, commitlint rejects those messages. Adding `global` keeps the restriction for packages while enabling root-level changes.

## Usage examples

```js
// commitlint.config.js
module.exports = {
  extends: ["@commitlint/config-pnpm-scopes"],
};
```

```sh
echo "chore(global): update pnpm-workspace.yaml" | commitlint
```

## How Has This Been Tested?

- `pnpm vitest run --environment node @commitlint/config-pnpm-scopes/index.test.ts`
  - (fails in the sandbox because `@commitlint/test` cannot be resolved; please re-run in a full workspace environment)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. *(Unable to complete locally due to missing dependency in sandbox)*