### PR TITLE
docs: add committier to community projects page

### DIFF
--- a/docs/reference/community-projects.md
+++ b/docs/reference/community-projects.md
@@ -10,9 +10,9 @@ If you want to add a project to this list [open a pull request](https://github.c
 
 ## List of Projects
 
-- [committier](https://github.com/iamyoki/committier) - fix and format commit messages
 - [Gitmoji Commit Workflow](https://github.com/arvinxx/gitmoji-commit-workflow)
 - [commitlint.io](https://github.com/tomasen/commitlintio) - helps your project to ensure nice and tidy commit messages without needing any download or installation
 - [commitlint plugin function rules](https://github.com/vidavidorra/commitlint-plugin-function-rules) - use functions as rule value to create rules based on commit messages, with regular expressions and more
 - [commitlint-plugin-selective-scope](https://github.com/ridvanaltun/commitlint-plugin-selective-scope) - limit scopes per type with regular expressions and plain text
 - [commitlint-gitlab-ci](https://gitlab.com/dmoonfire/commitlint-gitlab-ci/) - a small wrapper around `commitlint` for working with the quirks of Gitlab's CI without failing jobs
+- [committier](https://github.com/iamyoki/committier) - fix and format commit messages


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

committier is designed to enhance the commitlint experience by attempting to automatically format commit message to conform to the Conventional Commits specification before linting. It would be honored if committier could be added to the community projects page. Huge thanks.

More details on the [website](https://iamyoki.github.io/committier/), [repo](https://github.com/iamyoki/committier)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
