### PR TITLE
feat(rules): add scope-delimiter-style

### DIFF
--- a/@commitlint/rules/src/index.ts
+++ b/@commitlint/rules/src/index.ts
@@ -18,6 +18,7 @@ import { headerMinLength } from "./header-min-length.js";
 import { headerTrim } from "./header-trim.js";
 import { referencesEmpty } from "./references-empty.js";
 import { scopeCase } from "./scope-case.js";
+import { scopeDelimiterStyle } from "./scope-delimiter-style.js";
 import { scopeEmpty } from "./scope-empty.js";
 import { scopeEnum } from "./scope-enum.js";
 import { scopeMaxLength } from "./scope-max-length.js";
@@ -57,6 +58,7 @@ export default {
 	"header-trim": headerTrim,
 	"references-empty": referencesEmpty,
 	"scope-case": scopeCase,
+	"scope-delimiter-style": scopeDelimiterStyle,
 	"scope-empty": scopeEmpty,
 	"scope-enum": scopeEnum,
 	"scope-max-length": scopeMaxLength,

--- a/@commitlint/rules/src/scope-case.test.ts
+++ b/@commitlint/rules/src/scope-case.test.ts
@@ -322,3 +322,64 @@ test('with slash in subject should succeed for "always sentence case"', async ()
 	const expected = true;
 	expect(actual).toEqual(expected);
 });
+
+test("with object-based configuration should use default delimiters", async () => {
+	const commit = await parse("feat(scope/my-scope, shared-scope): subject");
+	const [actual] = scopeCase(commit, "always", {
+		cases: ["kebab-case"],
+	});
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test("with object-based configuration should support custom single delimiter", async () => {
+	const commit = await parse("feat(scope|my-scope): subject");
+	const [actual] = scopeCase(commit, "always", {
+		cases: ["kebab-case"],
+		delimiters: ["|"],
+	});
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test("with object-based configuration should support multiple custom delimiters", async () => {
+	const commit = await parse(
+		"feat(scope|my-scope/shared-scope,common-scope): subject",
+	);
+	const [actual] = scopeCase(commit, "always", {
+		cases: ["kebab-case"],
+		delimiters: ["|", "/", ","],
+	});
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test("with object-based configuration should fall back to default delimiters when empty array provided", async () => {
+	const commit = await parse("feat(scope/my-scope): subject");
+	const [actual] = scopeCase(commit, "always", {
+		cases: ["kebab-case"],
+		delimiters: [],
+	});
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test("with object-based configuration should handle special delimiters", async () => {
+	const commit = await parse("feat(scope*my-scope): subject");
+	const [actual] = scopeCase(commit, "always", {
+		cases: ["kebab-case"],
+		delimiters: ["*"],
+	});
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('with object-based configuration should respect "never" when custom delimiter is used', async () => {
+	const commit = await parse("feat(scope|my-scope): subject");
+	const [actual] = scopeCase(commit, "never", {
+		cases: ["kebab-case"],
+		delimiters: ["|"],
+	});
+	const expected = false;
+	expect(actual).toEqual(expected);
+});

--- a/@commitlint/rules/src/scope-delimiter-style.test.ts
+++ b/@commitlint/rules/src/scope-delimiter-style.test.ts
@@ -1,0 +1,194 @@
+import { describe, test, expect } from "vitest";
+import parse from "@commitlint/parse";
+import { scopeDelimiterStyle } from "./scope-delimiter-style.js";
+
+const messages = {
+	noScope: "feat: subject",
+
+	kebabScope: "feat(lint-staged): subject",
+	snakeScope: "feat(my_scope): subject",
+
+	defaultSlash: "feat(core/api): subject",
+	defaultComma: "feat(core,api): subject",
+	defaultCommaSpace: "feat(core, api): subject",
+	defaultBackslash: "feat(core\\api): subject",
+
+	nonDefaultPipe: "feat(core|api): subject",
+	nonDefaultStar: "feat(core*api): subject",
+	mixedCustom: "feat(core|api/utils): subject",
+} as const;
+
+describe("Scope Delimiter Validation", () => {
+	describe("Messages without scopes", () => {
+		test('Succeeds for "always" when there is no scope', async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.noScope),
+				"always",
+			);
+
+			expect(actual).toEqual(true);
+			expect(error).toEqual(undefined);
+		});
+
+		test('Succeeds for "never" when there is no scope', async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.noScope),
+				"never",
+			);
+
+			expect(actual).toEqual(true);
+			expect(error).toEqual(undefined);
+		});
+	});
+
+	describe('"always" with default configuration', () => {
+		test.each([
+			{ scenario: "kebab-case scope", commit: messages.kebabScope },
+			{ scenario: "snake_case scope", commit: messages.snakeScope },
+		] as const)(
+			"Treats $scenario as part of the scope and not a delimiter",
+			async ({ commit }) => {
+				const [actual, error] = scopeDelimiterStyle(
+					await parse(commit),
+					"always",
+				);
+
+				expect(actual).toEqual(true);
+				expect(error).toEqual("scope delimiters must be one of [/, \\, ,]");
+			},
+		);
+
+		test.each([
+			{ scenario: "comma ',' delimiter", commit: messages.defaultComma },
+			{ scenario: "slash '/' delimiter", commit: messages.defaultSlash },
+			{
+				scenario: "backslash '\\' delimiter",
+				commit: messages.defaultBackslash,
+			},
+		] as const)("Succeeds when only $scenario is used", async ({ commit }) => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(commit),
+				"always",
+			);
+
+			expect(actual).toEqual(true);
+			expect(error).toEqual("scope delimiters must be one of [/, \\, ,]");
+		});
+
+		test.each([
+			{ scenario: "comma without space", commit: messages.defaultComma },
+			{ scenario: "comma with space", commit: messages.defaultCommaSpace },
+		] as const)(
+			"Normalizes $scenario as the same delimiter ','",
+			async ({ commit }) => {
+				const [actual, error] = scopeDelimiterStyle(
+					await parse(commit),
+					"always",
+				);
+
+				expect(actual).toEqual(true);
+				expect(error).toEqual("scope delimiters must be one of [/, \\, ,]");
+			},
+		);
+
+		test("Fails when a non-default delimiter is used", async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.nonDefaultStar),
+				"always",
+			);
+
+			expect(actual).toEqual(false);
+			expect(error).toEqual("scope delimiters must be one of [/, \\, ,]");
+		});
+	});
+
+	describe('"never" with default configuration', () => {
+		test("Fails when scope uses only default delimiters", async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.defaultSlash),
+				"never",
+			);
+
+			expect(actual).toEqual(false);
+			expect(error).toEqual("scope delimiters must not be one of [/, \\, ,]");
+		});
+
+		test("Succeeds when scope uses only non-default delimiter", async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.nonDefaultPipe),
+				"never",
+			);
+
+			expect(actual).toEqual(true);
+			expect(error).toEqual("scope delimiters must not be one of [/, \\, ,]");
+		});
+	});
+
+	describe("Custom configuration", () => {
+		test("Falls back to default delimiters when delimiters is an empty array", async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.defaultComma),
+				"always",
+				[],
+			);
+
+			expect(actual).toEqual(true);
+			expect(error).toEqual("scope delimiters must be one of [/, \\, ,]");
+		});
+
+		test("Succeeds when a custom single allowed delimiter is used", async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.nonDefaultStar),
+				"always",
+				["*"],
+			);
+
+			expect(actual).toEqual(true);
+			expect(error).toEqual("scope delimiters must be one of [*]");
+		});
+
+		test("Fails when ',' is used but only '/' is allowed", async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.defaultComma),
+				"always",
+				["/"],
+			);
+
+			expect(actual).toEqual(false);
+			expect(error).toEqual("scope delimiters must be one of [/]");
+		});
+
+		test("Succeeds when both '/' and '|' are allowed and used in the scope", async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.mixedCustom),
+				"always",
+				["/", "|"],
+			);
+
+			expect(actual).toEqual(true);
+			expect(error).toEqual("scope delimiters must be one of [/, |]");
+		});
+
+		test('In "never" mode fails when explicitly forbidden delimiter is used', async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.nonDefaultPipe),
+				"never",
+				["|"],
+			);
+
+			expect(actual).toEqual(false);
+			expect(error).toEqual("scope delimiters must not be one of [|]");
+		});
+
+		test('In "never" mode succeeds when delimiter is not in the forbidden list', async () => {
+			const [actual, error] = scopeDelimiterStyle(
+				await parse(messages.nonDefaultPipe),
+				"never",
+				["/"],
+			);
+
+			expect(actual).toEqual(true);
+			expect(error).toEqual("scope delimiters must not be one of [/]");
+		});
+	});
+});

--- a/@commitlint/rules/src/scope-delimiter-style.ts
+++ b/@commitlint/rules/src/scope-delimiter-style.ts
@@ -1,0 +1,35 @@
+import * as ensure from "@commitlint/ensure";
+import message from "@commitlint/message";
+import { SyncRule } from "@commitlint/types";
+
+export const scopeDelimiterStyle: SyncRule<string[]> = (
+	{ scope },
+	when = "always",
+	value = [],
+) => {
+	if (!scope) {
+		return [true];
+	}
+
+	const delimiters = value.length ? value : ["/", "\\", ","];
+	const scopeRawDelimiters = scope.match(/[^A-Za-z0-9-_]+/g) ?? [];
+	const scopeDelimiters = [
+		...new Set(
+			scopeRawDelimiters.map((delimiter) => {
+				return delimiter.trim() === "," ? "," : delimiter;
+			}),
+		),
+	];
+
+	const isAllDelimitersAllowed = scopeDelimiters.every((delimiter) => {
+		return ensure.enum(delimiter, delimiters);
+	});
+	const isNever = when === "never";
+
+	return [
+		isNever ? !isAllDelimitersAllowed : isAllDelimitersAllowed,
+		message([
+			`scope delimiters must ${isNever ? "not " : ""}be one of [${delimiters.join(", ")}]`,
+		]),
+	];
+};

--- a/docs/concepts/commit-conventions.md
+++ b/docs/concepts/commit-conventions.md
@@ -18,9 +18,6 @@ footer?
 
 ## Multiple scopes
 
-Commitlint supports multiple scopes.  
-Current delimiter options are:
+Commitlint supports multiple scopes. Segments may be separated using delimiters (default: `/`, `\`, `,`).
 
-- "/"
-- "\\"
-- ","
+The set of allowed delimiters can be customized via the [scope-delimiter-style](/reference/rules.html#scope-delimiter-style) rule.

--- a/docs/reference/rules.md
+++ b/docs/reference/rules.md
@@ -219,6 +219,32 @@
   ];
   ```
 
+- extended value (object based)
+
+  ```js
+  {
+    cases: ["kebab-case"],
+    delimiters: ["/"]
+  }
+  ```
+
+  - `cases` — list of allowed case formats
+  - `delimiters` — optional list of delimiter strings used to split multi-segment scopes (default: `["/", "\", ","]`)
+
+## scope-delimiter-style
+
+- **condition**: all delimiters found in `scope` must match `value`
+- **rule**: `always`
+- **value**
+
+  ```text
+    ["/", "\", ","]
+  ```
+
+> [!NOTE]
+>
+> - When using this rule together with [scope-enum](#scope-enum) or [scope-case](#scope-case), make sure to provide the same `delimiters` configuration in those rules as well. Otherwise scope parsing may become inconsistent.
+
 ## scope-empty
 
 - **condition**: `scope` is empty
@@ -233,6 +259,18 @@
   ```text
   []
   ```
+
+- extended value (object based)
+
+  ```js
+  {
+    scopes: ["foo", "bar"],
+    delimiters: ["/"]
+  }
+  ```
+
+  - `scopes` — list of allowed scope values
+  - `delimiters` — optional list of delimiter strings used to split multi-segment scopes (default: `["/", "\", ","]`)
 
 > [!NOTE]
 >


### PR DESCRIPTION
## Description

This PR introduces a new rule, `scope-delimiter-style`, which validates that commit scopes use only the allowed delimiters. This ensures consistent behavior when custom delimiters are configured.

It also adds support for passing custom `delimiters` to the `scope-enum` and `scope-case` rules, allowing users to redefine how multi-segment scopes are split and validated.

The default delimiters (`/`, `\`, `,`) remain unchanged unless explicitly overridden.

Documentation has been updated to reflect:

- support for object-based configuration in `scope-enum` and `scope-case`
- ability to customize delimiters
- introduction of the new `scope-delimiter-style` rule
- updated Multiple Scopes section describing configurable delimiters

This brings delimiter handling across all scope-related rules to a unified and configurable model.

## Motivation and Context

Resolves #701 

Current scope-related rules (`scope-enum`, `scope-case`) use hardcoded delimiters to split multi-segment scopes. This makes it impossible for users to adapt commitlint to projects that use different delimiter conventions.

This PR introduces configurable delimiters and a dedicated `scope-delimiter-style` rule, enabling consistent validation across all scope rules. It provides a unified and flexible way to define how scopes should be parsed and validated, solving the long-standing limitation described in the linked issue.

## Usage examples

```js
// commitlint.config.js

const delimiters = ["/"];

export default {
  rules: {
    "scope-delimiter-style": [2, "always", delimiters],
    "scope-enum": [2, "always", { scopeEnums: ["api", "core"], delimiters }],
    "scope-case": [2, "always", { cases: "kebab-case", delimiters }],
  };
};
```

```sh
echo "feat(api,cor): add new version" | commitlint 

# ⧗   input: feat(api,cor): add new version
# ✖   scope must be one of [api, core] [scope-enum]
# ✖   scope delimiters must be one of [/] [scope-delimiter-style]
# ✖   found 2 problems, 0 warnings
```

```sh
echo "feat(api/core): add new version" | commitlint

# success
```

## How Has This Been Tested?

All changes are covered by an extended test suite:

- Updated existing tests for `scope-enum` and `scope-case` to ensure backward compatibility with default delimiters.

- Added new tests for object-based configuration, including custom delimiter lists and empty delimiter arrays.

- Added a full test suite for the new `scope-delimiter-style` rule, covering:

  - default behavior
  - custom delimiter configurations
  - `always` and `never` conditions
  - fallback to default delimiters
  - handling of special characters
  - non-delimiter characters such as `-` and `_`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
