### PR TITLE
fix: add git worktree support

### DIFF
--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -38,8 +38,12 @@
   "devDependencies": {
     "@commitlint/test": "^20.0.0",
     "@commitlint/utils": "^20.0.0",
+    "@types/fs-extra": "^11.0.3",
     "@types/git-raw-commits": "^2.0.3",
-    "@types/minimist": "^1.2.4"
+    "@types/minimist": "^1.2.4",
+    "@types/tmp": "^0.2.5",
+    "fs-extra": "^11.0.0",
+    "tmp": "^0.2.1"
   },
   "dependencies": {
     "@commitlint/top-level": "^20.0.0",

--- a/@commitlint/top-level/package.json
+++ b/@commitlint/top-level/package.json
@@ -38,8 +38,5 @@
   "devDependencies": {
     "@commitlint/utils": "^20.0.0"
   },
-  "dependencies": {
-    "find-up": "^7.0.0"
-  },
   "gitHead": "e82f05a737626bb69979d14564f5ff601997f679"
 }

--- a/@commitlint/top-level/package.json
+++ b/@commitlint/top-level/package.json
@@ -36,7 +36,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@commitlint/utils": "^20.0.0"
+    "@commitlint/utils": "^20.0.0",
+    "@types/fs-extra": "^11.0.3",
+    "@types/tmp": "^0.2.5",
+    "fs-extra": "^11.0.0",
+    "tmp": "^0.2.1"
   },
   "gitHead": "e82f05a737626bb69979d14564f5ff601997f679"
 }

--- a/@commitlint/top-level/src/index.test.ts
+++ b/@commitlint/top-level/src/index.test.ts
@@ -1,0 +1,127 @@
+import { test, expect, describe } from "vitest";
+import path from "node:path";
+import fs from "fs-extra";
+import tmp from "tmp";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { realpathSync } from "node:fs";
+
+import toplevel from "./index.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Normalize a path for cross-platform comparison.
+ * On Windows, tmp paths may use short names (e.g., RUNNER~1) while git returns long names.
+ * This resolves symlinks and normalizes the path format.
+ */
+function normalizePath(p: string): string {
+	return realpathSync(p).replace(/\\/g, "/");
+}
+
+async function initGitRepo(cwd: string): Promise<void> {
+	await execFileAsync("git", ["init"], { cwd });
+	await execFileAsync("git", ["config", "user.email", "test@example.com"], {
+		cwd,
+	});
+	await execFileAsync("git", ["config", "user.name", "test"], { cwd });
+	await execFileAsync("git", ["config", "commit.gpgsign", "false"], { cwd });
+}
+
+describe("toplevel", () => {
+	test("should return git root for a regular repository", async () => {
+		const tmpDir = tmp.dirSync({ keep: false, unsafeCleanup: true });
+		const repoDir = tmpDir.name;
+
+		await initGitRepo(repoDir);
+
+		const result = await toplevel(repoDir);
+		expect(normalizePath(result!)).toBe(normalizePath(repoDir));
+	});
+
+	test("should return git root from a subdirectory", async () => {
+		const tmpDir = tmp.dirSync({ keep: false, unsafeCleanup: true });
+		const repoDir = tmpDir.name;
+
+		await initGitRepo(repoDir);
+
+		const subDir = path.join(repoDir, "sub", "dir");
+		await fs.mkdirp(subDir);
+
+		const result = await toplevel(subDir);
+		expect(normalizePath(result!)).toBe(normalizePath(repoDir));
+	});
+
+	test("should return undefined for a non-git directory", async () => {
+		const tmpDir = tmp.dirSync({ keep: false, unsafeCleanup: true });
+
+		const result = await toplevel(tmpDir.name);
+		expect(result).toBeUndefined();
+	});
+
+	test("should work with git worktrees", async () => {
+		const tmpDir = tmp.dirSync({ keep: false, unsafeCleanup: true });
+		const mainRepoDir = path.join(tmpDir.name, "main");
+		const worktreeDir = path.join(tmpDir.name, "worktree");
+
+		await fs.mkdirp(mainRepoDir);
+		await initGitRepo(mainRepoDir);
+
+		// Create an initial commit (required for worktree)
+		await fs.writeFile(path.join(mainRepoDir, "file.txt"), "content");
+		await execFileAsync("git", ["add", "."], { cwd: mainRepoDir });
+		await execFileAsync("git", ["commit", "-m", "initial"], {
+			cwd: mainRepoDir,
+		});
+
+		// Create a new branch for the worktree
+		await execFileAsync("git", ["branch", "worktree-branch"], {
+			cwd: mainRepoDir,
+		});
+
+		// Create the worktree
+		await execFileAsync(
+			"git",
+			["worktree", "add", worktreeDir, "worktree-branch"],
+			{ cwd: mainRepoDir },
+		);
+
+		// toplevel should return the worktree directory, not the main repo
+		const result = await toplevel(worktreeDir);
+		expect(normalizePath(result!)).toBe(normalizePath(worktreeDir));
+	});
+
+	test("should work from a subdirectory of a git worktree", async () => {
+		const tmpDir = tmp.dirSync({ keep: false, unsafeCleanup: true });
+		const mainRepoDir = path.join(tmpDir.name, "main");
+		const worktreeDir = path.join(tmpDir.name, "worktree");
+
+		await fs.mkdirp(mainRepoDir);
+		await initGitRepo(mainRepoDir);
+
+		// Create an initial commit
+		await fs.writeFile(path.join(mainRepoDir, "file.txt"), "content");
+		await execFileAsync("git", ["add", "."], { cwd: mainRepoDir });
+		await execFileAsync("git", ["commit", "-m", "initial"], {
+			cwd: mainRepoDir,
+		});
+
+		// Create a new branch and worktree
+		await execFileAsync("git", ["branch", "worktree-branch"], {
+			cwd: mainRepoDir,
+		});
+		await execFileAsync(
+			"git",
+			["worktree", "add", worktreeDir, "worktree-branch"],
+			{ cwd: mainRepoDir },
+		);
+
+		// Create a subdirectory in the worktree
+		const subDir = path.join(worktreeDir, "sub", "dir");
+		await fs.mkdirp(subDir);
+
+		// toplevel from subdirectory should return the worktree root
+		const result = await toplevel(subDir);
+		expect(normalizePath(result!)).toBe(normalizePath(worktreeDir));
+	});
+});

--- a/@commitlint/top-level/src/index.ts
+++ b/@commitlint/top-level/src/index.ts
@@ -1,27 +1,47 @@
-import path from "node:path";
-import { findUp } from "find-up";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { realpathSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const execFileAsync = promisify(execFile);
 
 export default toplevel;
 
 /**
- * Find the next git root
+ * Find the git root directory using git rev-parse.
+ * This correctly handles git worktrees, submodules, and regular repositories.
  */
-async function toplevel(cwd?: string) {
-	const found = await searchDotGit(cwd);
+async function toplevel(cwd?: string): Promise<string | undefined> {
+	try {
+		const { stdout } = await execFileAsync(
+			"git",
+			["rev-parse", "--show-toplevel"],
+			{
+				cwd,
+			},
+		);
 
-	if (typeof found !== "string") {
-		return found;
+		const topLevel = stdout.trim();
+		if (topLevel) {
+			// Resolve symlinks and normalize path on Windows to handle short/long path names
+			// Git may return long paths while Node.js uses short paths (or vice versa)
+			// We need to resolve through the filesystem to ensure consistency
+			try {
+				// First resolve the path (handles relative paths and normalizes)
+				const resolvedPath = resolve(topLevel);
+				// Then use realpathSync to resolve symlinks and get canonical path
+				// On Windows, this also handles 8.3 short name conversions
+				if (existsSync(resolvedPath)) {
+					return realpathSync(resolvedPath);
+				}
+				return resolvedPath;
+			} catch {
+				return topLevel;
+			}
+		}
+
+		return undefined;
+	} catch {
+		return undefined;
 	}
-
-	return path.join(found, "..");
-}
-
-/**
- * Search .git, the '.git' can be a file(submodule), also can be a directory(normal)
- */
-async function searchDotGit(cwd?: string) {
-	const foundFile = await findUp(".git", { cwd, type: "file" });
-	const foundDir = await findUp(".git", { cwd, type: "directory" });
-
-	return foundFile || foundDir;
 }


### PR DESCRIPTION
### **User description**
## Summary

This PR fixes #787 by replacing custom git root detection with native git commands that properly handle git worktrees.

## Problem

When running commitlint from within a git worktree directory, users get the error:
```
could not find git root from undefined
```

This happens because the previous implementation used `find-up` to search for `.git` directories, which doesn't work correctly with worktrees where `.git` is a file pointing to the actual git directory.

## Solution

### 1. `@commitlint/top-level`
- Replaced `find-up` library with `git rev-parse --show-toplevel`
- This correctly returns the working tree root for regular repos, submodules, and worktrees
- Removed `find-up` dependency

### 2. `@commitlint/read` (get-edit-file-path)
- Replaced manual `.git` file/directory detection with `git rev-parse --git-dir`
- This correctly resolves to the actual git directory where `COMMIT_EDITMSG` lives, even in worktrees

## Testing

Added comprehensive tests for git worktree support:
- `@commitlint/top-level`: 5 new tests covering regular repos, subdirectories, non-git directories, and worktrees
- `@commitlint/read`: 1 new test verifying reading commit messages from worktrees

All existing tests continue to pass.

## Commits

1. `fix(top-level): use git rev-parse for worktree support` - Core implementation change
2. `fix(read): use git rev-parse --git-dir for worktree support` - Edit file path fix
3. `test: add git worktree tests for top-level and read` - Test coverage

Fixes #787


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `find-up` with native `git rev-parse` commands for proper worktree support

- Fix git root detection in `@commitlint/top-level` using `git rev-parse --show-toplevel`

- Fix edit file path resolution in `@commitlint/read` using `git rev-parse --git-dir`

- Add comprehensive test coverage for git worktree scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["find-up library"] -->|replaced with| B["git rev-parse"]
  B -->|--show-toplevel| C["@commitlint/top-level"]
  B -->|--git-dir| D["@commitlint/read"]
  C -->|handles| E["Worktrees & Submodules"]
  D -->|resolves| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Replace find-up with git rev-parse for root detection</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

@commitlint/top-level/src/index.ts

<ul><li>Replaced <code>find-up</code> library with <code>git rev-parse --show-toplevel</code> command<br> <li> Simplified implementation from multi-step search to single git command<br> <li> Added error handling to return <code>undefined</code> for non-git directories<br> <li> Updated JSDoc to clarify worktree, submodule, and regular repo support</ul>


</details>


  </td>
  <td><a href="https://github.com/conventional-changelog/commitlint/pull/4591/files#diff-03e173dc04d65341adfc5c686a4bce02f9db289e1c8de29db178e6d5493b1aa3">+19/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get-edit-file-path.ts</strong><dd><code>Use git rev-parse for edit file path resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

@commitlint/read/src/get-edit-file-path.ts

<ul><li>Replaced manual <code>.git</code> file/directory detection with <code>git rev-parse </code><br><code>--git-dir</code><br> <li> Removed <code>fs.lstat()</code> and <code>fs.readFile()</code> calls for simpler implementation<br> <li> Now correctly handles worktrees where <code>.git</code> is a file pointer<br> <li> Uses <code>execFile</code> with promisified async wrapper for git command execution</ul>


</details>


  </td>
  <td><a href="https://github.com/conventional-changelog/commitlint/pull/4591/files#diff-9edcbe8adcbecc3da0cdaf40ff4820b31b336a0184ebca55679049e22a6b1505">+11/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Add comprehensive git worktree test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

@commitlint/top-level/src/index.test.ts

<ul><li>Added 5 new comprehensive tests for git worktree support<br> <li> Tests cover regular repositories, subdirectories, non-git directories, <br>and worktrees<br> <li> Includes helper function <code>initGitRepo()</code> for test setup<br> <li> Tests verify correct behavior from worktree subdirectories</ul>


</details>


  </td>
  <td><a href="https://github.com/conventional-changelog/commitlint/pull/4591/files#diff-a3da9e58eaee469cf9a7afb733123ded702bccf6524f9328d78ac1571c33e9a7">+117/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>read.test.ts</strong><dd><code>Add git worktree read functionality test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

@commitlint/read/src/read.test.ts

<ul><li>Added new test for reading commit messages from git worktrees<br> <li> Test creates main repo, branch, and worktree with actual git <br>operations<br> <li> Verifies <code>read()</code> function correctly retrieves edit commit message from <br>worktree<br> <li> Uses <code>tmp</code>, <code>fs-extra</code>, and <code>tinyexec</code> for test infrastructure</ul>


</details>


  </td>
  <td><a href="https://github.com/conventional-changelog/commitlint/pull/4591/files#diff-348a0a52aee8c99be1874bdb4599fc115a92672daa1c857d2c3940351f3498a8">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Remove find-up, add test dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

@commitlint/top-level/package.json

<ul><li>Removed <code>find-up</code> dependency from <code>dependencies</code><br> <li> Added test dependencies: <code>fs-extra</code>, <code>tmp</code>, and their type definitions<br> <li> Moved <code>@commitlint/utils</code> to <code>devDependencies</code> section</ul>


</details>


  </td>
  <td><a href="https://github.com/conventional-changelog/commitlint/pull/4591/files#diff-7c44781ddc6a32a990c89d7a8749a8e56934d38304896eb67c99395be88ef696">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add test utility dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

@commitlint/read/package.json

<ul><li>Added <code>fs-extra</code>, <code>tmp</code> and their TypeScript type definitions as dev <br>dependencies<br> <li> Supports new worktree test implementation with file system utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/conventional-changelog/commitlint/pull/4591/files#diff-e0c01f2a5ea62415568f1cf83dd542821dc6b26a9c862b68456faf8343b4484f">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

