### PR TITLE
fix(types): add scope-delimiter-style types

### DIFF
--- a/@commitlint/types/src/rules.ts
+++ b/@commitlint/types/src/rules.ts
@@ -88,6 +88,10 @@ export type EnumRuleConfig<V = RuleConfigQuality.User> = RuleConfig<
 	V,
 	string[]
 >;
+export type ObjectRuleConfig<
+	V = RuleConfigQuality.User,
+	T = Record<string, unknown>,
+> = RuleConfig<V, T>;
 
 export type RulesConfig<V = RuleConfigQuality.User> = {
 	"body-case": CaseRuleConfig<V>;
@@ -109,9 +113,14 @@ export type RulesConfig<V = RuleConfigQuality.User> = {
 	"header-min-length": LengthRuleConfig<V>;
 	"header-trim": RuleConfig<V>;
 	"references-empty": RuleConfig<V>;
-	"scope-case": CaseRuleConfig<V>;
+	"scope-case":
+		| CaseRuleConfig<V>
+		| ObjectRuleConfig<V, { cases: TargetCaseType[]; delimiters?: string[] }>;
+	"scope-delimiter-style": EnumRuleConfig<V>;
 	"scope-empty": RuleConfig<V>;
-	"scope-enum": EnumRuleConfig<V>;
+	"scope-enum":
+		| EnumRuleConfig<V>
+		| ObjectRuleConfig<V, { scopes: string[]; delimiters?: string[] }>;
 	"scope-max-length": LengthRuleConfig<V>;
 	"scope-min-length": LengthRuleConfig<V>;
 	"signed-off-by": RuleConfig<V, string>;


### PR DESCRIPTION
### **User description**
## Description

This PR adds TypeScript support for object-based configurations introduced in the previous changes (https://github.com/conventional-changelog/commitlint/pull/4580).

While the runtime behavior and config validation already support object-based values for scope-enum and scope-case, TypeScript types were still restricted to the tuple-based format only. As a result, valid configurations caused TypeScript errors even though commitlint worked correctly at runtime.

This change extends the rule value types only for the affected rules (`scope-enum` and `scope-case`) to allow object-based configurations, without altering shared generic rule types. This keeps the existing type model intact while aligning TypeScript definitions with the actual supported configuration format.

No runtime behavior is changed, this PR only updates TypeScript types to reflect the existing functionality.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `ObjectRuleConfig` generic type for object-based rule configurations

- Extend `scope-case` type to support object format with cases and delimiters

- Extend `scope-enum` type to support object format with scopes and delimiters

- Add `scope-delimiter-style` rule type to RulesConfig


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ObjectRuleConfig<br/>Generic Type"] --> B["scope-case<br/>Union Type"]
  A --> C["scope-enum<br/>Union Type"]
  D["scope-delimiter-style<br/>EnumRuleConfig"] --> E["RulesConfig<br/>Updated"]
  B --> E
  C --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rules.ts</strong><dd><code>Add object-based scope rule configuration types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

@commitlint/types/src/rules.ts

<ul><li>Added new <code>ObjectRuleConfig</code> generic type to support object-based <br>configurations<br> <li> Updated <code>scope-case</code> to union type allowing both <code>CaseRuleConfig</code> and <br>object format with <code>cases</code> and optional <code>delimiters</code><br> <li> Updated <code>scope-enum</code> to union type allowing both <code>EnumRuleConfig</code> and <br>object format with <code>scopes</code> and optional <code>delimiters</code><br> <li> Added <code>scope-delimiter-style</code> rule using <code>EnumRuleConfig</code> type</ul>


</details>


  </td>
  <td><a href="https://github.com/conventional-changelog/commitlint/pull/4592/files#diff-1fe6446c7e9f082c60356c241604fe4b61ca7ca5957c8bd27ce605472a05f055">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

