### PR TITLE
fix(rules): ignore cherry-picks in signed-off-by

### DIFF
--- a/@commitlint/rules/src/signed-off-by.test.ts
+++ b/@commitlint/rules/src/signed-off-by.test.ts
@@ -17,6 +17,15 @@ Signed-off-by:
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
 `,
+
+	withSignoffAndCherryPick: `test: subject
+
+message body
+
+Signed-off-by:
+
+(cherry picked from commit 1234567aB)
+`,
 };
 
 const parsed = {
@@ -26,6 +35,7 @@ const parsed = {
 	inSubject: parse(messages.inSubject),
 	inBody: parse(messages.inBody),
 	withSignoffAndComments: parse(messages.withSignoffAndComments),
+	withSignoffAndCherryPick: parse(messages.withSignoffAndCherryPick),
 };
 
 test('empty against "always signed-off-by" should fail', async () => {
@@ -107,5 +117,25 @@ test('inBody against "always signed-off-by" should fail', async () => {
 test('inBody against "never signed-off-by" should succeed', async () => {
 	const [actual] = signedOffBy(await parsed.inBody, "never", "Signed-off-by:");
 	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test("cherry pick marker should be ignored", async () => {
+	const [actual] = signedOffBy(
+		await parsed.withSignoffAndCherryPick,
+		"always",
+		"Signed-off-by:",
+	);
+	const expected = true;
+	expect(actual).toEqual(expected);
+});
+
+test('cherry pick marker with "never signed-off-by" should fail', async () => {
+	const [actual] = signedOffBy(
+		await parsed.withSignoffAndCherryPick,
+		"never",
+		"Signed-off-by:",
+	);
+	const expected = false;
 	expect(actual).toEqual(expected);
 });

--- a/@commitlint/rules/src/signed-off-by.ts
+++ b/@commitlint/rules/src/signed-off-by.ts
@@ -2,6 +2,8 @@ import message from "@commitlint/message";
 import toLines from "@commitlint/to-lines";
 import { SyncRule } from "@commitlint/types";
 
+const CHERRY_PICK_REGEX = /^\(cherry picked from commit [0-9a-f]{7,64}\)$/i;
+
 export const signedOffBy: SyncRule<string> = (
 	parsed,
 	when = "always",
@@ -11,6 +13,8 @@ export const signedOffBy: SyncRule<string> = (
 		(ln) =>
 			// skip comments
 			!ln.startsWith("#") &&
+			// skip cherry pick commits
+			!CHERRY_PICK_REGEX.test(ln.trim()) &&
 			// ignore empty lines
 			Boolean(ln),
 	);


### PR DESCRIPTION
## Description

Before this change, the rule `signed-off-by` was rejecting cherry picked commits, as the cherry pick message wasn't appearing as the last line. With this in place, the rule will treat cherry picked commits just the same as regular commits.

## Motivation and Context

Addresses https://github.com/conventional-changelog/commitlint/issues/2704 to remove the need for the `trailer-exists` workaround.

## Usage examples

<!--- Provide examples of intended usage -->

1. cherry-pick any commit with  cherry-pick -x commit-id
1. run commitlint

or with the current change:

```sh
yarn build

printf 'fix: 🍒\n\nSigned-off-by: Manuel Zedel <manuel.zedel@northern.tech>\n\ncherry picked from commit 123' | commitlint --config @commitlint/cli/fixtures/signoff/commitlint.config.js
```

## How Has This Been Tested?

I added a unit-test, watched it fail and then fixed the implementation to make the test pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
