### PR TITLE
fix(types): allow context parameter in QualifiedRuleConfig functions

### DIFF
--- a/@commitlint/types/src/rules.test-d.ts
+++ b/@commitlint/types/src/rules.test-d.ts
@@ -44,3 +44,31 @@ const _scopeCaseSimpleCheck: Partial<RulesConfig> = {
 	"scope-case": _scopeCaseSimple,
 };
 void _scopeCaseSimpleCheck;
+
+// Tests for context parameter support:
+// https://github.com/conventional-changelog/commitlint/issues/4357
+// Rule functions should accept an optional context parameter with cwd.
+
+// Sync function with context
+const _syncWithCtx: Partial<RulesConfig> = {
+	"scope-enum": (ctx) => [ERROR, "always", ["foo", ctx?.cwd || "bar"]],
+};
+void _syncWithCtx;
+
+// Async function with context
+const _asyncWithCtx: Partial<RulesConfig> = {
+	"scope-enum": async (ctx) => [ERROR, "always", ["foo", ctx?.cwd || "bar"]],
+};
+void _asyncWithCtx;
+
+// Function without context (backward compatibility)
+const _funcNoCtx: Partial<RulesConfig> = {
+	"scope-enum": () => [ERROR, "always", ["foo", "bar"]],
+};
+void _funcNoCtx;
+
+// Async function without context (backward compatibility)
+const _asyncNoCtx: Partial<RulesConfig> = {
+	"scope-enum": async () => [ERROR, "always", ["foo", "bar"]],
+};
+void _asyncNoCtx;

--- a/@commitlint/types/src/rules.ts
+++ b/@commitlint/types/src/rules.ts
@@ -64,9 +64,13 @@ export enum RuleConfigQuality {
 	Qualified,
 }
 
+export interface RuleConfigContext {
+	cwd?: string;
+}
+
 export type QualifiedRuleConfig<T> =
-	| (() => RuleConfigTuple<T>)
-	| (() => Promise<RuleConfigTuple<T>>)
+	| ((ctx?: RuleConfigContext) => RuleConfigTuple<T>)
+	| ((ctx?: RuleConfigContext) => Promise<RuleConfigTuple<T>>)
 	| RuleConfigTuple<T>;
 
 export type RuleConfig<


### PR DESCRIPTION
Fixes #4357

## Description

This PR updates the `QualifiedRuleConfig` type in `@commitlint/types` to allow rule configuration functions to accept an optional context parameter with a `cwd` property.

Previously, the type only supported functions with no parameters:
```typescript
| (() => RuleConfigTuple<T>)
| (() => Promise<RuleConfigTuple<T>>)
```

Now it also supports functions with an optional context parameter:
```typescript
| ((ctx?: RuleConfigContext) => RuleConfigTuple<T>)
| ((ctx?: RuleConfigContext) => Promise<RuleConfigTuple<T>>)
```

A new `RuleConfigContext` interface is introduced:
```typescript
export interface RuleConfigContext {
  cwd?: string;
}
```

## Motivation and Context

Users using configs like `@commitlint/config-nx-scopes` need to pass a context parameter to rule functions. The JavaScript implementation already supports this pattern (context is optional and defaults to empty object), but the TypeScript types were preventing this usage.

This allows users to write configs like:
```typescript
import { utils } from '@commitlint/config-nx-scopes';
import type { UserConfig } from '@commitlint/types';
import { RuleConfigSeverity } from '@commitlint/types';

const config: UserConfig = {
  extends: ['@commitlint/config-conventional', '@commitlint/config-nx-scopes'],
  rules: {
    'scope-enum': async (ctx) => [
      RuleConfigSeverity.Error,
      'always',
      ['repo', 'deps', 'release', ...(await utils.getProjects(ctx))],
    ],
  },
};

export default config;
```

## Usage examples

```typescript
import type { UserConfig, RuleConfigSeverity } from '@commitlint/types';

const config: UserConfig = {
  rules: {
    // Sync function with context
    'scope-enum': (ctx) => [
      RuleConfigSeverity.Error,
      'always',
      ['foo', ctx?.cwd || 'default'],
    ],

    // Async function with context
    'scope-enum': async (ctx) => [
      RuleConfigSeverity.Error,
      'always',
      await getScopes(ctx?.cwd),
    ],

    // Without context (backward compatible)
    'scope-enum': () => [RuleConfigSeverity.Error, 'always', ['foo', 'bar']],
  },
};
```

## How Has This Been Tested?

- Added type tests in `@commitlint/types/src/rules.test-d.ts` to verify that:
  - Sync functions with context parameter are accepted
  - Async functions with context parameter are accepted
  - Functions without context parameter still work (backward compatibility)
- All existing tests pass (`npx vitest run @commitlint/types`)
- TypeScript build succeeds (`npx tsc -b`)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---

**Diff stats:**
```
 @commitlint/types/src/rules.test-d.ts | 32 ++++++++++++++++++++++++++
 @commitlint/types/src/rules.ts        |  8 +++++--
 2 files changed, 38 insertions(+), 2 deletions(-)
```