### PR TITLE
  ci: restore push on all branches, avoid duplicate runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - "**"
   pull_request:
     types: [opened, synchronize]
 
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
@@ -41,6 +42,7 @@ jobs:
 
   codeQuality:
     name: Code quality
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     needs: [build]
     runs-on: ubuntu-24.04
     steps:
@@ -62,6 +64,7 @@ jobs:
 
   nodeJsBaselineAptCompatibility:
     name: NodeJS installed from stock Ubuntu-LTS packages (not external sources)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-24.04
     container:
       image: "ubuntu:24.04"


### PR DESCRIPTION

 Reverts the push trigger from `master`-only back to `"**"` (all branches) so
  contributors can see CI status on their fork branches before opening a PR
  (reverts part of #4660, restores #3840).

  To avoid duplicate CI runs when a maintainer pushes to a branch with an open
  PR, each job skips `pull_request` events from the same repository — the same
  approach used by [Vue.js](https://github.com/vuejs/core/blob/main/.github/workflows/ci.yml):

  - **Push events**: always run
  - **Pull request events**: only run if the PR is from a fork
  - **Schedule/workflow_dispatch**: always run

  This avoids the "50% broken CI" visual noise that concurrency groups cause
  (cancelled jobs show as failures in the GitHub UI).
