### PR TITLE
chore!: minimum node version v22

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,9 +19,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
-        # Node versions match Ubuntu LTS defaults:
-        # 18 = Ubuntu 24.04, 20 = Ubuntu 25.x, 22 = Ubuntu 26.04
-        node: [18, 20, 22]
+        # 22 = Ubuntu 26.04 LTS
+        node: [22, 24]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -67,7 +66,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-24.04
     container:
-      image: "ubuntu:24.04"
+      image: "ubuntu:26.04"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
           cache: yarn
 
       - name: Setup Pages

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
-yarn lint-staged
+yarn --ignore-engines lint-staged
 
 # be sure to build with up to date source
 # before running pre-commit hook which is using `@commitlint/cli/lib/cli.js`
-yarn build
+yarn --ignore-engines build

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,2 @@
 [tools]
-node = "18"
+node = "22"

--- a/@alias/commitlint-config-angular/package.json
+++ b/@alias/commitlint-config-angular/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "@commitlint/config-angular": "^20.5.3"

--- a/@alias/commitlint-config-lerna-scopes/package.json
+++ b/@alias/commitlint-config-lerna-scopes/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "@commitlint/config-lerna-scopes": "^20.4.3"

--- a/@alias/commitlint-config-nx-scopes/package.json
+++ b/@alias/commitlint-config-nx-scopes/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "@commitlint/config-nx-scopes": "^20.5.0"

--- a/@alias/commitlint-config-patternplate/package.json
+++ b/@alias/commitlint-config-patternplate/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "@commitlint/config-patternplate": "^20.5.3"

--- a/@alias/commitlint/package.json
+++ b/@alias/commitlint/package.json
@@ -14,7 +14,7 @@
     "pkg": "pkg-check --skip-main"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -17,7 +17,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
     "@commitlint/test": "^20.4.3",
     "@commitlint/utils": "^20.0.0",
     "@types/conventional-commits-parser": "^5.0.2",
-    "@types/node": "^18.19.17",
+    "@types/node": "^22.0.0",
     "@types/yargs": "^17.0.29",
     "es-toolkit": "^1.46.0",
     "fs-extra": "^11.3.4"

--- a/@commitlint/config-angular-type-enum/package.json
+++ b/@commitlint/config-angular-type-enum/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "devDependencies": {
     "@commitlint/utils": "^20.0.0"

--- a/@commitlint/config-angular/package.json
+++ b/@commitlint/config-angular/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "devDependencies": {
     "@commitlint/lint": "^20.5.3",

--- a/@commitlint/config-conventional/package.json
+++ b/@commitlint/config-conventional/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "devDependencies": {
     "@commitlint/lint": "^20.5.3",

--- a/@commitlint/config-lerna-scopes/package.json
+++ b/@commitlint/config-lerna-scopes/package.json
@@ -37,7 +37,7 @@
     }
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "@commitlint/config-workspace-scopes": "^20.4.3",

--- a/@commitlint/config-nx-scopes/package.json
+++ b/@commitlint/config-nx-scopes/package.json
@@ -37,7 +37,7 @@
     }
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "@commitlint/types": "^20.5.0"

--- a/@commitlint/config-patternplate/package.json
+++ b/@commitlint/config-patternplate/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "@commitlint/config-angular": "^20.5.3",

--- a/@commitlint/config-pnpm-scopes/package.json
+++ b/@commitlint/config-pnpm-scopes/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "@pnpm/read-project-manifest": "^5.0.10",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@commitlint/test": "^20.4.3",
     "@commitlint/utils": "^20.0.0",
-    "@types/node": "^18.19.17",
+    "@types/node": "^22.0.0",
     "typescript": "^6.0.0"
   },
   "exports": {

--- a/@commitlint/config-rush-scopes/package.json
+++ b/@commitlint/config-rush-scopes/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "jsonc": "^2.0.0"

--- a/@commitlint/config-validator/package.json
+++ b/@commitlint/config-validator/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/config-workspace-scopes/package.json
+++ b/@commitlint/config-workspace-scopes/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "dependencies": {
     "glob": "^11.0.0"

--- a/@commitlint/core/package.json
+++ b/@commitlint/core/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/cz-commitlint/package.json
+++ b/@commitlint/cz-commitlint/package.json
@@ -33,7 +33,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "author": "Curly Brackets <water.curly@outlook.com>",
   "license": "MIT",

--- a/@commitlint/ensure/package.json
+++ b/@commitlint/ensure/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/execute-rule/package.json
+++ b/@commitlint/execute-rule/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/format/package.json
+++ b/@commitlint/format/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/is-ignored/package.json
+++ b/@commitlint/is-ignored/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/test": "^20.4.3",
-    "@types/node": "^18.19.17",
+    "@types/node": "^22.0.0",
     "conventional-changelog-atom": "^5.0.0",
     "typescript": "^6.0.0"
   },

--- a/@commitlint/message/package.json
+++ b/@commitlint/message/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/parse/package.json
+++ b/@commitlint/parse/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/prompt-cli/package.json
+++ b/@commitlint/prompt-cli/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "devDependencies": {
     "@commitlint/test": "^20.4.3",

--- a/@commitlint/prompt/package.json
+++ b/@commitlint/prompt/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://commitlint.js.org/",
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "devDependencies": {
     "@commitlint/config-angular": "^20.5.3",

--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check --skip-import"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/to-lines/package.json
+++ b/@commitlint/to-lines/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/top-level/package.json
+++ b/@commitlint/top-level/package.json
@@ -13,7 +13,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/travis-cli/package.json
+++ b/@commitlint/travis-cli/package.json
@@ -17,7 +17,7 @@
     "pkg": "pkg-check --skip-main"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@commitlint/types/package.json
+++ b/@commitlint/types/package.json
@@ -12,7 +12,7 @@
     "pkg": "pkg-check"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@packages/test-environment/package.json
+++ b/@packages/test-environment/package.json
@@ -10,7 +10,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@packages/test/package.json
+++ b/@packages/test/package.json
@@ -10,7 +10,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/@packages/utils/package.json
+++ b/@packages/utils/package.json
@@ -17,7 +17,7 @@
     "pkg": "node pkg-check.js --skip-main"
   },
   "engines": {
-    "node": ">=v18"
+    "node": ">=v22"
   },
   "repository": {
     "type": "git",

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM docker.io/library/node:18-alpine AS builder
+FROM docker.io/library/node:22-alpine AS builder
 WORKDIR /src
 COPY . ./
 RUN apk add --no-cache python3 py3-setuptools make g++ git
@@ -27,7 +27,7 @@ RUN yarn install --frozen-lockfile --network-timeout 100000 && \
     # Default commitlint config
     npm pack @commitlint/config-conventional
 
-FROM docker.io/library/node:18-alpine
+FROM docker.io/library/node:22-alpine
 RUN apk add --no-cache git
 COPY --from=builder /src/*.tgz ./
 RUN npm config set fetch-retry-mintimeout 20000 && \

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Check the [main website](https://commitlint.js.org/).
 
 ## Version Support and Releases
 
-- Node.js [LTS](https://github.com/nodejs/LTS#lts-schedule) `>= 18`
+- Node.js [LTS](https://github.com/nodejs/LTS#lts-schedule) `>= 22`
 - git `>= 2.13.2`
 
 ### Releases

--- a/docs/guides/ci-setup.md
+++ b/docs/guides/ci-setup.md
@@ -182,7 +182,7 @@ spec:
 Validate commits within a PR by leveraging [BitBucket`s default variables](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/):
 
 ```yml
-image: node:18
+image: node:22
 
 pipelines:
   pull-requests:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@packages/*"
   ],
   "engines": {
-    "node": ">=v18",
+    "node": ">=v22",
     "npm": ">=7"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1857,12 +1857,12 @@
   dependencies:
     undici-types "~7.16.0"
 
-"@types/node@^18.19.17":
-  version "18.19.130"
-  resolved "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz#da4c6324793a79defb7a62cba3947ec5add00d59"
-  integrity sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==
+"@types/node@^22.0.0":
+  version "22.19.15"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz#6091d99fdf7c08cb57dc8b1345d407ba9a1df576"
+  integrity sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~6.21.0"
 
 "@types/normalize-package-data@^2.4.0", "@types/normalize-package-data@^2.4.3":
   version "2.4.4"
@@ -7599,10 +7599,10 @@ uglify-js@^3.1.4:
   resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici-types@~7.16.0:
   version "7.16.0"


### PR DESCRIPTION
  BREAKING CHANGE: drop Node v18 and v20 support

  - Bump engines to >=v22 in all 39 package.json files
  - Update @types/node to ^22.0.0
  - Update CI matrix to Node [22, 24]
  - Update apt-baseline job to use ubuntu:26.04 Docker image
  - Update Dockerfile.ci and .mise.toml to Node 22
  - Update .github/workflows/{CI,docs-deploy}.yml
  - Update pre-commit hook to use --ignore-engines
  - Update README and docs (docs/guides/ci-setup.md)

  Note: the ubuntu-26.04 GitHub Actions runner label is not yet
  generally available in actions/runner-images. Adding it to the OS
  matrix will be a follow-up PR once the runner ships. Ubuntu 26
  compatibility is still exercised via the Docker-based apt-baseline
  job (image: ubuntu:26.04).