### PR TITLE
 fix: widen cz-commitlint inquirer peer dep to support v9–v12

### DIFF
--- a/@commitlint/cz-commitlint/package.json
+++ b/@commitlint/cz-commitlint/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "commitizen": "^4.0.3",
-    "inquirer": "^9.0.0"
+    "inquirer": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.7",


### PR DESCRIPTION


  Closes #4554. Supersedes #4672.

  `@commitlint/cz-commitlint`'s `inquirer` peerDependency was pinned to
  `^9.0.0`, blocking users from picking up newer `inquirer` majors. This
  widens the range to `^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0` so users
  can choose any of v9–v12.

  ## Why not v13

  Inquirer v13 [removed the `list` prompt type][v13-changelog], which
  `cz-commitlint` relies on for scope selection. Adopting v13 would
  require a non-trivial refactor of the prompt flow, so it's deliberately
  excluded from the peer range.

  [v13-changelog]: https://github.com/SBoudrias/Inquirer.js/releases

  ## Changes

  - **`@commitlint/cz-commitlint/package.json`** — peerDependency
    `"inquirer": "^9.0.0"` → `"^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"`.

  ## Notes

  - `@types/inquirer ^9.0.7` is kept as a devDep — only used by the repo's
    own TypeScript build, not shipped to consumers. Inquirer v10+ ships
    its own types, so users on those versions resolve types from their
    installed inquirer package directly.