### PR TITLE
  chore: remove cross-env, move env vars to vitest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "publish": "npm whoami && lerna publish --conventional-commits",
     "reinstall": "yarn clean && yarn install",
     "start": "yarn watch",
-    "test": "cross-env HOME=$PWD LANG=en_US.UTF-8 NO_COLOR=1 vitest run --coverage",
+    "test": "vitest run --coverage",
     "prepare": "husky"
   },
   "commitlint": {
@@ -89,7 +89,6 @@
     "@typescript-eslint/parser": "^8.56.1",
     "@vitest/coverage-istanbul": "~4.0.18",
     "@vitest/eslint-plugin": "^1.3.4",
-    "cross-env": "^7.0.3",
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.0.0",
     "eslint-import-resolver-typescript": "^4.4.3",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
 		typecheck: {
 			enabled: true,
 		},
+		env: {
+			HOME: process.cwd(),
+			LANG: "en_US.UTF-8",
+			NO_COLOR: "1",
+		},
 		exclude: ["**/node_modules/**", "**/lib/*.test.js"],
 		environment: "commitlint",
 		coverage: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3382,14 +3382,7 @@ cosmiconfig@^9.0.1:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
 
-cross-env@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
-  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
-  dependencies:
-    cross-spawn "^7.0.1"
-
-cross-spawn@^7.0.1, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
+cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==


### PR DESCRIPTION



  `cross-env` was archived by Kent C. Dodds in November 2025, and the
  project recommends migrating to native solutions where possible. This
  repo only used it in one place — the root `test` script — to set
  `HOME`, `LANG`, and `NO_COLOR` for the vitest run.

  ## Changes

  - **`package.json`**
    - Remove `cross-env ^7.0.3` from `devDependencies`.
    - Simplify `test` script: `cross-env HOME=$PWD LANG=en_US.UTF-8 NO_COLOR=1 vitest run --coverage` → `vitest run --coverage`.
  - **`vitest.config.ts`**
    - Add `test.env: { HOME: process.cwd(), LANG: "en_US.UTF-8", NO_COLOR: "1" }`.
  - **`yarn.lock`**
    - Pruned (cross-env and unused transitive entries).

  ## Equivalence

  Vitest's `test.env` injects values into `process.env` for the test
  run, matching the previous behaviour:

  | Var | Before (`cross-env`) | After (`vitest env`) |
  |---|---|---|
  | `HOME` | `$PWD` (shell-evaluated at run time) | `process.cwd()` (resolved at config load) |
  | `LANG` | `en_US.UTF-8` | `en_US.UTF-8` |
  | `NO_COLOR` | `1` | `"1"` |

  `HOME` is the only nuance: `$PWD` and `process.cwd()` resolve to the
  same value when `yarn test` is invoked from the repo root (as it
  always is in CI and the only documented workflow), so behaviour is
  unchanged.

