### PR TITLE
feat!: show input from a new line

### DIFF
--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -644,6 +644,7 @@ test("should print help", async () => {
 		  -q, --quiet          toggle console output  [boolean] [default: false]
 		  -t, --to             upper end of the commit range to lint; applies if edit=false  [string]
 		  -V, --verbose        enable verbose output for reports without problems  [boolean]
+		      --legacy-output  use the legacy input output format (single-line 'input: ...')  [boolean]
 		  -s, --strict         enable strict mode; result code 2 for warnings, 3 for errors  [boolean]
 		      --options        path to a JSON file or Common.js module containing CLI options
 		  -v, --version        display version information  [boolean]

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -136,7 +136,8 @@ const cli = yargs(process.argv.slice(2))
 			description: "enable verbose output for reports without problems",
 		},
 		"legacy-output": {
-			description: "use the legacy input output format (single-line 'input: ...')",
+			description:
+				"use the legacy input output format (single-line 'input: ...')",
 			type: "boolean",
 		},
 		strict: {

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -135,6 +135,10 @@ const cli = yargs(process.argv.slice(2))
 			type: "boolean",
 			description: "enable verbose output for reports without problems",
 		},
+		"legacy-output": {
+			description: "use the legacy input output format (single-line 'input: ...')",
+			type: "boolean",
+		},
 		strict: {
 			alias: "s",
 			type: "boolean",
@@ -398,6 +402,7 @@ async function main(args: MainArgs): Promise<void> {
 		color: flags.color,
 		verbose: flags.verbose,
 		helpUrl,
+		legacyOutput: flags["legacy-output"],
 	});
 
 	if (!flags.quiet && output !== "") {

--- a/@commitlint/cli/src/types.ts
+++ b/@commitlint/cli/src/types.ts
@@ -20,6 +20,7 @@ export interface CliFlags {
 	/** @type {'' | 'text' | 'json'} */
 	"print-config"?: string;
 	strict?: boolean;
+	"legacy-output"?: boolean;
 	_: (string | number)[];
 	$0: string;
 }

--- a/@commitlint/config-lerna-scopes/readme.md
+++ b/@commitlint/config-lerna-scopes/readme.md
@@ -31,16 +31,19 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   input: build(api): change something in api's build
+⧗   --- input ---
+build(api): change something in api's build
 ✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
-⧗   input: test(foo): this won't pass
+⧗   --- input ---
+test(foo): this won't pass
 ✖   scope must be one of [api, app, web] [scope-enum]
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   input: ci: do some general maintenance
+⧗   --- input ---
+ci: do some general maintenance
 ✔   found 0 problems, 0 warnings
 ```
 

--- a/@commitlint/config-lerna-scopes/readme.md
+++ b/@commitlint/config-lerna-scopes/readme.md
@@ -31,9 +31,6 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   --- input ---
-build(api): change something in api's build
-✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
 ⧗   --- input ---
@@ -42,9 +39,6 @@ test(foo): this won't pass
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   --- input ---
-ci: do some general maintenance
-✔   found 0 problems, 0 warnings
 ```
 
 Consult [Rules reference](https://commitlint.js.org/reference/rules) for a list of available rules.

--- a/@commitlint/config-nx-scopes/readme.md
+++ b/@commitlint/config-nx-scopes/readme.md
@@ -97,16 +97,19 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   input: build(api): change something in api's build
+⧗   --- input ---
+build(api): change something in api's build
 ✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
-⧗   input: test(foo): this won't pass
+⧗   --- input ---
+test(foo): this won't pass
 ✖   scope must be one of [api, app, web] [scope-enum]
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   input: ci: do some general maintenance
+⧗   --- input ---
+ci: do some general maintenance
 ✔   found 0 problems, 0 warnings
 ```
 

--- a/@commitlint/config-nx-scopes/readme.md
+++ b/@commitlint/config-nx-scopes/readme.md
@@ -97,9 +97,6 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   --- input ---
-build(api): change something in api's build
-✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
 ⧗   --- input ---
@@ -108,9 +105,6 @@ test(foo): this won't pass
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   --- input ---
-ci: do some general maintenance
-✔   found 0 problems, 0 warnings
 ```
 
 Consult [Rules reference](https://commitlint.js.org/reference/rules) for a list of available rules.

--- a/@commitlint/config-pnpm-scopes/readme.md
+++ b/@commitlint/config-pnpm-scopes/readme.md
@@ -28,16 +28,19 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   input: build(api): change something in api's build
+⧗   --- input ---
+build(api): change something in api's build
 ✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
-⧗   input: test(foo): this won't pass
+⧗   --- input ---
+test(foo): this won't pass
 ✖   scope must be one of [api, app, web] [scope-enum]
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   input: ci: do some general maintenance
+⧗   --- input ---
+ci: do some general maintenance
 ✔   found 0 problems, 0 warnings
 ```
 

--- a/@commitlint/config-pnpm-scopes/readme.md
+++ b/@commitlint/config-pnpm-scopes/readme.md
@@ -28,9 +28,6 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   --- input ---
-build(api): change something in api's build
-✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
 ⧗   --- input ---
@@ -39,9 +36,6 @@ test(foo): this won't pass
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   --- input ---
-ci: do some general maintenance
-✔   found 0 problems, 0 warnings
 ```
 
 Consult [Rules reference](https://commitlint.js.org/reference/rules) for a list of available rules.

--- a/@commitlint/config-rush-scopes/readme.md
+++ b/@commitlint/config-rush-scopes/readme.md
@@ -28,16 +28,19 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   input: build(api): change something in api's build
+⧗   --- input ---
+build(api): change something in api's build
 ✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
-⧗   input: test(foo): this won't pass
+⧗   --- input ---
+test(foo): this won't pass
 ✖   scope must be one of [api, app, web] [scope-enum]
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   input: ci: do some general maintenance
+⧗   --- input ---
+ci: do some general maintenance
 ✔   found 0 problems, 0 warnings
 ```
 

--- a/@commitlint/config-rush-scopes/readme.md
+++ b/@commitlint/config-rush-scopes/readme.md
@@ -28,9 +28,6 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   --- input ---
-build(api): change something in api's build
-✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
 ⧗   --- input ---
@@ -39,9 +36,6 @@ test(foo): this won't pass
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   --- input ---
-ci: do some general maintenance
-✔   found 0 problems, 0 warnings
 ```
 
 Consult [Rules reference](https://commitlint.js.org/reference/rules) for a list of available rules.

--- a/@commitlint/config-workspace-scopes/readme.md
+++ b/@commitlint/config-workspace-scopes/readme.md
@@ -31,16 +31,19 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   input: build(api): change something in api's build
+⧗   --- input ---
+build(api): change something in api's build
 ✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
-⧗   input: test(foo): this won't pass
+⧗   --- input ---
+test(foo): this won't pass
 ✖   scope must be one of [api, app, web] [scope-enum]
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   input: ci: do some general maintenance
+⧗   --- input ---
+ci: do some general maintenance
 ✔   found 0 problems, 0 warnings
 ```
 

--- a/@commitlint/config-workspace-scopes/readme.md
+++ b/@commitlint/config-workspace-scopes/readme.md
@@ -31,9 +31,6 @@ packages
 └── web
 
 ❯ echo "build(api): change something in api's build" | commitlint
-⧗   --- input ---
-build(api): change something in api's build
-✔   found 0 problems, 0 warnings
 
 ❯ echo "test(foo): this won't pass" | commitlint
 ⧗   --- input ---
@@ -42,9 +39,6 @@ test(foo): this won't pass
 ✖   found 1 problems, 0 warnings
 
 ❯ echo "ci: do some general maintenance" | commitlint
-⧗   --- input ---
-ci: do some general maintenance
-✔   found 0 problems, 0 warnings
 ```
 
 Consult [Rules reference](https://commitlint.js.org/reference/rules) for a list of available rules.

--- a/@commitlint/format/src/format.test.ts
+++ b/@commitlint/format/src/format.test.ts
@@ -58,6 +58,34 @@ test("returns empty summary with full commit message if verbose", () => {
 	);
 });
 
+test('returns input banner with errors and multi-line input', () => {
+	const actual = format(
+		{
+			results: [
+				{
+					errors: [
+						{
+							level: 2,
+							name: 'type-enum',
+							message:
+								'type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]',
+						},
+					],
+					warnings: [],
+					input: 'foo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester',
+				},
+			],
+		},
+		{
+			color: false,
+		}
+	);
+
+	expect(actual).toStrictEqual(
+		'⧗   --- input ---\nfoo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester\n✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]\n\n✖   found 1 problems, 0 warnings'
+	);
+});
+
 test("returns a correct summary of empty .errors and .warnings", () => {
 	const actualError = format({
 		results: [

--- a/@commitlint/format/src/format.test.ts
+++ b/@commitlint/format/src/format.test.ts
@@ -82,7 +82,7 @@ test("returns legacy output with full commit message if verbose and legacyOutput
 	);
 });
 
-test('returns input banner with errors and multi-line input', () => {
+test("returns input banner with errors and multi-line input", () => {
 	const actual = format(
 		{
 			results: [
@@ -90,27 +90,28 @@ test('returns input banner with errors and multi-line input', () => {
 					errors: [
 						{
 							level: 2,
-							name: 'type-enum',
+							name: "type-enum",
 							message:
-								'type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]',
+								"type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]",
 						},
 					],
 					warnings: [],
-					input: 'foo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester',
+					input:
+						"foo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester",
 				},
 			],
 		},
 		{
 			color: false,
-		}
+		},
 	);
 
 	expect(actual).toStrictEqual(
-		'⧗   --- input ---\nfoo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester\n✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]\n\n✖   found 1 problems, 0 warnings'
+		"⧗   --- input ---\nfoo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester\n✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]\n\n✖   found 1 problems, 0 warnings\n",
 	);
 });
 
-test('returns legacy input banner with errors and multi-line input', () => {
+test("returns legacy input banner with errors and multi-line input", () => {
 	const actual = format(
 		{
 			results: [
@@ -118,24 +119,25 @@ test('returns legacy input banner with errors and multi-line input', () => {
 					errors: [
 						{
 							level: 2,
-							name: 'type-enum',
+							name: "type-enum",
 							message:
-								'type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]',
+								"type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]",
 						},
 					],
 					warnings: [],
-					input: 'foo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester',
+					input:
+						"foo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester",
 				},
 			],
 		},
 		{
 			color: false,
 			legacyOutput: true,
-		}
+		},
 	);
 
 	expect(actual).toStrictEqual(
-		'⧗   input: foo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester\n✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]\n\n✖   found 1 problems, 0 warnings'
+		"⧗   input: foo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester\n✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]\n\n✖   found 1 problems, 0 warnings\n",
 	);
 });
 

--- a/@commitlint/format/src/format.test.ts
+++ b/@commitlint/format/src/format.test.ts
@@ -54,7 +54,31 @@ test("returns empty summary with full commit message if verbose", () => {
 	);
 
 	expect(actual).toStrictEqual(
-		"⧗  ---  inptu ---\n feat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester\n✔   found 0 problems, 0 warnings",
+		"⧗   --- input ---\nfeat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester\n✔   found 0 problems, 0 warnings",
+	);
+});
+
+test("returns legacy output with full commit message if verbose and legacyOutput", () => {
+	const actual = format(
+		{
+			results: [
+				{
+					errors: [],
+					warnings: [],
+					input:
+						"feat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester",
+				},
+			],
+		},
+		{
+			verbose: true,
+			color: false,
+			legacyOutput: true,
+		},
+	);
+
+	expect(actual).toStrictEqual(
+		"⧗   input: feat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester\n✔   found 0 problems, 0 warnings",
 	);
 });
 
@@ -83,6 +107,35 @@ test('returns input banner with errors and multi-line input', () => {
 
 	expect(actual).toStrictEqual(
 		'⧗   --- input ---\nfoo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester\n✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]\n\n✖   found 1 problems, 0 warnings'
+	);
+});
+
+test('returns legacy input banner with errors and multi-line input', () => {
+	const actual = format(
+		{
+			results: [
+				{
+					errors: [
+						{
+							level: 2,
+							name: 'type-enum',
+							message:
+								'type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]',
+						},
+					],
+					warnings: [],
+					input: 'foo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester',
+				},
+			],
+		},
+		{
+			color: false,
+			legacyOutput: true,
+		}
+	);
+
+	expect(actual).toStrictEqual(
+		'⧗   input: foo: this is an invalid header\n\nThis is a body\n\nSigned-off-by: tester\n✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]\n\n✖   found 1 problems, 0 warnings'
 	);
 });
 

--- a/@commitlint/format/src/format.test.ts
+++ b/@commitlint/format/src/format.test.ts
@@ -54,7 +54,7 @@ test("returns empty summary with full commit message if verbose", () => {
 	);
 
 	expect(actual).toStrictEqual(
-		"⧗   input: feat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester\n✔   found 0 problems, 0 warnings",
+		"⧗  ---  inptu ---\n feat(cli): this is a valid header\n\nThis is a valid body\n\nSigned-off-by: tester\n✔   found 0 problems, 0 warnings",
 	);
 });
 

--- a/@commitlint/format/src/format.ts
+++ b/@commitlint/format/src/format.ts
@@ -37,7 +37,7 @@ function formatInput(
 	result: FormattableResult & WithInput,
 	options: FormatOptions = {},
 ): string[] {
-	const { color: enabled = true } = options;
+	const { color: enabled = true, legacyOutput = false } = options;
 	const { errors = [], warnings = [], input = "" } = result;
 
 	if (!input) {
@@ -50,9 +50,16 @@ function formatInput(
 	const decoratedInput = enabled ? pc.bold(input) : input;
 	const hasProblems = errors.length > 0 || warnings.length > 0;
 
-	return options.verbose || hasProblems
-		? [`${decoration}   --- input ---\n${decoratedInput}`]
-		: [];
+	if (!(options.verbose || hasProblems)) {
+		return [];
+	}
+
+	if (legacyOutput) {
+		// legacy: single line with 'input: ' prefix, no extra newlines or dashes
+		return [`${decoration}   input: ${decoratedInput}`];
+	}
+
+	return [`${decoration}   --- input ---\n${decoratedInput}`];
 }
 
 export function formatResult(

--- a/@commitlint/format/src/format.ts
+++ b/@commitlint/format/src/format.ts
@@ -51,7 +51,7 @@ function formatInput(
 	const hasProblems = errors.length > 0 || warnings.length > 0;
 
 	return options.verbose || hasProblems
-		? [`${decoration}   input: ${decoratedInput}`]
+		? [`${decoration}   --- input ---\n${decoratedInput}`]
 		: [];
 }
 

--- a/@commitlint/types/src/format.ts
+++ b/@commitlint/types/src/format.ts
@@ -41,4 +41,5 @@ export interface FormatOptions {
 	colors?: readonly [PicocolorsColor, PicocolorsColor, PicocolorsColor];
 	verbose?: boolean;
 	helpUrl?: string;
+	legacyOutput?: boolean;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [22.0.0](https://github.com/conventional-changelog/commitlint/compare/v20.5.2...v22.0.0) (2026-04-30)
+
+### BREAKING CHANGES
+
+* When using commitlint in --verbose mode, commit message will be shown after a new line (EOL), instead of after a colon like in older versions. To restore the old behaviour, use the flag `--legacy-output`.
+
+
 ## [20.5.2](https://github.com/conventional-changelog/commitlint/compare/v20.5.1...v20.5.2) (2026-04-25)
 
 

--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -291,4 +291,7 @@ No staged files match any of provided globs.
 # husky > commit-msg
 ```
 
+Since [v22.0.0](https://github.com/conventional-changelog/commitlint/releases/tag/v22.0.0) `commitlint` will output the commit message after a new line (EOL) instead of after a colon.\
+(You can use the `--legacy-output` flag to get the previous output format used in older versions)
+
 Local linting is fine for fast feedback but can easily be tinkered with. To ensure all commits are linted you'll want to check commits on an automated CI Server too. Learn how to in the [CI Setup guide](/guides/ci-setup).

--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -271,7 +271,8 @@ You can test the hook by simply committing. You should see something like this i
 git commit -m "foo: this will fail"
 #  husky > commit-msg
 No staged files match any of provided globs.
-⧗   input: foo: this will fail
+⧗   --- input ---
+foo: this will fail
 ✖   type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test] [type-enum]
 
 ✖   found 1 problems, 0 warnings

--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -291,7 +291,7 @@ No staged files match any of provided globs.
 # husky > commit-msg
 ```
 
-Since [v22.0.0](https://github.com/conventional-changelog/commitlint/releases/tag/v22.0.0) `commitlint` will output the commit message after a new line (EOL) instead of after a colon.\
+Since [v21.0.0](https://github.com/conventional-changelog/commitlint/releases/tag/v21.0.0) `commitlint` will output the commit message after a new line (EOL) instead of after a colon.\
 (You can use the `--legacy-output` flag to get the previous output format used in older versions)
 
 Local linting is fine for fast feedback but can easily be tinkered with. To ensure all commits are linted you'll want to check commits on an automated CI Server too. Learn how to in the [CI Setup guide](/guides/ci-setup).


### PR DESCRIPTION
Supersedes https://github.com/conventional-changelog/commitlint/pull/4102

This will be less confusing to read, and also easier to test and copy/paste (for example for #4101).

This error log is confusing for people not familiar with `commitlint`.
```
⧗   input: fix: ingest - do not double strip /doc/ prefix
It is already stripped here
https://gitlab.com/gitlab-community/modelops/applied-ml/code-suggestions/ai-assist/-/blob/22bb9cf2b996dc2ec347bad761abb12fd11bcf75/scripts/ingest/gitlab-docs/steps/parse.rb#L16
✖   body's lines must not be longer than 100 characters [body-max-line-length]
✖   found 1 warnings
```

This one should be more clear.

```
⧗   --- input ---
fix: ingest - do not double strip /doc/ prefix

It is already stripped here
https://gitlab.com/gitlab-community/modelops/applied-ml/code-suggestions/ai-assist/-/blob/22bb9cf2b996dc2ec347bad761abb12fd11bcf75/scripts/ingest/gitlab-docs/steps/parse.rb#L16
✖   body's lines must not be longer than 100 characters [body-max-line-length]
✖   found 1 warnings
```

Or maybe even this one.

```
⧗   commit message:
fix: ingest - do not double strip /doc/ prefix

It is already stripped here
https://gitlab.com/gitlab-community/modelops/applied-ml/code-suggestions/ai-assist/-/blob/22bb9cf2b996dc2ec347bad761abb12fd11bcf75/scripts/ingest/gitlab-docs/steps/parse.rb#L16
✖   body's lines must not be longer than 100 characters [body-max-line-length]
✖   found 1 warnings
```

## Motivation and Context

Error output should not mess up original commit message, because it is hard to understand what is wrong. 

## Usage examples

<!--- Provide examples of intended usage -->

```js
// commitlint.config.js
module.exports = {};
```

```sh
echo "your commit message here" | commitlint # fails/passes
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
