### PR TITLE
docs: use nodejs commands for creating files on Windows (#4728)

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -32,16 +32,26 @@ deno add -D npm:@commitlint/cli npm:@commitlint/config-conventional
 
 Configure commitlint to use conventional config
 
+<!--
+**Note:**
+
+Command `echo "xxxx" > file` on Windows PowerShell v5 will create
+an UTF-16 LE file, which may cause execution failure.
+https://github.com/typicode/husky/issues/1426
+
+Here we use the `node -e` command create the UTF-8 file and hex encode
+the single-quote to `\x27` to avoid delimiter issues on various shells.
+-->
+
 ```sh
-echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
+node -e "fs.writeFileSync('commitlint.config.js','export default { extends: [\x27@commitlint/config-conventional\x27] };\n')"
 ```
 
-> [!NOTE]
-> **Windows users:** The `echo` command in PowerShell and `cmd.exe` may create the config file with a non-UTF-8 encoding (e.g. UTF-16LE or the system's default ANSI code page), which can cause commitlint to fail to read the configuration. To avoid this, create `commitlint.config.js` manually in your editor, or use PowerShell with explicit encoding:
->
-> ```powershell
-> "export default { extends: ['@commitlint/config-conventional'] };" | Out-File -Encoding utf8 commitlint.config.js
-> ```
+This command will create `commitlint.config.js` with the following content:
+
+```text
+export default { extends: ['@commitlint/config-conventional'] };
+```
 
 > [!WARNING]
 > Node v24 changes the way that modules are loaded, and this includes the commitlint config file. If your project does not contain a `package.json`, commitlint may fail to load the config, resulting in a `Please add rules to your commitlint.config.js` error message. This can be fixed by doing either of the following:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -32,26 +32,18 @@ deno add -D npm:@commitlint/cli npm:@commitlint/config-conventional
 
 Configure commitlint to use conventional config
 
-<!--
-**Note:**
+::: code-group
 
-Command `echo "xxxx" > file` on Windows PowerShell v5 will create
-an UTF-16 LE file, which may cause execution failure.
-https://github.com/typicode/husky/issues/1426
-
-Here we use the `node -e` command create the UTF-8 file and hex encode
-the single-quote to `\x27` to avoid delimiter issues on various shells.
--->
-
-```sh
-node -e "fs.writeFileSync('commitlint.config.js','export default { extends: [\x27@commitlint/config-conventional\x27] };\n')"
+```sh [Linux / macOS]
+echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
 ```
 
-This command will create `commitlint.config.js` with the following content:
-
-```text
-export default { extends: ['@commitlint/config-conventional'] };
+```sh [Windows]
+# Here we use the node command to avoid encoding issue on Windows.
+node -e "fs.writeFileSync('commitlint.config.js', process.argv[1])" "export default { extends: ['@commitlint/config-conventional'] };"
 ```
+
+:::
 
 > [!WARNING]
 > Node v24 changes the way that modules are loaded, and this includes the commitlint config file. If your project does not contain a `package.json`, commitlint may fail to load the config, resulting in a `Please add rules to your commitlint.config.js` error message. This can be fixed by doing either of the following:

--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -20,10 +20,18 @@ You can find complete setup instructions on the [official documentation](https:/
 > The following instructions are meant to `husky@v9` if you are using a different version
 > consult the official documentation of your version.
 
-> [!WARNING]
-> For Windows users: ensure all `husky` files are `UTF-8` enconded. If any other format is used an error may be thrown at runtime such as [cannot execute binary file](https://github.com/typicode/husky/issues/1426).
-
 ---
+
+<!--
+**Note:**
+
+Command `echo "xxxx" > file` on Windows PowerShell v5 will create
+an UTF-16 LE file, which may cause execution failure.
+https://github.com/typicode/husky/issues/1426
+
+So here we use the `node -e` command create the UTF-8 file. And hex encode the dollar sign
+to `\x24` in single-quote string to avoid escaping issues on various shells. (issue#4728)
+-->
 
 :::tabs
 == npm
@@ -37,16 +45,14 @@ npx husky init
 npx husky install
 
 # Add commit message linting to commit-msg hook
-echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
-# Windows PowerShell users should use ` to escape dollar signs
-echo "npx --no -- commitlint --edit `$1" > .husky/commit-msg
+node -e "fs.writeFileSync('.husky/commit-msg','npx --no -- commitlint --edit \x241\n')"
 ```
 
 As an alternative you can create a script inside `package.json`
 
 ```sh
 npm pkg set scripts.commitlint="commitlint --edit"
-echo "npm run commitlint \${1}" > .husky/commit-msg
+node -e "fs.writeFileSync('.husky/commit-msg','npm run commitlint \x24{1}\n')"
 ```
 
 == yarn
@@ -60,16 +66,14 @@ yarn husky init
 yarn husky install
 
 # Add commit message linting to commit-msg hook
-echo "yarn commitlint --edit \$1" > .husky/commit-msg
-# Windows PowerShell users should use ` to escape dollar signs
-echo "yarn commitlint --edit `$1" > .husky/commit-msg
+node -e "fs.writeFileSync('.husky/commit-msg','yarn commitlint --edit \x241\n')"
 ```
 
 As an alternative you can create a script inside `package.json`
 
 ```sh
 npm pkg set scripts.commitlint="commitlint --edit"
-echo "yarn commitlint \${1}" > .husky/commit-msg
+node -e "fs.writeFileSync('.husky/commit-msg','yarn commitlint \x24{1}\n')"
 ```
 
 > [!WARNING]
@@ -86,16 +90,14 @@ pnpm husky init
 pnpm husky install
 
 # Add commit message linting to commit-msg hook
-echo "pnpm dlx commitlint --edit \$1" > .husky/commit-msg
-# Windows PowerShell users should use ` to escape dollar signs
-echo "pnpm dlx commitlint --edit `$1" > .husky/commit-msg
+node -e "fs.writeFileSync('.husky/commit-msg','pnpm dlx commitlint --edit \x241\n')"
 ```
 
 As an alternative you can create a script inside `package.json`
 
 ```sh
 npm pkg set scripts.commitlint="commitlint --edit"
-echo "pnpm commitlint \${1}" > .husky/commit-msg
+node -e "fs.writeFileSync('.husky/commit-msg','pnpm commitlint \x24{1}\n')"
 ```
 
 == bun
@@ -109,9 +111,7 @@ bunx husky init
 bunx husky install
 
 # Add commit message linting to commit-msg hook
-echo "bunx commitlint --edit \$1" > .husky/commit-msg
-# Windows PowerShell users should use ` to escape dollar signs
-echo "bunx commitlint --edit `$1" > .husky/commit-msg
+node -e "fs.writeFileSync('.husky/commit-msg','bunx commitlint --edit \x241\n')"
 ```
 
 == deno
@@ -125,9 +125,7 @@ deno task --eval husky init
 deno task --eval husky install
 
 # Add commit message linting to commit-msg hook
-echo "deno task --eval commitlint --edit \$1" > .husky/commit-msg
-# Windows PowerShell users should use ` to escape dollar signs
-echo "deno task --eval commitlint --edit `$1" > .husky/commit-msg
+node -e "fs.writeFileSync('.husky/commit-msg','deno task --eval commitlint --edit \x241\n')"
 ```
 
 :::

--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -22,16 +22,8 @@ You can find complete setup instructions on the [official documentation](https:/
 
 ---
 
-<!--
-**Note:**
-
-Command `echo "xxxx" > file` on Windows PowerShell v5 will create
-an UTF-16 LE file, which may cause execution failure.
-https://github.com/typicode/husky/issues/1426
-
-So here we use the `node -e` command create the UTF-8 file. And hex encode the dollar sign
-to `\x24` in single-quote string to avoid escaping issues on various shells. (issue#4728)
--->
+::::tabs
+=== Linux / macOS
 
 :::tabs
 == npm
@@ -45,14 +37,14 @@ npx husky init
 npx husky install
 
 # Add commit message linting to commit-msg hook
-node -e "fs.writeFileSync('.husky/commit-msg','npx --no -- commitlint --edit \x241\n')"
+echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`
 
 ```sh
 npm pkg set scripts.commitlint="commitlint --edit"
-node -e "fs.writeFileSync('.husky/commit-msg','npm run commitlint \x24{1}\n')"
+echo "npm run commitlint \${1}" > .husky/commit-msg
 ```
 
 == yarn
@@ -66,14 +58,14 @@ yarn husky init
 yarn husky install
 
 # Add commit message linting to commit-msg hook
-node -e "fs.writeFileSync('.husky/commit-msg','yarn commitlint --edit \x241\n')"
+echo "yarn commitlint --edit \$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`
 
 ```sh
 npm pkg set scripts.commitlint="commitlint --edit"
-node -e "fs.writeFileSync('.husky/commit-msg','yarn commitlint \x24{1}\n')"
+echo "yarn commitlint \${1}" > .husky/commit-msg
 ```
 
 > [!WARNING]
@@ -90,14 +82,14 @@ pnpm husky init
 pnpm husky install
 
 # Add commit message linting to commit-msg hook
-node -e "fs.writeFileSync('.husky/commit-msg','pnpm dlx commitlint --edit \x241\n')"
+echo "pnpm dlx commitlint --edit \$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`
 
 ```sh
 npm pkg set scripts.commitlint="commitlint --edit"
-node -e "fs.writeFileSync('.husky/commit-msg','pnpm commitlint \x24{1}\n')"
+echo "pnpm commitlint \${1}" > .husky/commit-msg
 ```
 
 == bun
@@ -111,7 +103,7 @@ bunx husky init
 bunx husky install
 
 # Add commit message linting to commit-msg hook
-node -e "fs.writeFileSync('.husky/commit-msg','bunx commitlint --edit \x241\n')"
+echo "bunx commitlint --edit \$1" > .husky/commit-msg
 ```
 
 == deno
@@ -125,10 +117,110 @@ deno task --eval husky init
 deno task --eval husky install
 
 # Add commit message linting to commit-msg hook
-node -e "fs.writeFileSync('.husky/commit-msg','deno task --eval commitlint --edit \x241\n')"
+echo "deno task --eval commitlint --edit \$1" > .husky/commit-msg
 ```
 
 :::
+
+=== Windows
+
+:::tabs
+== npm
+
+```sh
+npm install --save-dev husky
+
+# husky@v9
+npx husky init
+# husky@v8 or lower
+npx husky install
+
+# Add commit message linting to commit-msg hook
+node -e "fs.writeFileSync('.husky/commit-msg', 'npx --no -- commitlint --edit $'+'1\n')"
+```
+
+As an alternative you can create a script inside `package.json`
+
+```sh
+npm pkg set scripts.commitlint="commitlint --edit"
+node -e "fs.writeFileSync('.husky/commit-msg', 'npm run commitlint $'+'{1}\n')"
+```
+
+== yarn
+
+```sh
+yarn add --dev husky
+
+# husky@v9
+yarn husky init
+# husky@v8 or lower
+yarn husky install
+
+# Add commit message linting to commit-msg hook
+node -e "fs.writeFileSync('.husky/commit-msg', 'yarn commitlint --edit $'+'1\n')"
+```
+
+As an alternative you can create a script inside `package.json`
+
+```sh
+npm pkg set scripts.commitlint="commitlint --edit"
+node -e "fs.writeFileSync('.husky/commit-msg', 'yarn commitlint $'+'{1}\n')"
+```
+
+> [!WARNING]
+> Please note that currently @commitlint/cli doesn't support yarn v2 Plug'n'Play (using yarn > v2 with `nodeLinker: node-modules` in your .yarnrc.yml file may work sometimes)
+
+== pnpm
+
+```sh
+pnpm add --save-dev husky
+
+# husky@v9
+pnpm husky init
+# husky@v8 or lower
+pnpm husky install
+
+# Add commit message linting to commit-msg hook
+node -e "fs.writeFileSync('.husky/commit-msg', 'pnpm dlx commitlint --edit $'+'1\n')"
+```
+
+As an alternative you can create a script inside `package.json`
+
+```sh
+npm pkg set scripts.commitlint="commitlint --edit"
+node -e "fs.writeFileSync('.husky/commit-msg', 'pnpm commitlint $'+'{1}\n')"
+```
+
+== bun
+
+```sh
+bun add --dev husky
+
+# husky@v9
+bunx husky init
+# husky@v8 or lower
+bunx husky install
+
+# Add commit message linting to commit-msg hook
+node -e "fs.writeFileSync('.husky/commit-msg', 'bunx commitlint --edit $'+'1\n')"
+```
+
+== deno
+
+```sh
+deno add --dev husky
+
+# husky@v9
+deno task --eval husky init
+# husky@v8 or lower
+deno task --eval husky install
+
+# Add commit message linting to commit-msg hook
+node -e "fs.writeFileSync('.husky/commit-msg', 'deno task --eval commitlint --edit $'+'1\n')"
+```
+
+:::
+::::
 
 ---
 

--- a/docs/guides/local-setup.md
+++ b/docs/guides/local-setup.md
@@ -38,8 +38,8 @@ npx husky install
 
 # Add commit message linting to commit-msg hook
 echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
-# Windows users should use ` to escape dollar signs
-echo "npx --no -- commitlint --edit `$1`" > .husky/commit-msg
+# Windows PowerShell users should use ` to escape dollar signs
+echo "npx --no -- commitlint --edit `$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`
@@ -61,8 +61,8 @@ yarn husky install
 
 # Add commit message linting to commit-msg hook
 echo "yarn commitlint --edit \$1" > .husky/commit-msg
-# Windows users should use ` to escape dollar signs
-echo "yarn commitlint --edit `$1`" > .husky/commit-msg
+# Windows PowerShell users should use ` to escape dollar signs
+echo "yarn commitlint --edit `$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`
@@ -87,8 +87,8 @@ pnpm husky install
 
 # Add commit message linting to commit-msg hook
 echo "pnpm dlx commitlint --edit \$1" > .husky/commit-msg
-# Windows users should use ` to escape dollar signs
-echo "pnpm dlx commitlint --edit `$1`" > .husky/commit-msg
+# Windows PowerShell users should use ` to escape dollar signs
+echo "pnpm dlx commitlint --edit `$1" > .husky/commit-msg
 ```
 
 As an alternative you can create a script inside `package.json`
@@ -110,8 +110,8 @@ bunx husky install
 
 # Add commit message linting to commit-msg hook
 echo "bunx commitlint --edit \$1" > .husky/commit-msg
-# Windows users should use ` to escape dollar signs
-echo "bunx commitlint --edit `$1`" > .husky/commit-msg
+# Windows PowerShell users should use ` to escape dollar signs
+echo "bunx commitlint --edit `$1" > .husky/commit-msg
 ```
 
 == deno
@@ -126,8 +126,8 @@ deno task --eval husky install
 
 # Add commit message linting to commit-msg hook
 echo "deno task --eval commitlint --edit \$1" > .husky/commit-msg
-# Windows users should use ` to escape dollar signs
-echo "deno task --eval commitlint --edit `$1`" > .husky/commit-msg
+# Windows PowerShell users should use ` to escape dollar signs
+echo "deno task --eval commitlint --edit `$1" > .husky/commit-msg
 ```
 
 :::


### PR DESCRIPTION
## Description

**This PR updates the doc to use node.js commands for creating files on Windows. And makes a clear distinction for the setup guide between Linux/macOS and Windows.**

**It brings some benefits:**
- Fixes the broken windows command. Resolve #4728
- Supports windows CMD.
- Avoids UTF-8 issues in PowerShell. Such as #788 and https://github.com/typicode/husky/issues/1426
- Avoids escape character problem across different shells.

**Windows commands before and after:**
```sh
# before
echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js

# after
node -e "fs.writeFileSync('commitlint.config.js', process.argv[1])" "export default { extends: ['@commitlint/config-conventional'] };"
```

```sh
# before
echo "pnpm dlx commitlint --edit `$1" > .husky/commit-msg

# after
node -e "fs.writeFileSync('.husky/commit-msg', 'pnpm dlx commitlint --edit $'+'1\n')"
```

## Motivation and Context

The original doc specifically pointed out encoding issues on Windows, and instructed users to create files manually.

Commands may behave different on various shells in Powershell v5 or v7, Git Bash, Windows CMD.

This change runs a js script which consistently creates UTF-8 files across all platforms. Additionally, single-quoted strings and string concat are used in the commands to avoid special character issues.

## How Has This Been Tested?

### Tested on
- Node.js v18
- Node.js v24
- windows powershell v5
- windows powershell v7
- windows cmd
- windows Git Bash

### Previous commands on windows + node v24
```sh
D:\Code\test-echo
❯ echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js

D:\Code\test-echo via  v24.12.0
❯ echo "pnpm dlx commitlint --edit `$1" > .husky/commit-msg

D:\Code\test-echo via  v24.12.0
❯ file -i .\commitlint.config.js
.\commitlint.config.js: application/javascript; charset=utf-16le

D:\Code\test-echo via  v24.12.0
❯ file -i .\.husky\commit-msg
.\.husky\commit-msg: text/plain; charset=utf-16le

D:\Code\test-echo via  v24.12.0
❯ cat .husky/commit-msg
pnpm dlx commitlint --edit $1

D:\Code\test-echo via  v24.12.0
❯ cat .\commitlint.config.js
export default { extends: ['@commitlint/config-conventional'] };
```

### New commands on windows + node v24

```sh
D:\Code\test-commands
> node -e "fs.writeFileSync('commitlint.config.js', process.argv[1])" "export default { extends: ['@commitlint/config-conventional'] };"

D:\Code\test-commands via  v24.12.0
> cat commitlint.config.js
export default { extends: ['@commitlint/config-conventional'] };

D:\Code\test-commands via  v24.12.0
> node -e "fs.writeFileSync('.husky/commit-msg', 'pnpm dlx commitlint --edit $'+'1\n')"

D:\Code\test-commands via  v24.12.0
> cat .husky/commit-msg
pnpm dlx commitlint --edit $1

D:\Code\test-commands via  v24.12.0
> node -e "fs.writeFileSync('.husky/commit-msg', 'pnpm commitlint $'+'{1}\n')"

D:\Code\test-commands via  v24.12.0
> cat .husky/commit-msg
pnpm commitlint ${1}
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
