### PR TITLE
refactor: replace all lodash.* dependencies with es-toolkit/compat

### DIFF
--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -42,11 +42,10 @@
     "@commitlint/test": "^20.4.3",
     "@commitlint/utils": "^20.0.0",
     "@types/conventional-commits-parser": "^5.0.2",
-    "@types/lodash.mergewith": "^4.6.8",
     "@types/node": "^18.19.17",
     "@types/yargs": "^17.0.29",
-    "fs-extra": "^11.3.4",
-    "lodash.mergewith": "^4.6.2"
+    "es-toolkit": "^1.46.0",
+    "fs-extra": "^11.3.4"
   },
   "dependencies": {
     "@commitlint/format": "^20.5.0",

--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { fix, git } from "@commitlint/test";
 import fs from "fs-extra";
-import mergeWith from "lodash.mergewith";
+import { merge } from "es-toolkit/compat";
 import { x } from "tinyexec";
 import { ExitCode } from "./cli-error.js";
 
@@ -720,6 +720,6 @@ describe("should print config", () => {
 async function writePkg(payload: unknown, options: TestOptions) {
 	const pkgPath = path.join(options.cwd, "package.json");
 	const pkg = JSON.parse(await fs.readFile(pkgPath, "utf-8"));
-	const result = mergeWith(pkg, payload);
+	const result = merge(pkg, payload);
 	await fs.writeFile(pkgPath, JSON.stringify(result, null, "  "));
 }

--- a/@commitlint/config-patternplate/index.js
+++ b/@commitlint/config-patternplate/index.js
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import configAngular from "@commitlint/config-angular";
 import { glob } from "glob";
-import mergeWith from "lodash.mergewith";
+import { merge } from "es-toolkit/compat";
 
 function pathToId(root, filePath) {
 	const relativePath = path.relative(root, filePath);
@@ -16,7 +16,7 @@ async function getPatternIDs() {
 	return files.map((result) => pathToId(root, result));
 }
 
-export default mergeWith(configAngular, {
+export default merge(configAngular, {
 	rules: {
 		"scope-enum": () =>
 			getPatternIDs().then((ids) => [2, "always", ids.concat(["system"])]),

--- a/@commitlint/config-patternplate/package.json
+++ b/@commitlint/config-patternplate/package.json
@@ -33,12 +33,11 @@
   },
   "dependencies": {
     "@commitlint/config-angular": "^20.5.0",
-    "glob": "^11.0.0",
-    "lodash.mergewith": "^4.6.2"
+    "es-toolkit": "^1.46.0",
+    "glob": "^11.0.0"
   },
   "devDependencies": {
-    "@commitlint/utils": "^20.0.0",
-    "@types/lodash.mergewith": "^4.6.8"
+    "@commitlint/utils": "^20.0.0"
   },
   "gitHead": "e82f05a737626bb69979d14564f5ff601997f679"
 }

--- a/@commitlint/ensure/package.json
+++ b/@commitlint/ensure/package.json
@@ -37,20 +37,11 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/utils": "^20.0.0",
-    "@types/lodash.camelcase": "^4.3.8",
-    "@types/lodash.kebabcase": "^4.1.8",
-    "@types/lodash.snakecase": "^4.1.8",
-    "@types/lodash.startcase": "^4.4.8",
-    "@types/lodash.upperfirst": "^4.3.8",
     "glob": "^11.0.0"
   },
   "dependencies": {
     "@commitlint/types": "^20.5.0",
-    "lodash.camelcase": "^4.3.0",
-    "lodash.kebabcase": "^4.1.1",
-    "lodash.snakecase": "^4.1.1",
-    "lodash.startcase": "^4.4.0",
-    "lodash.upperfirst": "^4.3.1"
+    "es-toolkit": "^1.46.0"
   },
   "gitHead": "e82f05a737626bb69979d14564f5ff601997f679"
 }

--- a/@commitlint/ensure/src/index.test.ts
+++ b/@commitlint/ensure/src/index.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { globSync } from "glob";
-import camelCase from "lodash.camelcase";
+import { camelCase } from "es-toolkit/compat";
 
 import * as ensure from "./index.js";
 

--- a/@commitlint/ensure/src/to-case.ts
+++ b/@commitlint/ensure/src/to-case.ts
@@ -1,9 +1,11 @@
 import { TargetCaseType } from "@commitlint/types";
-import camelCase from "lodash.camelcase";
-import kebabCase from "lodash.kebabcase";
-import snakeCase from "lodash.snakecase";
-import upperFirst from "lodash.upperfirst";
-import startCase from "lodash.startcase";
+import {
+	camelCase,
+	kebabCase,
+	snakeCase,
+	startCase,
+	upperFirst,
+} from "es-toolkit/compat";
 
 export default function toCase(input: string, target: TargetCaseType): string {
 	switch (target) {

--- a/@commitlint/load/package.json
+++ b/@commitlint/load/package.json
@@ -37,7 +37,6 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/test": "^20.4.3",
-    "@types/lodash.mergewith": "^4.6.8",
     "@types/node": "^18.19.17",
     "conventional-changelog-atom": "^5.0.0",
     "typescript": "^6.0.0"
@@ -49,8 +48,8 @@
     "@commitlint/types": "^20.5.0",
     "cosmiconfig": "^9.0.1",
     "cosmiconfig-typescript-loader": "^6.1.0",
+    "es-toolkit": "^1.46.0",
     "is-plain-obj": "^4.1.0",
-    "lodash.mergewith": "^4.6.2",
     "picocolors": "^1.1.1"
   },
   "gitHead": "e82f05a737626bb69979d14564f5ff601997f679"

--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -16,7 +16,7 @@ import {
 	UserConfig,
 } from "@commitlint/types";
 import isPlainObject from "is-plain-obj";
-import mergeWith from "lodash.mergewith";
+import { merge } from "es-toolkit/compat";
 
 import { loadConfig } from "./utils/load-config.js";
 import { loadParserOpts } from "./utils/load-parser-opts.js";
@@ -52,7 +52,7 @@ export default async function load(
 	}
 
 	// Merge passed config with file based options
-	config = mergeWith(
+	config = merge(
 		{
 			extends: [],
 			plugins: [],

--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -36,15 +36,14 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@commitlint/utils": "^20.0.0",
-    "@types/lodash.mergewith": "^4.6.8"
+    "@commitlint/utils": "^20.0.0"
   },
   "dependencies": {
     "@commitlint/config-validator": "^20.5.0",
     "@commitlint/types": "^20.5.0",
+    "es-toolkit": "^1.46.0",
     "global-directory": "^5.0.0",
     "import-meta-resolve": "^4.0.0",
-    "lodash.mergewith": "^4.6.2",
     "resolve-from": "^5.0.0"
   },
   "gitHead": "e82f05a737626bb69979d14564f5ff601997f679"

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -6,7 +6,7 @@ import { pathToFileURL, fileURLToPath } from "node:url";
 
 import globalDirectory from "global-directory";
 import { moduleResolve } from "import-meta-resolve";
-import mergeWith from "lodash.mergewith";
+import { mergeWith } from "es-toolkit/compat";
 import resolveFrom_ from "resolve-from";
 import { validateConfig } from "@commitlint/config-validator";
 import type { ParserPreset, UserConfig } from "@commitlint/types";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,53 +1815,6 @@
   resolved "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz#21413001973106cda1c3a9b91eedd4ccd5469d76"
   integrity sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
 
-"@types/lodash.camelcase@^4.3.8":
-  version "4.3.9"
-  resolved "https://registry.npmjs.org/@types/lodash.camelcase/-/lodash.camelcase-4.3.9.tgz#da7b65013d6914fecb8759d5220a6ca9b658ee23"
-  integrity sha512-ys9/hGBfsKxzmFI8hckII40V0ASQ83UM2pxfQRghHAwekhH4/jWtjz/3/9YDy7ZpUd/H0k2STSqmPR28dnj7Zg==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.kebabcase@^4.1.8":
-  version "4.1.9"
-  resolved "https://registry.npmjs.org/@types/lodash.kebabcase/-/lodash.kebabcase-4.1.9.tgz#48d3df753b89499e75eba5e017979b560d69df85"
-  integrity sha512-kPrrmcVOhSsjAVRovN0lRfrbuidfg0wYsrQa5IYuoQO1fpHHGSme66oyiYA/5eQPVl8Z95OA3HG0+d2SvYC85w==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.mergewith@^4.6.8":
-  version "4.6.9"
-  resolved "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz#7093028a36de3cae4495d03b9d92c351cab1f8bf"
-  integrity sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.snakecase@^4.1.8":
-  version "4.1.9"
-  resolved "https://registry.npmjs.org/@types/lodash.snakecase/-/lodash.snakecase-4.1.9.tgz#2d2b3313a44500cb6d8a1c598e0353778d4420d2"
-  integrity sha512-emBZJUiNlo+QPXr1junMKXwzHJK9zbFvTVdyAoorFcm1YRsbzkZCYPTVMM9AW+dlnA6utG7vpfvOs8alxv/TMw==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.startcase@^4.4.8":
-  version "4.4.9"
-  resolved "https://registry.npmjs.org/@types/lodash.startcase/-/lodash.startcase-4.4.9.tgz#fba0daa4bb5f279e05628c03193ae1d5e32c438d"
-  integrity sha512-C0M4DlN1pnn2vEEhLHkTHxiRZ+3GlTegpoAEHHGXnuJkSOXyJMHGiSc+SLRzBlFZWHsBkixe6FqvEAEU04g14g==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.upperfirst@^4.3.8":
-  version "4.3.9"
-  resolved "https://registry.npmjs.org/@types/lodash.upperfirst/-/lodash.upperfirst-4.3.9.tgz#66e150885a67866ed8bc4331c8c305ab682a198c"
-  integrity sha512-bYhT1QEsk9/ggrFjK86Pb5bnKJgTBbpVA77Ygbb1aW1oiWJNGRbVjSlQ9We/ihB9vVpX5WqDJvbISXlukGR+dQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.17.16"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz#94ae78fab4a38d73086e962d0b65c30d816bfb0a"
-  integrity sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==
-
 "@types/markdown-it@^14.1.2":
   version "14.1.2"
   resolved "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz#57f2532a0800067d9b934f3521429a2e8bfb4c61"
@@ -3796,6 +3749,11 @@ es-set-tostringtag@^2.1.0:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
+es-toolkit@^1.46.0:
+  version "1.46.0"
+  resolved "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz#40f79f4a491cf3e890a1f397889de89f02332977"
+  integrity sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==
+
 esbuild@^0.21.3:
   version "0.21.5"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
@@ -5490,11 +5448,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.camelcase@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
-
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -5505,35 +5458,10 @@ lodash.ismatch@^4.4.0:
   resolved "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==
 
-lodash.kebabcase@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
-  integrity sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==
-
 lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==
-
-lodash.mergewith@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
-
-lodash.snakecase@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
-  integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
-
-lodash.startcase@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
-  integrity sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==
-
-lodash.upperfirst@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
-  integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
 lodash@4.17.21, lodash@^4.17.21:
   version "4.17.21"


### PR DESCRIPTION
## Description
Replacing `lodash.*` with `es-toolkit/compat`

Replacements:

- lodash.camelcase / kebabcase / snakecase / startcase / upperfirst → es-toolkit/compat in @commitlint/ensure (case helpers)
- lodash.mergewith → es-toolkit/compat:
  - mergeWith (with customizer) in @commitlint/resolve-extends
  - merge (no customizer) in @commitlint/load, @commitlint/config-patternplate, and the cli test helper

Notes:
- For strings handling, it's noted #462 revert kasi change due to non-Latin subject-case regressions
use of compat mode `es-toolkit/compat` should pass them
- es-toolkit/compat's mergeWith always treats the last positional argument as the customizer, unlike lodash's createAssigner which detects function-typed customizers. Call sites that passed objects (no customizer) are switched to es-toolkit's variadic merge to preserve behavior.

## Motivation and Context
For improving performance, minimizing dependencies and supply chain attack vectors. 
Reference: https://e18e.dev/docs/replacements/lodash-underscore

## How Has This Been Tested?


Test results: 1185/1185 tests across 90 files pass, including the Cyrillic / Chinese / Arabic / Hebrew / mixed-script subject-case cases that broke under kasi.


## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. See the README for information on testing. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
