### PR TITLE
fix(types): add presetConfig to ParserPreset interface

### DIFF
--- a/@commitlint/types/src/load.test-d.ts
+++ b/@commitlint/types/src/load.test-d.ts
@@ -1,0 +1,29 @@
+/**
+ * Compile-time type checks for `UserConfig` and `ParserPreset`.
+ * If a line fails to compile, the associated type definition needs to be fixed.
+ */
+
+import type { ParserPreset, UserConfig } from "./index.js";
+
+// Regression: `parserPreset.presetConfig` must be assignable when configuring
+// a preset like `conventional-changelog-conventionalcommits`. See #4748.
+const _presetConfigCheck: UserConfig = {
+	parserPreset: {
+		name: "conventional-changelog-conventionalcommits",
+		presetConfig: {
+			types: [
+				{ type: "feat", section: "Features" },
+				{ type: "fix", section: "Bug Fixes" },
+				{ type: "docs", section: "Documentation", hidden: false },
+				{ type: "chore", hidden: true },
+			],
+		},
+	},
+};
+void _presetConfigCheck;
+
+const _parserPresetCheck: ParserPreset = {
+	name: "conventional-changelog-conventionalcommits",
+	presetConfig: { types: [] },
+};
+void _parserPresetCheck;

--- a/@commitlint/types/src/load.ts
+++ b/@commitlint/types/src/load.ts
@@ -52,4 +52,5 @@ export interface ParserPreset {
 	path?: string;
 	parserOpts?: unknown;
 	parser?: unknown;
+	presetConfig?: unknown;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `presetConfig?: unknown` to the `ParserPreset` interface in `@commitlint/types` so TypeScript users can configure presets like `conventional-changelog-conventionalcommits` without a type error.

## Motivation and Context

Fixes #4748.

The `presetConfig` field is documented in `docs/reference/configuration.md` (`### presetConfig`) and is the standard way to customize presets like `conventional-changelog-conventionalcommits` (which exports a factory accepting a `presetConfig` argument). However, the `ParserPreset` interface only declared `name`, `path`, `parserOpts`, and `parser`, so passing `presetConfig` from a TypeScript config produced `Object literal may only specify known properties, and 'presetConfig' does not exist in type 'ParserPreset'`.

`unknown` is used (matching `parserOpts`/`parser`) because the shape of `presetConfig` is preset-specific.

## Usage examples

```ts
// commitlint.config.ts
import type { UserConfig } from "@commitlint/types";

const config: UserConfig = {
  parserPreset: {
    name: "conventional-changelog-conventionalcommits",
    presetConfig: {
      types: [
        { type: "feat", section: "Features" },
        { type: "fix", section: "Bug Fixes" },
        { type: "docs", section: "Documentation", hidden: false },
        { type: "chore", hidden: true },
      ],
    },
  },
};

export default config;
```

```sh
echo "feat: add new feature" | commitlint # passes
```

## How Has This Been Tested?

- Added `@commitlint/types/src/load.test-d.ts` with compile-time checks asserting that `presetConfig` is assignable on both `UserConfig.parserPreset` and `ParserPreset` directly. Verified the test fails on `master` with the exact error from the issue and passes with this change.
- `yarn build`, `yarn vitest run @commitlint/types`, `yarn lint`, and `yarn format` all pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.