### PR TITLE
fix(read): fail when --from and --to share no merge-base #4555

### DIFF
--- a/@commitlint/read/src/read.test.ts
+++ b/@commitlint/read/src/read.test.ts
@@ -164,3 +164,43 @@ test("should not read any commits when there are no tags", async () => {
 
 	expect(result).toHaveLength(0);
 });
+
+test("throws when from and to share no merge-base", async () => {
+	const cwd: string = await git.bootstrap();
+	await x("git", ["commit", "--allow-empty", "-m", "main commit"], {
+		nodeOptions: { cwd },
+	});
+	const initialBranch = (
+		await x("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+			nodeOptions: { cwd },
+		})
+	).stdout.trim();
+
+	await x("git", ["checkout", "--orphan", "other"], { nodeOptions: { cwd } });
+	await x("git", ["commit", "--allow-empty", "-m", "orphan commit"], {
+		nodeOptions: { cwd },
+	});
+
+	await expect(read({ from: initialBranch, to: "other", cwd })).rejects.toThrow(
+		/Cannot find merge-base/,
+	);
+});
+
+test("throws when from has no merge-base with HEAD (no --to)", async () => {
+	const cwd: string = await git.bootstrap();
+	await x("git", ["commit", "--allow-empty", "-m", "main commit"], {
+		nodeOptions: { cwd },
+	});
+	const initialBranch = (
+		await x("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+			nodeOptions: { cwd },
+		})
+	).stdout.trim();
+
+	await x("git", ["checkout", "--orphan", "other"], { nodeOptions: { cwd } });
+	await x("git", ["commit", "--allow-empty", "-m", "orphan commit"], {
+		nodeOptions: { cwd },
+	});
+
+	await expect(read({ from: initialBranch, cwd })).rejects.toThrow(/Cannot find merge-base/);
+});

--- a/@commitlint/read/src/read.ts
+++ b/@commitlint/read/src/read.ts
@@ -59,6 +59,27 @@ export default async function getCommitMessages(
 		}
 	}
 
+	// Verify the two refs share a merge-base before handing off the range
+	// walk to git-raw-commits. In a shallow clone the common ancestor may
+	// be missing, in which case `git log from..to` silently returns only
+	// the commits that happen to be present, hiding invalid commits in the
+	// unfetched portion of history.
+	if (from) {
+		// `to` is left undefined here when no --to was given; git-raw-commits
+		// defaults it to HEAD, so we mirror that for the merge-base check.
+		const effectiveTo = to ?? "HEAD";
+		const mergeBase = await x("git", ["merge-base", from, effectiveTo], {
+			nodeOptions: { cwd },
+		});
+		if (mergeBase.exitCode === 1) {
+			throw new Error(
+				`Cannot find merge-base between '${from}' and '${effectiveTo}'. ` +
+					`This typically indicates incomplete git history (e.g., a shallow clone). ` +
+					`Consider fetching more history.`,
+			);
+		}
+	}
+
 	let gitOptions: GitOptions = { from, to };
 	if (gitLogArgs) {
 		const { values, positionals } = parseArgs({


### PR DESCRIPTION
Fixes #4555.

When linting a range with `--from A --to B` in a shallow clone where the merge-base wasn't fetched, `git log A..B` silently returns whatever subset of the range exists locally. We validate that subset and report success — even though we never saw the rest of the range. Most visible in CI: `actions/checkout@v4` clones with `fetch-depth: 1`, so a branch with N commits ahead of `origin/master` surfaces only `HEAD`; if `HEAD` is well-formed, the lint passes regardless of the unfetched commits.

This PR adds a `git merge-base` check between `from` and `to` (defaulting `to` to `HEAD` to mirror what `git-raw-commits` does internally) before walking the range, and errors with a clear message if no common ancestor exists. `--last`, `--edit`, and the no-flag default all bypass the check, since none of them depend on a two-ended range.

## Tests

Two new tests in `@commitlint/read/src/read.test.ts` use `git checkout --orphan` to create unrelated histories — the exact condition the check enforces, decoupled from shallow-clone trigger specifics.

## Out of scope

- **`--from-last-tag` in a shallow clone** has a related failure mode (`git describe` falls back to a hash → no-op range → silent pass). The merge-base check doesn't catch it because the no-op sets `from = HEAD-hash`, which trivially merge-bases with `HEAD`. Surfacing this requires a separate decision (warn vs. error, and how a library function should communicate diagnostics) and is left for follow-up.
- **#3376** (`--from === --to` silently succeeds) is a related but distinct issue, also out of scope here.

## Alternative considered

The issue thread suggested gating on `.git/shallow` instead. Merge-base is more precise — it detects the actual broken state regardless of cause, and matches `git diff --three-dot`'s behavior. A path-based shallow check would also be wrong in worktrees and submodules, where `.git` is a file pointing elsewhere; if such a check is ever wanted, `git rev-parse --is-shallow-repository` is the right primitive.