### PR TITLE
fix: emit actionable error when --edit cannot find COMMIT_EDITMSG (#589)

### DIFF
--- a/@commitlint/read/src/get-edit-commit.ts
+++ b/@commitlint/read/src/get-edit-commit.ts
@@ -15,7 +15,20 @@ export async function getEditCommit(
 	}
 
 	const editFilePath = await getEditFilePath(top, edit);
-	const editFile: Buffer = await fs.readFile(editFilePath);
+
+	let editFile: Buffer;
+	try {
+		editFile = await fs.readFile(editFilePath);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+			throw new Error(
+				`No commit message file found at ${editFilePath}.\n` +
+					`--edit reads the message prepared by 'git commit' and is intended to run from a commit-msg hook. ` +
+					`If you want to lint existing history, use --from / --to instead; to lint a specific file, pass its path as --edit <file>.`,
+			);
+		}
+		throw err;
+	}
 
 	return [`${editFile.toString("utf-8")}\n`];
 }

--- a/@commitlint/read/src/get-edit-commit.ts
+++ b/@commitlint/read/src/get-edit-commit.ts
@@ -21,10 +21,13 @@ export async function getEditCommit(
 		editFile = await fs.readFile(editFilePath);
 	} catch (err) {
 		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+			const hint =
+				typeof edit === "string"
+					? `Check that the path passed to --edit exists and is readable.`
+					: `--edit reads the message prepared by 'git commit' and is intended to run from a commit-msg hook. If you want to lint existing history, use --from / --to instead; to lint a specific file, pass its path as --edit <file>.`;
 			throw new Error(
-				`No commit message file found at ${editFilePath}.\n` +
-					`--edit reads the message prepared by 'git commit' and is intended to run from a commit-msg hook. ` +
-					`If you want to lint existing history, use --from / --to instead; to lint a specific file, pass its path as --edit <file>.`,
+				`No commit message file found at ${editFilePath}. ${hint}`,
+				{ cause: err },
 			);
 		}
 		throw err;

--- a/@commitlint/read/src/read.test.ts
+++ b/@commitlint/read/src/read.test.ts
@@ -16,6 +16,14 @@ test("get edit commit message specified by the `edit` flag", async () => {
 	expect(actual).toEqual(expected);
 });
 
+test("throws an actionable error when --edit is used on a fresh repo without COMMIT_EDITMSG", async () => {
+	const cwd: string = await git.bootstrap();
+
+	await expect(read({ edit: true, cwd })).rejects.toThrow(
+		/No commit message file found.*commit-msg hook/s,
+	);
+});
+
 test("get edit commit message from git root", async () => {
 	const cwd: string = await git.bootstrap();
 

--- a/@commitlint/read/src/read.test.ts
+++ b/@commitlint/read/src/read.test.ts
@@ -24,6 +24,14 @@ test("throws an actionable error when --edit is used on a fresh repo without COM
 	);
 });
 
+test("throws an actionable error when --edit <file> points at a missing path", async () => {
+	const cwd: string = await git.bootstrap();
+
+	await expect(read({ edit: "does-not-exist", cwd })).rejects.toThrow(
+		/No commit message file found.*Check that the path passed to --edit/s,
+	);
+});
+
 test("get edit commit message from git root", async () => {
 	const cwd: string = await git.bootstrap();
 


### PR DESCRIPTION
Fixes: #589

Catch ENOENT from reading the edit file and throw a message that explains --edit is meant for a commit-msg hook and points at --from / --to or --edit <file> for other use cases. Avoids the raw fs error on fresh checkouts.

