### PR TITLE
chore: pre pnpm cleanup

### DIFF
--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -50,6 +50,7 @@
     "@commitlint/utils": "^21.0.0",
     "@types/node": "^22.0.0",
     "@types/yargs": "^17.0.29",
+    "conventional-commits-parser": "^6.3.0",
     "es-toolkit": "^1.46.0"
   },
   "engines": {

--- a/@commitlint/cli/package.json
+++ b/@commitlint/cli/package.json
@@ -48,7 +48,6 @@
   "devDependencies": {
     "@commitlint/test": "^21.0.0",
     "@commitlint/utils": "^21.0.0",
-    "@types/conventional-commits-parser": "^5.0.2",
     "@types/node": "^22.0.0",
     "@types/yargs": "^17.0.29",
     "es-toolkit": "^1.46.0"

--- a/@commitlint/config-validator/package.json
+++ b/@commitlint/config-validator/package.json
@@ -38,7 +38,8 @@
     "ajv": "^8.11.0"
   },
   "devDependencies": {
-    "@commitlint/utils": "^21.0.0"
+    "@commitlint/utils": "^21.0.0",
+    "@types/node": "^22.0.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/@commitlint/lint/package.json
+++ b/@commitlint/lint/package.json
@@ -41,7 +41,8 @@
   },
   "devDependencies": {
     "@commitlint/test": "^21.0.0",
-    "@commitlint/utils": "^21.0.0"
+    "@commitlint/utils": "^21.0.0",
+    "@types/node": "^22.0.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/@commitlint/parse/package.json
+++ b/@commitlint/parse/package.json
@@ -40,8 +40,7 @@
   },
   "devDependencies": {
     "@commitlint/test": "^21.0.0",
-    "@commitlint/utils": "^21.0.0",
-    "@types/conventional-commits-parser": "^5.0.2"
+    "@commitlint/utils": "^21.0.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/@commitlint/prompt/package.json
+++ b/@commitlint/prompt/package.json
@@ -43,7 +43,8 @@
     "@commitlint/utils": "^21.0.0",
     "@types/inquirer": "^9.0.7",
     "@types/node": "^22.0.0",
-    "commitizen": "^4.2.4"
+    "commitizen": "^4.2.4",
+    "rxjs": "^7.5.5"
   },
   "config": {
     "commitizen": {

--- a/@commitlint/prompt/package.json
+++ b/@commitlint/prompt/package.json
@@ -42,6 +42,7 @@
     "@commitlint/types": "^14.0.0",
     "@commitlint/utils": "^21.0.0",
     "@types/inquirer": "^9.0.7",
+    "@types/node": "^22.0.0",
     "commitizen": "^4.2.4"
   },
   "config": {

--- a/@commitlint/resolve-extends/package.json
+++ b/@commitlint/resolve-extends/package.json
@@ -41,7 +41,8 @@
     "resolve-from": "^5.0.0"
   },
   "devDependencies": {
-    "@commitlint/utils": "^21.0.0"
+    "@commitlint/utils": "^21.0.0",
+    "@types/node": "^22.0.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -43,6 +43,7 @@
     "@commitlint/parse": "^21.0.0",
     "@commitlint/test": "^21.0.0",
     "@commitlint/utils": "^21.0.0",
+    "@types/node": "^22.0.0",
     "conventional-changelog-angular": "^8.2.0",
     "conventional-commits-parser": "^6.3.0"
   },

--- a/@commitlint/rules/package.json
+++ b/@commitlint/rules/package.json
@@ -43,7 +43,6 @@
     "@commitlint/parse": "^21.0.0",
     "@commitlint/test": "^21.0.0",
     "@commitlint/utils": "^21.0.0",
-    "@types/conventional-commits-parser": "^5.0.2",
     "conventional-changelog-angular": "^8.2.0",
     "conventional-commits-parser": "^6.3.0"
   },

--- a/@commitlint/top-level/package.json
+++ b/@commitlint/top-level/package.json
@@ -37,7 +37,8 @@
     "escalade": "^3.2.0"
   },
   "devDependencies": {
-    "@commitlint/test": "^21.0.0"
+    "@commitlint/test": "^21.0.0",
+    "@types/node": "^22.0.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/@commitlint/travis-cli/package.json
+++ b/@commitlint/travis-cli/package.json
@@ -42,7 +42,8 @@
   },
   "devDependencies": {
     "@commitlint/test": "^21.0.0",
-    "@commitlint/utils": "^21.0.0"
+    "@commitlint/utils": "^21.0.0",
+    "@types/node": "^22.0.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/@commitlint/types/package.json
+++ b/@commitlint/types/package.json
@@ -31,8 +31,7 @@
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@commitlint/utils": "^21.0.0",
-    "@types/conventional-commits-parser": "^5.0.2"
+    "@commitlint/utils": "^21.0.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "vitepress": "^1.3.4",
     "vitepress-plugin-tabs": "^0.9.0",
     "vitest": "~4.0.18",
+    "vitest-environment-commitlint": "^21.0.0",
     "vue": "^3.5.29"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@commitlint/config-conventional": "^21.0.0",
+    "@commitlint/config-workspace-scopes": "^21.0.0",
     "@swc/core": "^1.15.18",
     "@vitest/coverage-istanbul": "~4.0.18",
     "husky": "^9.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1760,13 +1760,6 @@
     "@types/deep-eql" "*"
     assertion-error "^2.0.1"
 
-"@types/conventional-commits-parser@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz#987db915796deb9d0c8ffb7a8ed42cb5bb257cd5"
-  integrity sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==
-  dependencies:
-    "@types/node" "*"
-
 "@types/deep-eql@*":
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"


### PR DESCRIPTION
  1. Drop @types/conventional-commits-parser — cc-parser v6 ships its own types
  2. Declare @types/node in 7 packages that import node:*
  3. Declare rxjs in @commitlint/prompt
  4. Declare conventional-commits-parser in @commitlint/cli
  5. Declare vitest-environment-commitlint at root
  6. Declare @commitlint/config-conventional and @commitlint/config-workspace-scopes at root