### PR TITLE
fix(load): only resolve relative formatter paths

### DIFF
--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -23,9 +23,14 @@ import { loadParserOpts } from "./utils/load-parser-opts.js";
 import loadPlugin from "./utils/load-plugin.js";
 
 /**
- * formatter should be kept as is when unable to resolve it from config directory
+ * Resolve relative/custom formatter paths from the config directory.
+ * Package specifiers (e.g. "@commitlint/format") are kept as-is so the
+ * runtime resolves them via standard module resolution at import time.
  */
 const resolveFormatter = (formatter: string, parent?: string): string => {
+	if (!formatter.startsWith(".")) {
+		return formatter;
+	}
 	try {
 		return resolveFrom(formatter, parent);
 	} catch (error) {

--- a/@commitlint/load/src/load.ts
+++ b/@commitlint/load/src/load.ts
@@ -23,9 +23,10 @@ import { loadParserOpts } from "./utils/load-parser-opts.js";
 import loadPlugin from "./utils/load-plugin.js";
 
 /**
- * Resolve relative/custom formatter paths from the config directory.
- * Package specifiers (e.g. "@commitlint/format") are kept as-is so the
- * runtime resolves them via standard module resolution at import time.
+ * Resolve relative formatter paths (e.g. "./my-formatter.js") from the
+ * config directory. Package specifiers and absolute paths are kept as-is
+ * so the runtime resolves them via standard module resolution at import
+ * time.
  */
 const resolveFormatter = (formatter: string, parent?: string): string => {
 	if (!formatter.startsWith(".")) {


### PR DESCRIPTION
resolveFrom() returns an absolute path on success, which leaks the internal package location into the loaded config when the formatter is a package specifier (e.g. "@commitlint/format"). Under yarn's flat node_modules layout the resolution typically failed and the specifier was preserved by accident; under stricter resolution (pnpm, npm with hoisting disabled) it succeeds and the absolute path appears in config output.

Skip resolveFrom for non-relative specifiers and let the runtime resolve them via standard module resolution at import time.
