### PR TITLE
fix: apply oxfmt formatting to get-edit-commit.ts

### DIFF
--- a/@commitlint/read/src/get-edit-commit.ts
+++ b/@commitlint/read/src/get-edit-commit.ts
@@ -22,10 +22,7 @@ export async function getEditCommit(cwd?: string, edit?: boolean | string): Prom
 				typeof edit === "string"
 					? `Check that the path passed to --edit exists and is readable.`
 					: `--edit reads the message prepared by 'git commit' and is intended to run from a commit-msg hook. If you want to lint existing history, use --from / --to instead; to lint a specific file, pass its path as --edit <file>.`;
-			throw new Error(
-				`No commit message file found at ${editFilePath}. ${hint}`,
-				{ cause: err },
-			);
+			throw new Error(`No commit message file found at ${editFilePath}. ${hint}`, { cause: err });
 		}
 		throw err;
 	}


### PR DESCRIPTION
The --edit error handling change in #4755 merged with an unformatted multi-line throw expression, breaking the format check on subsequent CI runs. Collapse it to oxfmt's expected single-line form.
