### PR TITLE
fix(read): strip verbose diff from commit message

### DIFF
--- a/@commitlint/read/src/get-edit-commit.ts
+++ b/@commitlint/read/src/get-edit-commit.ts
@@ -27,5 +27,22 @@ export async function getEditCommit(cwd?: string, edit?: boolean | string): Prom
 		throw err;
 	}
 
-	return [`${editFile.toString("utf-8")}\n`];
+	const raw = editFile.toString("utf-8");
+
+	// Strip the verbose diff added by `git commit --verbose`.
+	// Git appends the diff after a scissors line and/or a `diff --git`
+	// marker.  The diff is never part of the final commit message so
+	// neither should commitlint see it (see #437).
+	const diffIndex = raw.indexOf("\ndiff --git ");
+	const scissorsIndex = raw.indexOf("\n# ------------------------ >8 ------------------------");
+	const cutIndex =
+		diffIndex !== -1 && scissorsIndex !== -1
+			? Math.min(diffIndex, scissorsIndex)
+			: diffIndex !== -1
+				? diffIndex
+				: scissorsIndex;
+
+	const cleaned = cutIndex !== -1 ? raw.slice(0, cutIndex) : raw;
+
+	return [`${cleaned}\n`];
 }


### PR DESCRIPTION
## Description

When `git commit --verbose` is used, git appends the diff to the commit message file (`COMMIT_EDITMSG`). Commitlint's `--edit` mode reads this file directly, causing `body-max-line-length` and `footer-max-line-length` rules to incorrectly fail on diff lines that exceed the configured limit.

## Root Cause

`getEditCommit()` in `@commitlint/read` reads the raw commit message file without stripping the verbose diff. Git itself strips everything after the scissors line (`# ------------------------ >8 ------------------------`) before storing the commit, but commitlint sees the pre-stripped version when running as a commit-msg hook.

## Fix

Strip everything after either:
- The scissors line: `# ------------------------ >8 ------------------------`
- The first `diff --git` marker

whichever comes first. This mirrors git's own stripping behavior without needing to parse `core.commentChar`.

## Related

Fixes #437
Closes #437