### PR TITLE
fix: disallow same commit hash for --from and --to

### DIFF
--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -120,6 +120,21 @@ test("regression test for running with --last flag", async () => {
 	expect(output.stderr).toEqual("");
 });
 
+test("should fail when --from and --to point to the same commit", async () => {
+	const cwd = await gitBootstrap("fixtures/default");
+	const result = cli(["--from", "abc123", "--to", "abc123"], { cwd })();
+	const output = await result;
+	expect(output.stderr).toContain("--from");
+	expect(output.stderr).toContain("--to");
+	expect(output.stderr).toContain("abc123");
+
+	// suggestions to user
+	expect(output.stderr).toContain("--last");
+	expect(output.stderr).toContain("abc123^");
+
+	expect(result.exitCode).toBe(ExitCode.CommitlintInvalidArgument);
+});
+
 test("should produce no output with --quiet flag", async () => {
 	const cwd = await gitBootstrap("fixtures/default");
 	const result = cli(["--quiet"], { cwd })("foo: bar");

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -253,6 +253,17 @@ async function main(args: MainArgs): Promise<void> {
 		throw err;
 	}
 
+	if (Object.hasOwn(flags, "from") && Object.hasOwn(flags, "to") && flags.from === flags.to) {
+		const err = new CliError(
+			`Invalid input flags: --from and --to point to the same commit. To lint that single commit, use --last (if HEAD) or --from ${flags.from}^ --to ${flags.from}.`,
+			pkg.name,
+			ExitCode.CommitlintInvalidArgument,
+		);
+		cli.showHelp("log");
+		console.error(err.message);
+		throw err;
+	}
+
 	const input = await (fromStdin
 		? stdin()
 		: read({


### PR DESCRIPTION
Fixes https://github.com/conventional-changelog/commitlint/issues/3376

## Description

Before executing anything, make commitlint-cli check the --from and --to args, and if they are the same, throw an early error (before a more cryptic one throws under the hood, or before a misleading exitCode=0 happens).

## Motivation and Context

https://github.com/conventional-changelog/commitlint/issues/3376

## Usage examples

See https://github.com/conventional-changelog/commitlint/issues/3376

## How Has This Been Tested?

TDD

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
