### PR TITLE
ci: have renovate rebase stale PRs before merging

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "packageManager": "pnpm@11.3.0+sha512.2c403d6594527287672b1f7056343a1f7c3634036a67ffabfcc2b3d7595d843768f8787148d1b57cf7956c90606bbd192857c363af19e96d2d0ec9ec5741d215",
   "renovate": {
     "rangeStrategy": "update-lockfile",
+    "rebaseWhen": "behind-base-branch",
     "ignorePaths": [
       "**/fixtures/**/package.json"
     ],


### PR DESCRIPTION
Set rebaseWhen=behind-base-branch in the package.json renovate block so any renovate PR whose base has moved gets re-pushed and re-tested against the new tip before it can land.

This closes a class of merge-time race we just hit: PR #4781 (tinyexec 1.1.2 -> 1.2.2) passed CI on a base that pinned pnpm@11.1.2, but was squash-merged on top of master after PR #4776 had bumped pnpm to 11.3.0. pnpm 11.3.0 added a supply-chain verification pass that re-applies the default minimumReleaseAge (1440 min) to every lockfile entry on every install -- 11.1.2 only checked it at resolve time, so the renovate PR's --frozen-lockfile run never noticed tinyexec@1.2.2 was too new. Post-merge, master CI failed with
ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION until the package aged in.

Forcing a rebase before merge surfaces that mismatch in the PR run, where it can be retried or held, instead of breaking master.
