### PR TITLE
chore: have renovate hold PRs for 3 days after release

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
   "renovate": {
     "rangeStrategy": "update-lockfile",
     "rebaseWhen": "behind-base-branch",
+    "minimumReleaseAge": "3 days",
+    "internalChecksFilter": "strict",
     "ignorePaths": [
       "**/fixtures/**/package.json"
     ],


### PR DESCRIPTION
Recent renovate PRs went red because freshly-published versions weren't fully propagated on the npm registry / CDN. `minimumReleaseAge` delays PRs until the version is at least three days old, and `internalChecksFilter: "strict"` suppresses the PR entirely until that window passes rather than opening it and blocking merge.
