### PR TITLE
ci: run commitlint once per same-repo PR

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,6 +2,8 @@ name: Conventional Commitlint
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Scope the push trigger to the default branch so Renovate (and any other same-repo branch) fires only the pull_request event instead of both push and pull_request, which currently runs the Commitlint check twice for a single PR.

Coverage improves rather than regresses: the pull_request path validates the full commit range (--from base --to head), whereas the dropped push run only checked --last (the tip commit). Direct pushes/merges to master still run the --last validation, and fork PRs were already single-run.
