### PR TITLE
fix(rules): ignore footer lines in body max length

### DIFF
--- a/@commitlint/rules/src/body-max-line-length.test.ts
+++ b/@commitlint/rules/src/body-max-line-length.test.ts
@@ -5,6 +5,7 @@ import { bodyMaxLineLength } from "./body-max-line-length.js";
 
 const short = "a";
 const long = "ab";
+const longFooter = `Signed-off-by: ${"a".repeat(110)}`;
 const url = "https://example.com/URL/with/a/very/long/path";
 
 const value = short.length;
@@ -13,6 +14,7 @@ const messages = {
 	empty: "test: subject",
 	short: `test: subject\n${short}`,
 	long: `test: subject\n${long}`,
+	longFooter: `test: subject\n\n${short}\n\n${longFooter}`,
 	shortMultipleLines: `test:subject\n${short}\n${short}\n${short}`,
 	longMultipleLines: `test:subject\n${short}\n${long}\n${short}`,
 	urlStandalone: `test:subject\n${short}\n${url}\n${short}`,
@@ -54,6 +56,12 @@ test("with short should succeed", async () => {
 test("with long should fail", async () => {
 	const [actual] = bodyMaxLineLength(await parsed.long, undefined, value);
 	const expected = false;
+	expect(actual).toEqual(expected);
+});
+
+test("with long footer should succeed", async () => {
+	const [actual] = bodyMaxLineLength(await parsed.longFooter, undefined, value);
+	const expected = true;
 	expect(actual).toEqual(expected);
 });
 

--- a/@commitlint/rules/src/body-max-line-length.ts
+++ b/@commitlint/rules/src/body-max-line-length.ts
@@ -1,12 +1,49 @@
 import { maxLineLength } from "@commitlint/ensure";
+import toLines from "@commitlint/to-lines";
 import { SyncRule } from "@commitlint/types";
 
-export const bodyMaxLineLength: SyncRule<number> = (parsed, _when = undefined, value = 0) => {
-	const input = parsed.body;
+const TRAILER_TOKEN = /^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+:\s\S/;
 
-	if (!input) {
+function withoutTrailingFooter(body: string, footer?: string | null): string {
+	const footerStart = footer ? body.length - footer.length : -1;
+	const input =
+		footer &&
+		footerStart >= 0 &&
+		body.endsWith(footer) &&
+		(footerStart === 0 || body[footerStart - 1] === "\n")
+			? body.slice(0, footerStart).replace(/(\r?\n)+$/, "")
+			: body;
+
+	const lines = toLines(input);
+	let last = lines.length - 1;
+
+	while (last >= 0 && lines[last] === "") {
+		last--;
+	}
+
+	let first = last;
+
+	while (first >= 0 && lines[first] !== "") {
+		first--;
+	}
+
+	const footerLines = lines.slice(first + 1, last + 1);
+
+	if (footerLines.length === 0 || !footerLines.every((line) => TRAILER_TOKEN.test(line))) {
+		return input;
+	}
+
+	return lines.slice(0, first).join("\n");
+}
+
+export const bodyMaxLineLength: SyncRule<number> = (parsed, _when = undefined, value = 0) => {
+	const body = parsed.body;
+
+	if (!body) {
 		return [true];
 	}
+
+	const input = withoutTrailingFooter(body, parsed.footer);
 
 	return [maxLineLength(input, value), `body's lines must not be longer than ${value} characters`];
 };


### PR DESCRIPTION
## Summary
- ignore trailing footer/trailer paragraphs when checking body line lengths
- add a regression test for long `Signed-off-by` footer lines with short body lines

Fixes #4088

## Tests
- pnpm exec vitest run @commitlint/rules/src/body-max-line-length.test.ts @commitlint/rules/src/footer-max-line-length.test.ts
- node scripts/check-no-focused-tests.js @commitlint/rules/src/body-max-line-length.test.ts
- pnpm exec oxfmt --check --ignore-path .oxfmtignore @commitlint/rules/src/body-max-line-length.ts @commitlint/rules/src/body-max-line-length.test.ts
- pnpm exec oxlint @commitlint/rules/src/body-max-line-length.ts @commitlint/rules/src/body-max-line-length.test.ts
- git diff --check
- pnpm build