### PR TITLE
chore: exempt lock file maintenance from minimumReleaseAge check

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,15 @@
       "schedule": [
         "before 5am on monday"
       ]
-    }
+    },
+    "packageRules": [
+      {
+        "description": "Lock file maintenance is package-manager-controlled and produces upgrade entries without a releaseTimestamp, so the minimumReleaseAge (renovate/stability-days) check can never pass and these PRs sit pending forever. Exempt them; this mirrors Renovate's security:minimumReleaseAgeNpm preset. The 3-day gate still applies to all regular dependency updates.",
+        "matchUpdateTypes": [
+          "lockFileMaintenance"
+        ],
+        "minimumReleaseAge": null
+      }
+    ]
   }
 }


### PR DESCRIPTION
Lock file maintenance updates are package-manager-controlled and have no release timestamp, so the minimumReleaseAge (renovate/stability-days) status check can never pass. These PRs sit pending forever (e.g. #4786, #4775) even though all real CI is green and the check is non-required.

Add a packageRule setting minimumReleaseAge: null for the lockFileMaintenance update type, mirroring Renovate's own security:minimumReleaseAgeNpm preset ("Do not require Minimum Release Age for update types that are controlled by the package manager"). The 3-day gate and internalChecksFilter: strict stay in effect for all regular dependency updates.

