### PR TITLE
fix: remove duplicate es-toolkit@1.47.1 keys from lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3160,9 +3160,6 @@ packages:
   es-toolkit@1.47.1:
     resolution: {integrity: sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==}
 
-  es-toolkit@1.47.1:
-    resolution: {integrity: sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==}
-
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -7793,9 +7790,6 @@ snapshots:
       hasown: 2.0.2
 
   es-toolkit@1.47.1: {}
-
-  es-toolkit@1.47.1:
-    optional: true
 
   esbuild@0.21.5:
     optionalDependencies:


### PR DESCRIPTION
PR #4831 (commitizen v4.3.2) merged from a stale base and appended duplicate es-toolkit@1.47.1 entries to the packages and snapshots sections. The duplicated mapping key made pnpm-lock.yaml invalid YAML, breaking `pnpm install --frozen-lockfile` on master (ERR_PNPM_BROKEN_LOCKFILE).
