### PR TITLE
ci: install git in stock-Ubuntu baseline job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,8 +113,15 @@ jobs:
           apt update --yes
 
           # NOTE: do not change the below with an `actions/setup-node` step! or it
-          # would make this CI job entirely pointless
-          apt install --yes nodejs npm
+          # would make this CI job entirely pointless.
+          #
+          # `git` is needed because the test suite bootstraps throwaway repos via
+          # `git init`. It used to arrive as an apt Recommends of the npm chain,
+          # but on ubuntu:26.04 apt stopped pulling that recommend in (same image
+          # digest, same node/npm versions), so install it explicitly. The
+          # checkout step runs before this and uses the REST API fallback either
+          # way, which is fine — the tests create their own repos.
+          apt install --yes nodejs npm git
 
           # Ubuntu's bundled corepack (with stock Node) trips on the dynamic
           # ESM imports pnpm 11 uses at launch (ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING).


### PR DESCRIPTION
## Problem

The `nodeJsBaselineAptCompatibility` CI job ("NodeJS installed from stock Ubuntu-LTS packages") has been **red on `master` since 2026-06-25**, failing with ~189 errors across `config-*-scopes`, `load`, `cli`, `get-edit-commit`, and find-up tests.

It is **not** caused by any code change. The same commit (`d4a79621`) passed on 2026-06-24 and failed on 2026-06-25 with identical code.

## Root cause

The job runs `apt install --yes nodejs npm` inside an `ubuntu:26.04` container. The test suite bootstraps throwaway repos via `git init`, but the `git` binary only ever arrived as an apt **Recommends** of the npm chain — never a hard dependency.

Comparing the last green run to the first red run:

| | green (06-24) | red (06-25) |
|---|---|---|
| commit SHA | `d4a79621` | `d4a79621` (same) |
| `ubuntu:26.04` image digest | `sha256:5395…ffdba` | `sha256:5395…ffdba` (**same**) |
| nodejs / npm | 22.22.1 / 9.2.0 | 22.22.1 / 9.2.0 (**same**) |
| packages installed | 695 | 538 |
| `git` present | ✅ | ❌ |

On the red run apt simply stopped installing the recommended set, logging:

```
Recommended packages:
  build-essential  git  libfile-mimeinfo-perl  libnet-dbus-perl  libx11-protocol-perl
```

`ubuntu:26.04` is a fast-moving archive (gcc-15, perl 5.40, python 3.14) refreshed by `apt update` on every run, so Recommends resolution is not stable day-to-day. The job was silently relying on an un-guaranteed default.

(Side note: `actions/checkout` here always uses the REST API fallback — the container is bare at checkout time — so this is unrelated to checkout; the tests create their own repos.)

## Fix

Install `git` explicitly so the job no longer depends on an incidental Recommends. This stays in the spirit of the job (stock apt packages, no `actions/setup-node`); `git` is a standard system tool, not a Node toolchain shortcut.

## Verification

The previously-failing job passes on this branch: the `nodeJsBaselineAptCompatibility` job concluded **success** on the push run for `fix/ci-stock-ubuntu-missing-git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)