### PR TITLE
chore(read): replace deprecated git-raw-commits with git-client

### DIFF
--- a/@commitlint/read/package.json
+++ b/@commitlint/read/package.json
@@ -36,13 +36,12 @@
   "dependencies": {
     "@commitlint/top-level": "workspace:^",
     "@commitlint/types": "workspace:^",
-    "git-raw-commits": "^5.0.0",
+    "@conventional-changelog/git-client": "^3.0.0",
     "tinyexec": "^1.0.0"
   },
   "devDependencies": {
     "@commitlint/test": "workspace:^",
-    "@commitlint/utils": "workspace:^",
-    "@types/git-raw-commits": "^5.0.0"
+    "@commitlint/utils": "workspace:^"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/@commitlint/read/src/get-history-commits.ts
+++ b/@commitlint/read/src/get-history-commits.ts
@@ -1,17 +1,17 @@
-import type { GitOptions } from "git-raw-commits";
-import { getRawCommits } from "git-raw-commits";
+import { GitClient, type GitLogParams } from "@conventional-changelog/git-client";
+
+export type HistoryCommitsOptions = GitLogParams & Record<string, unknown>;
 
 // Get commit messages from history
 export async function getHistoryCommits(
-	options: GitOptions,
+	options: HistoryCommitsOptions,
 	opts: { cwd?: string } = {},
 ): Promise<string[]> {
-	// Note: git-raw-commits v5 drops support for arbitrary git log arguments.
-	// We extract and handle 'skip' manually here to preserve backward compatibility.
-	// Other arbitrary arguments passed via gitLogArgs may be silently ignored by v5.
-	const { skip: skipRaw, ...gitOptions } = options as GitOptions & {
-		skip?: unknown;
-	};
+	// Note: @conventional-changelog/git-client doesn't support arbitrary git
+	// log arguments. We extract and handle 'skip' manually here to preserve
+	// backward compatibility. Other arbitrary arguments passed via gitLogArgs
+	// may be silently ignored.
+	const { skip: skipRaw, ...gitOptions } = options;
 
 	let skipNum = 0;
 	if (skipRaw !== undefined) {
@@ -21,8 +21,10 @@ export async function getHistoryCommits(
 		}
 	}
 
+	const client = new GitClient(opts.cwd ?? process.cwd());
+
 	const data: string[] = [];
-	for await (const commit of getRawCommits({ ...gitOptions, cwd: opts.cwd })) {
+	for await (const commit of client.getRawCommits(gitOptions)) {
 		if (skipNum > 0) {
 			skipNum--;
 			continue;

--- a/@commitlint/read/src/read.ts
+++ b/@commitlint/read/src/read.ts
@@ -1,7 +1,6 @@
 import { parseArgs } from "node:util";
-import type { GitOptions } from "git-raw-commits";
 
-import { getHistoryCommits } from "./get-history-commits.js";
+import { getHistoryCommits, type HistoryCommitsOptions } from "./get-history-commits.js";
 import { getEditCommit } from "./get-edit-commit.js";
 
 import { x } from "tinyexec";
@@ -60,12 +59,12 @@ export default async function getCommitMessages(
 	}
 
 	// Verify the two refs share a merge-base before handing off the range
-	// walk to git-raw-commits. In a shallow clone the common ancestor may
+	// walk to the git client. In a shallow clone the common ancestor may
 	// be missing, in which case `git log from..to` silently returns only
 	// the commits that happen to be present, hiding invalid commits in the
 	// unfetched portion of history.
 	if (from) {
-		// `to` is left undefined here when no --to was given; git-raw-commits
+		// `to` is left undefined here when no --to was given; the git client
 		// defaults it to HEAD, so we mirror that for the merge-base check.
 		const effectiveTo = to ?? "HEAD";
 		const mergeBase = await x("git", ["merge-base", from, effectiveTo], {
@@ -80,7 +79,7 @@ export default async function getCommitMessages(
 		}
 	}
 
-	let gitOptions: GitOptions = { from, to };
+	let gitOptions: HistoryCommitsOptions = { from, to };
 	if (gitLogArgs) {
 		const { values, positionals } = parseArgs({
 			args: gitLogArgs.split(" "),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,9 +575,9 @@ importers:
       '@commitlint/types':
         specifier: workspace:^
         version: link:../types
-      git-raw-commits:
-        specifier: ^5.0.0
-        version: 5.0.1(conventional-commits-parser@6.4.0)
+      '@conventional-changelog/git-client':
+        specifier: ^3.0.0
+        version: 3.0.1(conventional-commits-parser@7.0.0)
       tinyexec:
         specifier: ^1.0.0
         version: 1.2.4
@@ -588,9 +588,6 @@ importers:
       '@commitlint/utils':
         specifier: workspace:^
         version: link:../../@packages/utils
-      '@types/git-raw-commits':
-        specifier: ^5.0.0
-        version: 5.0.1
 
   '@commitlint/resolve-extends':
     dependencies:
@@ -928,12 +925,12 @@ packages:
     resolution: {integrity: sha512-YodnnnH1Cp+08nP8HGNJAIuB6L3/vdCTHVRTfF8Ik/wRCLOTsU9zwv3yO1cSPQRDa9CLYtE+UJ2K67r7CwMSFw==}
     engines: {node: '>=22.12.0'}
 
-  '@conventional-changelog/git-client@2.7.0':
-    resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
-    engines: {node: '>=18'}
+  '@conventional-changelog/git-client@3.0.1':
+    resolution: {integrity: sha512-5gW6MaxbrErdhK2YopOY6EXU7iyuE0132wK4h/6a6n1iqML9G063hU3ixOAMb7CEGDkcqVrgrRRbK16QtMpdEg==}
+    engines: {node: '>=22'}
     peerDependencies:
-      conventional-commits-filter: ^5.0.0
-      conventional-commits-parser: ^6.4.0
+      conventional-commits-filter: ^6.0.0
+      conventional-commits-parser: ^7.0.0
     peerDependenciesMeta:
       conventional-commits-filter:
         optional: true
@@ -2145,9 +2142,9 @@ packages:
     resolution: {integrity: sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@simple-libs/child-process-utils@1.0.2':
-    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
-    engines: {node: '>=18'}
+  '@simple-libs/child-process-utils@2.0.0':
+    resolution: {integrity: sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==}
+    engines: {node: '>=22'}
 
   '@simple-libs/stream-utils@1.2.0':
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
@@ -2281,9 +2278,6 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
-  '@types/git-raw-commits@5.0.1':
-    resolution: {integrity: sha512-sd4kgxJbuZF0RDy6cX7KlKSGiwqB1mqn8nriUbxt5e1F+MO/N4hJlhaYn0Omw4g2biClFpT5Mre07x7OkGt8tg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -3328,12 +3322,6 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
-    hasBin: true
-
-  git-raw-commits@5.0.1:
-    resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
-    engines: {node: '>=18'}
     deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
@@ -5696,13 +5684,13 @@ snapshots:
       picocolors: 1.1.1
     optional: true
 
-  '@conventional-changelog/git-client@2.7.0(conventional-commits-parser@6.4.0)':
+  '@conventional-changelog/git-client@3.0.1(conventional-commits-parser@7.0.0)':
     dependencies:
-      '@simple-libs/child-process-utils': 1.0.2
-      '@simple-libs/stream-utils': 1.2.0
+      '@simple-libs/child-process-utils': 2.0.0
+      '@simple-libs/stream-utils': 2.0.0
       semver: 7.8.5
     optionalDependencies:
-      conventional-commits-parser: 6.4.0
+      conventional-commits-parser: 7.0.0
 
   '@conventional-changelog/template@1.2.0': {}
 
@@ -6058,7 +6046,7 @@ snapshots:
       proggy: 3.0.0
       promise-all-reject-late: 1.0.1
       promise-call-limit: 3.0.2
-      semver: 7.7.2
+      semver: 7.8.5
       ssri: 12.0.0
       treeverse: 3.0.0
       walk-up-path: 4.0.0
@@ -6067,11 +6055,11 @@ snapshots:
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.7.2
+      semver: 7.8.5
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.7.2
+      semver: 7.8.5
 
   '@npmcli/git@6.0.3':
     dependencies:
@@ -6081,7 +6069,7 @@ snapshots:
       npm-pick-manifest: 10.0.0
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      semver: 7.7.2
+      semver: 7.8.5
       which: 5.0.0
 
   '@npmcli/git@7.0.2':
@@ -6092,7 +6080,7 @@ snapshots:
       lru-cache: 11.5.1
       npm-pick-manifest: 11.0.3
       proc-log: 6.1.0
-      semver: 7.7.2
+      semver: 7.8.5
       which: 6.0.1
 
   '@npmcli/installed-package-contents@3.0.0':
@@ -6118,7 +6106,7 @@ snapshots:
       json-parse-even-better-errors: 5.0.0
       pacote: 21.5.1
       proc-log: 6.1.0
-      semver: 7.7.2
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -6137,7 +6125,7 @@ snapshots:
       hosted-git-info: 9.0.3
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.7.2
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   '@npmcli/promise-spawn@8.0.3':
@@ -6172,7 +6160,7 @@ snapshots:
       enquirer: 2.3.6
       minimatch: 10.2.5
       nx: 22.7.6(@swc/core@1.15.43)
-      semver: 7.7.2
+      semver: 7.8.5
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
@@ -6656,11 +6644,12 @@ snapshots:
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.1
 
-  '@simple-libs/child-process-utils@1.0.2':
+  '@simple-libs/child-process-utils@2.0.0':
     dependencies:
-      '@simple-libs/stream-utils': 1.2.0
+      '@simple-libs/stream-utils': 2.0.0
 
-  '@simple-libs/stream-utils@1.2.0': {}
+  '@simple-libs/stream-utils@1.2.0':
+    optional: true
 
   '@simple-libs/stream-utils@2.0.0': {}
 
@@ -6756,10 +6745,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
-
-  '@types/git-raw-commits@5.0.1':
-    dependencies:
-      '@types/node': 22.20.0
 
   '@types/hast@3.0.4':
     dependencies:
@@ -7390,7 +7375,7 @@ snapshots:
       handlebars: 4.7.9
       json-stringify-safe: 5.0.1
       meow: 8.1.2
-      semver: 7.7.2
+      semver: 7.8.5
       split: 1.0.1
 
   conventional-commit-types@3.0.0: {}
@@ -7817,14 +7802,6 @@ snapshots:
       meow: 8.1.2
       split2: 3.2.2
 
-  git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
-    dependencies:
-      '@conventional-changelog/git-client': 2.7.0(conventional-commits-parser@6.4.0)
-      meow: 13.2.0
-    transitivePeerDependencies:
-      - conventional-commits-filter
-      - conventional-commits-parser
-
   git-remote-origin-url@2.0.0:
     dependencies:
       gitconfiglocal: 1.0.0
@@ -7833,7 +7810,7 @@ snapshots:
   git-semver-tags@5.0.1:
     dependencies:
       meow: 8.1.2
-      semver: 7.7.2
+      semver: 7.8.5
 
   git-up@7.0.0:
     dependencies:
@@ -8044,7 +8021,7 @@ snapshots:
       npm-package-arg: 13.0.1
       promzard: 2.0.0
       read: 4.1.0
-      semver: 7.7.2
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 6.0.2
 
@@ -8343,7 +8320,7 @@ snapshots:
       npm-package-arg: 13.0.1
       npm-registry-fetch: 19.1.0
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.8.5
       sigstore: 4.1.1
       ssri: 12.0.0
     transitivePeerDependencies:
@@ -8612,7 +8589,8 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  meow@13.2.0: {}
+  meow@13.2.0:
+    optional: true
 
   meow@14.1.0: {}
 
@@ -8892,7 +8870,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.2
+      semver: 7.8.5
       tar: 7.5.11
       tinyglobby: 0.2.12
       undici: 6.27.0
@@ -8919,7 +8897,7 @@ snapshots:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.2
-      semver: 7.7.2
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   npm-bundled@4.0.0:
@@ -8932,11 +8910,11 @@ snapshots:
 
   npm-install-checks@7.1.2:
     dependencies:
-      semver: 7.7.2
+      semver: 7.8.5
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.8.5
 
   npm-normalize-package-bin@4.0.0: {}
 
@@ -8946,14 +8924,14 @@ snapshots:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.8.5
       validate-npm-package-name: 6.0.2
 
   npm-package-arg@13.0.1:
     dependencies:
       hosted-git-info: 9.0.3
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.8.5
       validate-npm-package-name: 6.0.2
 
   npm-packlist@10.0.3:
@@ -8966,14 +8944,14 @@ snapshots:
       npm-install-checks: 7.1.2
       npm-normalize-package-bin: 4.0.0
       npm-package-arg: 12.0.2
-      semver: 7.7.2
+      semver: 7.8.5
 
   npm-pick-manifest@11.0.3:
     dependencies:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
       npm-package-arg: 13.0.1
-      semver: 7.7.2
+      semver: 7.8.5
 
   npm-registry-fetch@19.1.0:
     dependencies:


### PR DESCRIPTION
`git-raw-commits` is deprecated in favor of `@conventional-changelog/git-client`, which is now used directly via `GitClient.getRawCommits`.

## Description

Replaces the deprecated `git-raw-commits` dependency in `@commitlint/read` with its official successor, `@conventional-changelog/git-client`.

- `getHistoryCommits` now reads history through `new GitClient(cwd).getRawCommits(...)` instead of the standalone `getRawCommits` function.
- `cwd` is passed to the `GitClient` constructor (previously passed inline per call).
- The `GitOptions` type is replaced by a local `HistoryCommitsOptions` (`GitLogParams & Record<string, unknown>`), since the client exposes `GitLogParams`.
- Drops the now-unnecessary `@types/git-raw-commits` dev dependency — the client ships its own types.
- Dependency pinned as `^3.0.0` (resolves to `3.0.1`).

## Motivation and Context

1. `git-raw-commits` is deprecated and no longer maintained; its own deprecation notice recommends migrating to `@conventional-changelog/git-client`. This keeps `@commitlint/read` on a supported dependency with no intended change in behavior.

2. This migration removes the deprecation warning that end users see when installing `commitlint` packages:

```shell
% npm i -D @commitlint/cli @commitlint/config-conventional
npm warn deprecated git-raw-commits@5.0.1: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
```

## Usage examples

No user-facing API or configuration change — behavior is unchanged. Reading commit messages from a range continues to work as before:

```sh
commitlint --from HEAD~10 --to HEAD
```

## How Has This Been Tested?

- `@commitlint/read` unit tests pass (including `get-history-commits`).
- Type-checking is clean (`tsc --noEmit`) and Vitest reports no type errors.
- Verified the new dependency resolves and the direct `git-raw-commits@5` dependency is no longer pulled in by `@commitlint/read`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified that any documentation examples I added/changed actually work.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] For a feature/bug fix, my commits follow the [test-driven flow](https://github.com/conventional-changelog/commitlint/blob/master/.github/CONTRIBUTING.md#test-driven-development): a failing-test commit, then the implementation.
