### PR TITLE
docs(issue-template): ask for package manager and version

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -79,3 +79,11 @@ body:
       placeholder: vx.x.x
     validations:
       required: true
+  - type: input
+    id: package-manager
+    attributes:
+      label: "Package manager & version"
+      description: Include the install mode too — resolution differs a lot, especially Yarn Plug'n'Play (no node_modules)
+      placeholder: "e.g. yarn 4.17.0 (Plug'n'Play), pnpm 9.15.0, npm 10.8.0"
+    validations:
+      required: true


### PR DESCRIPTION
## What

Adds a required **Package manager & version** field to the bug report issue form.

## Why

Module resolution behaves very differently depending on the package manager and install mode — most notably Yarn Plug'n'Play, which has no `node_modules`. The template already collects `commitlint`, `git`, and `node` versions but never asks which package manager / install mode is in use, so it has to be dragged out of reporters after the fact.

This surfaced in #4864: the real root cause (pure-ESM preset resolution failing under Yarn PnP — same class as #2637 / #3936) only became clear once a reporter mentioned they were on Yarn 4 PnP.

A free-text input (rather than a dropdown) keeps it simple and future-proof as new tools appear; the field description nudges reporters to include the install mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
