### PR TITLE
chore(cz-commitlint): allow inquirer v14 compatibility

### DIFF
--- a/@commitlint/cz-commitlint/README.md
+++ b/@commitlint/cz-commitlint/README.md
@@ -13,9 +13,9 @@ The interactive process is inspired by [cz-conventional-changelog](https://githu
 ### Configure commitizen adapter
 
 ```bash
-npm install --save-dev @commitlint/cz-commitlint commitizen inquirer@9  # inquirer is required as peer dependency
+npm install --save-dev @commitlint/cz-commitlint commitizen inquirer@14 # inquirer is required as peer dependency
 # or yarn
-yarn add -D @commitlint/cz-commitlint commitizen inquirer@9             # inquirer is required as peer dependency
+yarn add -D @commitlint/cz-commitlint commitizen inquirer@14            # inquirer is required as peer dependency
 ```
 
 In package.json

--- a/@commitlint/cz-commitlint/package.json
+++ b/@commitlint/cz-commitlint/package.json
@@ -43,12 +43,12 @@
     "word-wrap": "^1.2.5"
   },
   "devDependencies": {
-    "@types/inquirer": "^9.0.7",
-    "commitizen": "^4.2.4"
+    "commitizen": "^4.2.4",
+    "inquirer": "^14.0.2"
   },
   "peerDependencies": {
     "commitizen": "^4.0.3",
-    "inquirer": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "inquirer": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^14.0.0"
   },
   "config": {
     "commitizen": {

--- a/@commitlint/cz-commitlint/src/Process.test.ts
+++ b/@commitlint/cz-commitlint/src/Process.test.ts
@@ -1,14 +1,14 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import { QualifiedRules, RuleConfigSeverity, UserPromptConfig } from "@commitlint/types";
-import { Answers, DistinctQuestion } from "inquirer";
 
 import process from "./Process.js";
+import { PromptAnswers, PromptQuestion } from "./types.js";
 
 const mockShowTitle = vi.fn();
 const mockShowValidation = vi.fn((message) => message);
 
 // mock inquirer
-const mockPrompt = vi.fn(async function (questions: DistinctQuestion[], answers: Answers) {
+const mockPrompt = vi.fn(async function (questions: PromptQuestion[], answers: PromptAnswers) {
 	for (const { name, message, when, filter, validate } of questions) {
 		if (typeof when !== "function" || (await when(answers))) {
 			const title =
@@ -32,9 +32,9 @@ const mockPrompt = vi.fn(async function (questions: DistinctQuestion[], answers:
 	}
 });
 
-function InquirerFactory(answers: Answers) {
+function InquirerFactory(answers: PromptAnswers) {
 	const inquirer = {
-		async prompt(questions: DistinctQuestion[]) {
+		async prompt(questions: PromptQuestion[]) {
 			await mockPrompt(questions, answers);
 			return answers;
 		},

--- a/@commitlint/cz-commitlint/src/Process.ts
+++ b/@commitlint/cz-commitlint/src/Process.ts
@@ -1,5 +1,5 @@
 import { QualifiedRules, UserPromptConfig } from "@commitlint/types";
-import type { Answers, DistinctQuestion } from "inquirer";
+import type { PromptAnswers, PromptQuestion } from "./types.js";
 
 import {
 	combineCommitMessage as combineBody,
@@ -20,7 +20,7 @@ export default async function (
 	rules: QualifiedRules,
 	prompts: UserPromptConfig,
 	inquirer: {
-		prompt(questions: DistinctQuestion[]): Promise<Answers>;
+		prompt(questions: PromptQuestion[]): Promise<PromptAnswers>;
 	},
 ): Promise<string> {
 	setRules(rules);

--- a/@commitlint/cz-commitlint/src/Question.test.ts
+++ b/@commitlint/cz-commitlint/src/Question.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, vi } from "vitest";
 import pc from "picocolors";
-import inquirer, { Answers, InputQuestionOptions } from "inquirer";
+import inquirer from "inquirer";
 
 import Question from "./Question.js";
+import { PromptAnswers } from "./types.js";
 
 const MESSAGES = {
 	skip: "(press enter to skip)",
@@ -54,12 +55,12 @@ describe("name", () => {
 });
 
 describe("type", () => {
-	test('should return "list" type when enumList is array and multipleSelectDefaultDelimiter is undefined', () => {
+	test('should return "select" type when enumList is array and multipleSelectDefaultDelimiter is undefined', () => {
 		const question = new Question("scope", {
 			...QUESTION_CONFIG,
 			enumList: ["cli", "core"],
 		}).question;
-		expect(question).toHaveProperty("type", "list");
+		expect(question).toHaveProperty("type", "select");
 		expect(question).toHaveProperty("choices", ["cli", "core"]);
 		expect(question).not.toHaveProperty("transformer");
 	});
@@ -81,7 +82,7 @@ describe("type", () => {
 			enumList: ["cli", "core"],
 			skip: true,
 		}).question;
-		expect(question).toHaveProperty("type", "list");
+		expect(question).toHaveProperty("type", "select");
 		expect(question).toHaveProperty("choices", [
 			"cli",
 			"core",
@@ -112,6 +113,10 @@ describe("type", () => {
 		expect(question).toHaveProperty("transformer", expect.any(Function));
 	});
 });
+
+type QuestionWithTransformer = {
+	transformer?: (input: string, answers: PromptAnswers, context?: unknown) => string;
+};
 
 describe("message", () => {
 	test("should display title when it is not input", () => {
@@ -176,7 +181,7 @@ describe("message", () => {
 	test("should execute function beforeQuestionStart when init message", () => {
 		const mockFn = vi.fn();
 		class CustomQuestion extends Question {
-			beforeQuestionStart(answers: Answers): void {
+			beforeQuestionStart(answers: PromptAnswers): void {
 				mockFn(answers);
 			}
 		}
@@ -303,7 +308,7 @@ describe("transformer", () => {
 			fullStopFn: (input: string) => input + "!",
 		}).question;
 
-		expect((question as InputQuestionOptions)?.transformer?.("xxxx", {}, {})).toBe("Xxxx!");
+		expect((question as QuestionWithTransformer)?.transformer?.("xxxx", {}, {})).toBe("Xxxx!");
 	});
 
 	test("should char count with green color when in the limit range", () => {
@@ -312,7 +317,7 @@ describe("transformer", () => {
 			maxLength: 5,
 		}).question;
 
-		expect((question as InputQuestionOptions)?.transformer?.("xxx", {}, {})).toEqual(
+		expect((question as QuestionWithTransformer)?.transformer?.("xxx", {}, {})).toEqual(
 			pc.green(`(3) xxx`),
 		);
 
@@ -321,7 +326,7 @@ describe("transformer", () => {
 			minLength: 2,
 		}).question;
 
-		expect((question as InputQuestionOptions)?.transformer?.("xxx", {}, {})).toEqual(
+		expect((question as QuestionWithTransformer)?.transformer?.("xxx", {}, {})).toEqual(
 			pc.green(`(3) xxx`),
 		);
 	});
@@ -332,7 +337,7 @@ describe("transformer", () => {
 			maxLength: 5,
 		}).question;
 
-		expect((question as InputQuestionOptions)?.transformer?.("xxxxxx", {}, {})).toEqual(
+		expect((question as QuestionWithTransformer)?.transformer?.("xxxxxx", {}, {})).toEqual(
 			pc.red(`(6) xxxxxx`),
 		);
 
@@ -341,13 +346,15 @@ describe("transformer", () => {
 			minLength: 2,
 		}).question;
 
-		expect((question as InputQuestionOptions)?.transformer?.("x", {}, {})).toEqual(pc.red(`(1) x`));
+		expect((question as QuestionWithTransformer)?.transformer?.("x", {}, {})).toEqual(
+			pc.red(`(1) x`),
+		);
 	});
 });
 
 describe("inquirer question", () => {
 	test('should pass "when" and "default" field to inquirer question', () => {
-		const when = (answers: Answers) => !!answers.header;
+		const when = (answers: PromptAnswers) => !!answers.header;
 		const question = new Question("body", {
 			...QUESTION_CONFIG,
 			when,

--- a/@commitlint/cz-commitlint/src/Question.ts
+++ b/@commitlint/cz-commitlint/src/Question.ts
@@ -1,22 +1,26 @@
 import { PromptMessages, PromptName } from "@commitlint/types";
 import pc from "picocolors";
-import inquirer, { Answers, ChoiceCollection, DistinctQuestion } from "inquirer";
+import inquirer from "inquirer";
 
+import { PromptAnswers, PromptQuestion } from "./types.js";
 import { CaseFn } from "./utils/case-fn.js";
 import { FullStopFn } from "./utils/full-stop-fn.js";
 
 export type QuestionConfig = {
+	enumList?: Array<
+		| string
+		| {
+				name: string;
+				value: string;
+		  }
+	> | null;
 	title: string;
 	messages: PromptMessages;
 	maxLength?: number;
 	minLength?: number;
 	defaultValue?: string;
-	when?: DistinctQuestion["when"];
+	when?: PromptQuestion["when"];
 	skip?: boolean;
-	enumList?: ChoiceCollection<{
-		name: string;
-		value: string;
-	}> | null;
 	multipleValueDelimiters?: RegExp;
 	multipleSelectDefaultDelimiter?: string;
 	fullStopFn?: FullStopFn;
@@ -24,7 +28,7 @@ export type QuestionConfig = {
 };
 
 export default class Question {
-	private _question: Readonly<DistinctQuestion>;
+	private _question: Readonly<PromptQuestion>;
 	private messages: PromptMessages;
 	private skip: boolean;
 	private _maxLength: number;
@@ -68,7 +72,7 @@ export default class Question {
 
 		if (enumList && Array.isArray(enumList)) {
 			this._question = {
-				type: multipleSelectDefaultDelimiter ? "checkbox" : "list",
+				type: multipleSelectDefaultDelimiter ? "checkbox" : "select",
 				choices: skip
 					? [
 							...enumList,
@@ -105,7 +109,7 @@ export default class Question {
 		return this.messages[key] ?? "";
 	}
 
-	get question(): Readonly<DistinctQuestion> {
+	get question(): Readonly<PromptQuestion> {
 		return this._question;
 	}
 
@@ -125,7 +129,7 @@ export default class Question {
 		this._minLength = minLength;
 	}
 
-	protected beforeQuestionStart(_answers: Answers): void {
+	protected beforeQuestionStart(_answers: PromptAnswers): void {
 		return;
 	}
 
@@ -172,7 +176,7 @@ export default class Question {
 		return this.fullStopFn(toCased);
 	}
 
-	protected transformer(input: string, _answers: Answers): string {
+	protected transformer(input: string, _answers: PromptAnswers): string {
 		const output = this.filter(input);
 
 		if (this.maxLength === Infinity && this.minLength === 0) {
@@ -183,7 +187,7 @@ export default class Question {
 		return color("(" + output.length + ") " + output);
 	}
 
-	protected decorateMessage(_answers: Answers): string {
+	protected decorateMessage(_answers: PromptAnswers): string {
 		if (this.beforeQuestionStart) {
 			this.beforeQuestionStart(_answers);
 		}

--- a/@commitlint/cz-commitlint/src/SectionBody.ts
+++ b/@commitlint/cz-commitlint/src/SectionBody.ts
@@ -1,13 +1,13 @@
-import { Answers, DistinctQuestion } from "inquirer";
 import wrap from "word-wrap";
 
 import Question from "./Question.js";
 import getRuleQuestionConfig from "./services/getRuleQuestionConfig.js";
 import { getRule } from "./store/rules.js";
+import { PromptAnswers, PromptQuestion } from "./types.js";
 import getLeadingBlankFn from "./utils/leading-blank-fn.js";
 import { getMaxLength } from "./utils/rules.js";
 
-export function getQuestions(): Array<DistinctQuestion> {
+export function getQuestions(): Array<PromptQuestion> {
 	// body
 	const questionConfig = getRuleQuestionConfig("body");
 
@@ -15,7 +15,7 @@ export function getQuestions(): Array<DistinctQuestion> {
 	else return [new Question("body", questionConfig).question];
 }
 
-export function combineCommitMessage(answers: Answers): string {
+export function combineCommitMessage(answers: PromptAnswers): string {
 	const maxLineLength = getMaxLength(getRule("body", "max-line-length"));
 	const leadingBlankFn = getLeadingBlankFn(getRule("body", "leading-blank"));
 	const { body, breakingBody, issuesBody } = answers;

--- a/@commitlint/cz-commitlint/src/SectionFooter.ts
+++ b/@commitlint/cz-commitlint/src/SectionFooter.ts
@@ -1,11 +1,11 @@
 import { PromptName } from "@commitlint/types";
-import { Answers, DistinctQuestion } from "inquirer";
 import wrap from "word-wrap";
 
 import Question, { QuestionConfig } from "./Question.js";
 import getRuleQuestionConfig from "./services/getRuleQuestionConfig.js";
 import { getPromptMessages, getPromptQuestions } from "./store/prompts.js";
 import { getRule } from "./store/rules.js";
+import { PromptAnswers, PromptQuestion } from "./types.js";
 import getLeadingBlankFn from "./utils/leading-blank-fn.js";
 import { getMaxLength } from "./utils/rules.js";
 
@@ -22,7 +22,7 @@ export class FooterQuestion extends Question {
 		this.footerMaxLength = footerMaxLength ?? Infinity;
 		this.footerMinLength = footerMinLength ?? 0;
 	}
-	beforeQuestionStart(answers: Answers): void {
+	beforeQuestionStart(answers: PromptAnswers): void {
 		const footerRemainLength =
 			this.footerMaxLength - combineCommitMessage(answers).length - "\n".length;
 		this.maxLength = Math.min(this.maxLength, footerRemainLength);
@@ -30,7 +30,7 @@ export class FooterQuestion extends Question {
 	}
 }
 
-export function getQuestions(): Array<DistinctQuestion> {
+export function getQuestions(): Array<PromptQuestion> {
 	const footerQuestionConfig = getRuleQuestionConfig("footer");
 
 	if (!footerQuestionConfig) return [];
@@ -68,7 +68,7 @@ export function getQuestions(): Array<DistinctQuestion> {
 
 			if (name === "breakingBody") {
 				Object.assign(questionConfigs, {
-					when: (answers: Answers) => {
+					when: (answers: PromptAnswers) => {
 						return answers.isBreaking && !answers.body;
 					},
 				});
@@ -76,7 +76,7 @@ export function getQuestions(): Array<DistinctQuestion> {
 
 			if (name === "breaking") {
 				Object.assign(questionConfigs, {
-					when: (answers: Answers) => {
+					when: (answers: PromptAnswers) => {
 						return answers.isBreaking;
 					},
 				});
@@ -90,7 +90,7 @@ export function getQuestions(): Array<DistinctQuestion> {
 
 			if (name === "issuesBody") {
 				Object.assign(questionConfigs, {
-					when: (answers: Answers) => {
+					when: (answers: PromptAnswers) => {
 						return answers.isIssueAffected && !answers.body && !answers.breakingBody;
 					},
 				});
@@ -98,7 +98,7 @@ export function getQuestions(): Array<DistinctQuestion> {
 
 			if (name === "issues") {
 				Object.assign(questionConfigs, {
-					when: (answers: Answers) => {
+					when: (answers: PromptAnswers) => {
 						return answers.isIssueAffected;
 					},
 				});
@@ -116,7 +116,7 @@ export function getQuestions(): Array<DistinctQuestion> {
 		});
 }
 
-export function combineCommitMessage(answers: Answers): string {
+export function combineCommitMessage(answers: PromptAnswers): string {
 	// TODO references-empty
 	// TODO signed-off-by
 	const maxLineLength = getMaxLength(getRule("footer", "max-line-length"));

--- a/@commitlint/cz-commitlint/src/SectionHeader.ts
+++ b/@commitlint/cz-commitlint/src/SectionHeader.ts
@@ -1,9 +1,9 @@
 import { PromptName, RuleField } from "@commitlint/types";
-import { Answers, DistinctQuestion } from "inquirer";
 
 import Question, { QuestionConfig } from "./Question.js";
 import getRuleQuestionConfig from "./services/getRuleQuestionConfig.js";
 import { getPromptSettings } from "./store/prompts.js";
+import { PromptAnswers, PromptQuestion } from "./types.js";
 
 export class HeaderQuestion extends Question {
 	headerMaxLength: number;
@@ -18,7 +18,7 @@ export class HeaderQuestion extends Question {
 		this.headerMaxLength = headerMaxLength ?? Infinity;
 		this.headerMinLength = headerMinLength ?? 0;
 	}
-	beforeQuestionStart(answers: Answers): void {
+	beforeQuestionStart(answers: PromptAnswers): void {
 		const headerRemainLength = this.headerMaxLength - combineCommitMessage(answers).length;
 		// Reserve 1 char for '!' when useExclamationMark is enabled.
 		const reservedLength = getPromptSettings()["useExclamationMark"] ? 1 : 0;
@@ -28,7 +28,7 @@ export class HeaderQuestion extends Question {
 	}
 }
 
-export function combineCommitMessage(answers: Answers): string {
+export function combineCommitMessage(answers: PromptAnswers): string {
 	const { type = "", scope = "", subject = "", isBreaking } = answers;
 	const hasPrefix = Boolean(type || scope);
 	const breakingMark =
@@ -42,9 +42,9 @@ export function combineCommitMessage(answers: Answers): string {
 	}
 }
 
-export function getQuestions(): Array<DistinctQuestion> {
+export function getQuestions(): Array<PromptQuestion> {
 	// header: type, scope, subject
-	const questions: Array<DistinctQuestion> = [];
+	const questions: Array<PromptQuestion> = [];
 
 	const headerRuleFields: RuleField[] = ["type", "scope", "subject"];
 	const headerRuleQuestionConfig = getRuleQuestionConfig("header");

--- a/@commitlint/cz-commitlint/src/index.ts
+++ b/@commitlint/cz-commitlint/src/index.ts
@@ -1,5 +1,5 @@
 import load from "@commitlint/load";
-import type { Answers, DistinctQuestion } from "inquirer";
+import type { PromptAnswers, PromptQuestion } from "./types.js";
 
 import process from "./Process.js";
 
@@ -12,7 +12,7 @@ type Commit = (message: string) => void;
  */
 export function prompter(
 	inquirerIns: {
-		prompt(questions: DistinctQuestion[]): Promise<Answers>;
+		prompt(questions: PromptQuestion[]): Promise<PromptAnswers>;
 	},
 	commit: Commit,
 ): void {

--- a/@commitlint/cz-commitlint/src/types.ts
+++ b/@commitlint/cz-commitlint/src/types.ts
@@ -4,3 +4,20 @@ export type Rule =
 	| Readonly<[RuleConfigSeverity.Disabled]>
 	| Readonly<[RuleConfigSeverity, RuleConfigCondition]>
 	| Readonly<[RuleConfigSeverity, RuleConfigCondition, unknown]>;
+
+export type PromptAnswers = Record<string, any>;
+
+export type PromptQuestion = {
+	name?: string;
+	type?: string;
+	choices?: Array<string | { name: string; value: string } | unknown>;
+	default?: unknown;
+	when?: (answers: PromptAnswers) => boolean | Promise<boolean>;
+	validate?: (
+		input: string,
+		answers?: PromptAnswers,
+	) => boolean | string | Promise<boolean | string>;
+	filter?: (input: string | string[], answers: PromptAnswers) => string;
+	transformer?: (input: string, answers: PromptAnswers) => string;
+	message?: string | ((answers: PromptAnswers) => string | Promise<string>);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,9 +338,6 @@ importers:
       '@commitlint/types':
         specifier: workspace:^
         version: link:../types
-      inquirer:
-        specifier: ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
-        version: 9.3.8(@types/node@22.20.0)
       is-plain-obj:
         specifier: ^4.1.0
         version: 4.1.0
@@ -351,12 +348,12 @@ importers:
         specifier: ^1.2.5
         version: 1.2.5
     devDependencies:
-      '@types/inquirer':
-        specifier: ^9.0.7
-        version: 9.0.10
       commitizen:
         specifier: ^4.2.4
         version: 4.3.2(@types/node@22.20.0)(typescript@6.0.3)
+      inquirer:
+        specifier: ^14.0.2
+        version: 14.0.2(@types/node@22.20.0)
 
   '@commitlint/ensure':
     dependencies:
@@ -1142,9 +1139,22 @@ packages:
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/checkbox@4.3.2':
     resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1160,9 +1170,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/core@10.3.2':
     resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1178,9 +1206,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/expand@4.0.23':
     resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1196,13 +1242,35 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/figures@1.0.15':
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
 
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/input@4.3.1':
     resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1218,9 +1286,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/password@4.0.23':
     resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1236,9 +1322,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/rawlist@4.1.11':
     resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1254,6 +1358,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/select@4.4.2':
     resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
     engines: {node: '>=18'}
@@ -1263,9 +1376,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/type@3.0.10':
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3190,8 +3321,17 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.3:
     resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
@@ -3531,6 +3671,15 @@ packages:
   inquirer@12.9.6:
     resolution: {integrity: sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  inquirer@14.0.2:
+    resolution: {integrity: sha512-VsSx1JneSNp3ld1veMTLe+UDcUD8Tw2/jjOthhkX3/IX2q+xHhVELifeb/hsb1fBw31pabEPNUf/xUOyb+KZjA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -4169,6 +4318,10 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
@@ -5825,6 +5978,8 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
+  '@inquirer/ansi@2.0.7': {}
+
   '@inquirer/checkbox@4.3.2(@types/node@22.20.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -5835,10 +5990,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.0
 
+  '@inquirer/checkbox@5.2.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
   '@inquirer/confirm@5.1.21(@types/node@22.20.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@22.20.0)
       '@inquirer/type': 3.0.10(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/confirm@6.1.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
     optionalDependencies:
       '@types/node': 22.20.0
 
@@ -5855,11 +6026,31 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.0
 
+  '@inquirer/core@11.2.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.20.0
+
   '@inquirer/editor@4.2.23(@types/node@22.20.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@22.20.0)
       '@inquirer/external-editor': 1.0.3(@types/node@22.20.0)
       '@inquirer/type': 3.0.10(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/editor@5.2.2(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/external-editor': 3.0.3(@types/node@22.20.0)
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
     optionalDependencies:
       '@types/node': 22.20.0
 
@@ -5871,7 +6062,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.0
 
+  '@inquirer/expand@5.1.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
   '@inquirer/external-editor@1.0.3(@types/node@22.20.0)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/external-editor@3.0.3(@types/node@22.20.0)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.3
@@ -5880,10 +6085,19 @@ snapshots:
 
   '@inquirer/figures@1.0.15': {}
 
+  '@inquirer/figures@2.0.7': {}
+
   '@inquirer/input@4.3.1(@types/node@22.20.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@22.20.0)
       '@inquirer/type': 3.0.10(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/input@5.1.2(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
     optionalDependencies:
       '@types/node': 22.20.0
 
@@ -5894,11 +6108,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.0
 
+  '@inquirer/number@4.1.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
   '@inquirer/password@4.0.23(@types/node@22.20.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/core': 10.3.2(@types/node@22.20.0)
       '@inquirer/type': 3.0.10(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/password@5.1.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
     optionalDependencies:
       '@types/node': 22.20.0
 
@@ -5917,11 +6146,33 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.0
 
+  '@inquirer/prompts@8.5.2(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1(@types/node@22.20.0)
+      '@inquirer/confirm': 6.1.1(@types/node@22.20.0)
+      '@inquirer/editor': 5.2.2(@types/node@22.20.0)
+      '@inquirer/expand': 5.1.1(@types/node@22.20.0)
+      '@inquirer/input': 5.1.2(@types/node@22.20.0)
+      '@inquirer/number': 4.1.1(@types/node@22.20.0)
+      '@inquirer/password': 5.1.1(@types/node@22.20.0)
+      '@inquirer/rawlist': 5.3.1(@types/node@22.20.0)
+      '@inquirer/search': 4.2.1(@types/node@22.20.0)
+      '@inquirer/select': 5.2.1(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
   '@inquirer/rawlist@4.1.11(@types/node@22.20.0)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@22.20.0)
       '@inquirer/type': 3.0.10(@types/node@22.20.0)
       yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/rawlist@5.3.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
     optionalDependencies:
       '@types/node': 22.20.0
 
@@ -5931,6 +6182,14 @@ snapshots:
       '@inquirer/figures': 1.0.15
       '@inquirer/type': 3.0.10(@types/node@22.20.0)
       yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/search@4.2.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
     optionalDependencies:
       '@types/node': 22.20.0
 
@@ -5944,7 +6203,20 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.0
 
+  '@inquirer/select@5.2.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
   '@inquirer/type@3.0.10(@types/node@22.20.0)':
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/type@4.0.7(@types/node@22.20.0)':
     optionalDependencies:
       '@types/node': 22.20.0
 
@@ -7663,7 +7935,17 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.3: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fault@2.0.1:
     dependencies:
@@ -8026,6 +8308,17 @@ snapshots:
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  inquirer@14.0.2(@types/node@22.20.0):
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@22.20.0)
+      '@inquirer/prompts': 8.5.2(@types/node@22.20.0)
+      '@inquirer/type': 4.0.7(@types/node@22.20.0)
+      mute-stream: 3.0.0
+      run-async: 4.0.6
     optionalDependencies:
       '@types/node': 22.20.0
 
@@ -8845,6 +9138,8 @@ snapshots:
   mute-stream@1.0.0: {}
 
   mute-stream@2.0.0: {}
+
+  mute-stream@3.0.0: {}
 
   nanoid@3.3.15: {}
 


### PR DESCRIPTION
## Description

Update `@commitlint/cz-commitlint` for inquirer 14 compatibility while preserving existing prompt behavior.

## Motivation and Context

`@commitlint/cz-commitlint` had a peer range capped at inquirer 12, which caused downstream dependency-management friction for projects using newer inquirer versions.

This change addresses that by:
- extending the inquirer peer range to include v14
- switching single-select question type from `list` to `select` (required by modern inquirer)
- replacing direct dependence on strict inquirer question typings with package-local prompt interfaces so existing adapter behavior remains intact

Fixes #4877.

## Usage examples

```js
// commitlint.config.js
module.exports = {
  extends: ['@commitlint/config-conventional'],
};
```

```sh
npm i -D @commitlint/cz-commitlint commitizen inquirer@14
npm run commit
```

## How Has This Been Tested?

- `pnpm build`
- `pnpm test`
- local interactive smoke test via commitizen prompt:
  - stage a file
  - run `pnpm --filter @commitlint/cz-commitlint exec git-cz`
  - verify prompt flow and message generation

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have verified that any documentation examples I added/changed actually work.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] For a feature/bug fix, my commits follow the [test-driven flow](https://github.com/conventional-changelog/commitlint/blob/master/.github/CONTRIBUTING.md#test-driven-development): a failing-test commit, then the implementation.