### PR TITLE
docs: fix typos in comments and JSDoc

### DIFF
--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -465,7 +465,7 @@ function getEditValue(flags: CliFlags) {
 	// This does not work properly with win32 systems, where env variable declarations
 	// use a different syntax
 	// See https://github.com/conventional-changelog/commitlint/issues/103 for details
-	// This has been superceded by the `-E GIT_PARAMS` / `-E HUSKY_GIT_PARAMS`
+	// This has been superseded by the `-E GIT_PARAMS` / `-E HUSKY_GIT_PARAMS`
 	const isGitParams = edit === "$GIT_PARAMS" || edit === "%GIT_PARAMS%";
 	const isHuskyParams = edit === "$HUSKY_GIT_PARAMS" || edit === "%HUSKY_GIT_PARAMS%";
 

--- a/@commitlint/format/src/format.test.ts
+++ b/@commitlint/format/src/format.test.ts
@@ -327,7 +327,7 @@ test("format result prints help for warnings", () => {
 	expect(actual).toEqual(expect.arrayContaining([expect.stringContaining("Get help:")]));
 });
 
-test("format result help cotains options.helpUrl", () => {
+test("format result help contains options.helpUrl", () => {
 	const helpUrl = "https://example.com";
 
 	const actual = formatResult(

--- a/@commitlint/load/src/utils/plugin-naming.ts
+++ b/@commitlint/load/src/utils/plugin-naming.ts
@@ -82,7 +82,7 @@ export function getShorthandName(fullname: string) {
 /**
  * Gets the scope (namespace) of a term.
  * @param {string} term The term which may have the namespace.
- * @returns {string} The namepace of the term if it has one.
+ * @returns {string} The namespace of the term if it has one.
  */
 export function getNamespaceFromTerm(term: string) {
 	const match = NAMESPACE_REGEX.exec(term);


### PR DESCRIPTION
## Summary

Fix three genuine typos found in source code comments and a JSDoc block:

- `superceded` → `superseded` in `@commitlint/cli/src/cli.ts` (inline comment)
- `namepace` → `namespace` in `@commitlint/load/src/utils/plugin-naming.ts` (JSDoc `@returns`)
- `cotains` → `contains` in `@commitlint/format/src/format.test.ts` (test name string)

These are straightforward spelling corrections with no behavior change.