### PR TITLE
docs: fix Deno setup without package.json

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -24,7 +24,7 @@ bun add -d @commitlint/cli @commitlint/config-conventional
 
 ```sh [deno]
 deno add -D npm:@commitlint/cli npm:@commitlint/config-conventional
-# Create a local node_modules directory for Node.js module resolution
+# Deno 2 only: create a local node_modules directory for Node.js module resolution
 deno install --node-modules-dir=auto
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -24,6 +24,8 @@ bun add -d @commitlint/cli @commitlint/config-conventional
 
 ```sh [deno]
 deno add -D npm:@commitlint/cli npm:@commitlint/config-conventional
+# Create a local node_modules directory for Node.js module resolution
+deno install --node-modules-dir=auto
 ```
 
 :::


### PR DESCRIPTION
## Description

Add a local node_modules installation step to the Deno setup instructions.

## Motivation and Context

Deno projects without a package.json resolve npm packages from the global cache by default. commitlint loads shareable configs through Node.js module resolution, so the documented command fails in that setup. Installing with --node-modules-dir=auto gives commitlint the local module tree it expects.

Fixes #4593.

## Usage examples

    deno add -D npm:@commitlint/cli npm:@commitlint/config-conventional
    deno install --node-modules-dir=auto

## How Has This Been Tested?

- Checked the command syntax and option availability with Deno 2.6.3
- Previewed the updated Markdown on GitHub

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have verified that any documentation examples I added/changed actually work.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] For a feature/bug fix, my commits follow the test-driven flow.