### PR TITLE
docs(config-conventional): document rules that go beyond the spec

### DIFF
--- a/@commitlint/config-conventional/README.md
+++ b/@commitlint/config-conventional/README.md
@@ -12,6 +12,28 @@ npm install --save-dev @commitlint/config-conventional @commitlint/cli
 echo "export default {extends: ['@commitlint/config-conventional']};" > commitlint.config.js
 ```
 
+## Beyond the specification
+
+This config enforces the [Conventional Commits](https://conventionalcommits.org/) convention, plus a few stylistic rules the specification itself does not require.
+The stylistic rules are inherited from the [Angular commit convention](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md) commitlint originates from:
+
+- `header-max-length`, `body-max-line-length` and `footer-max-line-length` limit lines to 100 characters to keep messages readable in git tooling — body and footer lines containing URLs are exempt
+- `type-enum` restricts the type to the list below, while the specification allows any type
+- `type-case`, `subject-case` and `subject-full-stop` normalize style: lower-case types, no sentence-case, start-case, pascal-case or upper-case subjects, no trailing full-stop
+
+These rules narrow the specification — they do not conflict with it.
+If you prefer the plain specification, override the rules you do not want in your config:
+
+```js
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0],
+  },
+};
+```
+
 ## Rules
 
 ### Problems

--- a/@commitlint/config-conventional/README.md
+++ b/@commitlint/config-conventional/README.md
@@ -12,6 +12,28 @@ npm install --save-dev @commitlint/config-conventional @commitlint/cli
 echo "export default {extends: ['@commitlint/config-conventional']};" > commitlint.config.js
 ```
 
+## Beyond the specification
+
+This config enforces the [Conventional Commits](https://conventionalcommits.org/) convention, plus a few stylistic rules the specification itself does not require.
+The stylistic rules are inherited from the [Angular commit convention](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md) commitlint originates from:
+
+- `header-max-length`, `body-max-line-length` and `footer-max-line-length` limit lines to 100 characters to keep messages readable in git tooling — lines containing URLs are exempt
+- `type-enum` restricts the type to the list below, while the specification allows any type
+- `type-case`, `subject-case` and `subject-full-stop` normalize style: lower-case types, no sentence-case subjects, no trailing full-stop
+
+These rules narrow the specification — they do not conflict with it.
+If you prefer the plain specification, override the rules you do not want in your config:
+
+```js
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0],
+  },
+};
+```
+
 ## Rules
 
 ### Problems


### PR DESCRIPTION
## Description

Adds a short "Beyond the specification" section to the `@commitlint/config-conventional` README, between "Getting started" and "Rules". It states which rules are stylistic additions on top of the Conventional Commits specification (`header-max-length`, `body-max-line-length`, `footer-max-line-length`, `type-enum`, `type-case`, `subject-case`, `subject-full-stop`), where they come from (the Angular commit convention commitlint originates from, see #303 / #436), notes that body and footer lines containing URLs are exempt from the line-length rules (#4486, since v20) — `header-max-length` has no URL exemption — and shows how to override the rules for a spec-only setup.

## Motivation and Context

Suggestion for #4908, which points out that the body/footer line-length defaults are not part of the Conventional Commits specification. The limits are an intentional design decision dating back to #303 and #436, but the README currently only says "enforcing conventional commits" without mentioning the additional house style. Documenting the difference was one of the outcomes proposed in the issue.

The framing "these rules narrow the specification — they do not conflict with it" is deliberate: every rule only rejects some spec-valid messages, none demands anything spec-invalid.

## Usage examples

Not applicable — documentation only. The override snippet added to the README:

```js
export default {
	extends: ["@commitlint/config-conventional"],
	rules: {
		"body-max-line-length": [0],
		"footer-max-line-length": [0],
	},
};
```

## How Has This Been Tested?

Every claim in the section was verified against the built workspace CLI, each exemption paired with a control proving the rule fires:

- header >100 chars containing a URL — fails (`header-max-length` has no URL exemption)
- body and footer lines >100 chars containing a URL — pass (URL exemption); the same lines without a URL — fail
- sentence-case, start-case, pascal-case and upper-case subjects — all fail; a lower-case subject passes
- a long plain body with the README override snippet — passes

README formatted with `oxfmt` via lint-staged.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Documentation only.

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have verified that any documentation examples I added/changed actually work.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] For a feature/bug fix, my commits follow the [test-driven flow](https://github.com/conventional-changelog/commitlint/blob/master/.github/CONTRIBUTING.md#test-driven-development): a failing-test commit, then the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
