### PR TITLE
fix(container): resolve packages from TypeScript configs

### DIFF
--- a/.github/fixtures/docker/commitlint.config.ts
+++ b/.github/fixtures/docker/commitlint.config.ts
@@ -1,0 +1,8 @@
+import { RuleConfigSeverity } from "@commitlint/types";
+import type { UserConfig } from "@commitlint/types";
+
+export default {
+	rules: {
+		"header-max-length": [RuleConfigSeverity.Error, "always", 100],
+	},
+} satisfies UserConfig;

--- a/.github/fixtures/docker/commitlint.config.ts
+++ b/.github/fixtures/docker/commitlint.config.ts
@@ -1,8 +1,0 @@
-import { RuleConfigSeverity } from "@commitlint/types";
-import type { UserConfig } from "@commitlint/types";
-
-export default {
-	rules: {
-		"header-max-length": [RuleConfigSeverity.Error, "always", 100],
-	},
-} satisfies UserConfig;

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -46,12 +46,12 @@ import type { UserConfig } from "@commitlint/types";
 export default {
 	extends: ["@commitlint/config-conventional"],
 	rules: {
-		"header-max-length": [RuleConfigSeverity.Error, "always", 100],
+		"header-max-length": [RuleConfigSeverity.Error, "always", 50],
 	},
 } satisfies UserConfig;
 CONFIG
 echo "fix: load TypeScript config" | commitlint --config /tmp/commitlint.config.ts
-if echo "fix: this TypeScript configuration rule rejects a header that is deliberately longer than one hundred characters in the container smoke test" | commitlint --config /tmp/commitlint.config.ts; then
+if echo "fix: reject a header that exceeds the custom configured limit" | commitlint --config /tmp/commitlint.config.ts; then
 	exit 1
 fi
 rm -rf /tmp/jiti /tmp/node-compile-cache /tmp/commitlint.config.ts

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -37,6 +37,23 @@ RUN npm config set fetch-retry-mintimeout 20000 && \
     npm config set fetch-retry-maxtimeout 120000 && \
     npm install --no-audit -g *.tgz && \
     rm -rf *.tgz
-RUN --mount=type=bind,source=.github/fixtures/docker/commitlint.config.ts,target=/tmp/commitlint.config.ts \
-    echo "fix: load TypeScript config" | commitlint --config /tmp/commitlint.config.ts
+RUN <<'EOF'
+set -eu
+cat >/tmp/commitlint.config.ts <<'CONFIG'
+import { RuleConfigSeverity } from "@commitlint/types";
+import type { UserConfig } from "@commitlint/types";
+
+export default {
+	extends: ["@commitlint/config-conventional"],
+	rules: {
+		"header-max-length": [RuleConfigSeverity.Error, "always", 100],
+	},
+} satisfies UserConfig;
+CONFIG
+echo "fix: load TypeScript config" | commitlint --config /tmp/commitlint.config.ts
+if echo "fix: this TypeScript configuration rule rejects a header that is deliberately longer than one hundred characters in the container smoke test" | commitlint --config /tmp/commitlint.config.ts; then
+	exit 1
+fi
+rm -rf /tmp/jiti /tmp/node-compile-cache /tmp/commitlint.config.ts
+EOF
 ENTRYPOINT ["commitlint"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -36,4 +36,6 @@ RUN npm config set fetch-retry-mintimeout 20000 && \
     npm config set fetch-retry-maxtimeout 120000 && \
     npm install --no-audit -g *.tgz && \
     rm -rf *.tgz
+RUN --mount=type=bind,source=.github/fixtures/docker/commitlint.config.ts,target=/tmp/commitlint.config.ts \
+    echo "fix: load TypeScript config" | commitlint --config /tmp/commitlint.config.ts
 ENTRYPOINT ["commitlint"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -30,6 +30,7 @@ RUN corepack enable && \
     npm pack @commitlint/config-conventional
 
 FROM docker.io/library/node:22-alpine
+ENV NODE_PATH=/usr/local/lib/node_modules
 RUN apk add --no-cache git
 COPY --from=builder /src/*.tgz ./
 RUN npm config set fetch-retry-mintimeout 20000 && \


### PR DESCRIPTION
## Description

Make globally installed commitlint packages resolvable from TypeScript configuration files in the CI image. The image build now exercises a mounted TypeScript fixture that imports both a runtime value and a type from `@commitlint/types`.

## Motivation and Context

The image installs commitlint packages globally, but the TypeScript config loader resolves imports relative to the config file. As a result, configs that import commitlint packages fail with `Cannot find module '@commitlint/types'`.

Setting `NODE_PATH` to the image's global module directory makes those imports available to the loader.

Fixes #4623.

## Usage examples

```ts
import { RuleConfigSeverity } from "@commitlint/types";
import type { UserConfig } from "@commitlint/types";

export default {
	rules: {
		"header-max-length": [RuleConfigSeverity.Error, "always", 100],
	},
} satisfies UserConfig;
```

## How Has This Been Tested?

- Reproduced the module resolution failure with globally installed commitlint packages and the TypeScript fixture
- Verified the same fixture passes when the global module directory is provided through `NODE_PATH`
- Ran `pnpm lint`
- Ran `pnpm build`
- Ran the focused TypeScript config-loader test
- Ran the CLI test suite (71 tests)

A container runtime is not installed locally, so the final Docker image build is left to CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified that any documentation examples I added/changed actually work.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] For a feature/bug fix, my commits follow the test-driven flow.
