### PR TITLE
fix(resolve-extends): support Yarn Plug'n'Play

### DIFF
--- a/@commitlint/resolve-extends/src/index.test.ts
+++ b/@commitlint/resolve-extends/src/index.test.ts
@@ -704,6 +704,21 @@ test("resolveFrom resolves a pure-ESM package exposing only the import condition
 	);
 });
 
+test("resolveFrom does not load pnpapi outside Plug'n'Play", () => {
+	const pkg = "pnp-esm-only-preset";
+	const { root } = scaffoldPnpModule(
+		pkg,
+		{
+			name: pkg,
+			type: "module",
+			exports: { types: "./index.d.ts", import: "./index.js" },
+		},
+		{ "index.js": "export default {};" },
+	);
+
+	expect(() => resolveFrom(pkg, root)).toThrow(/Cannot find module/);
+});
+
 test("resolveFrom resolves a pure-ESM package through Yarn Plug'n'Play", () => {
 	const pkg = "pnp-esm-only-preset";
 	const { root, pkgDir } = scaffoldPnpModule(
@@ -716,7 +731,17 @@ test("resolveFrom resolves a pure-ESM package through Yarn Plug'n'Play", () => {
 		{ "index.js": "export default {};" },
 	);
 
-	expect(resolveFrom(pkg, root)).toBe(path.join(pkgDir, "index.js"));
+	const descriptor = Object.getOwnPropertyDescriptor(process.versions, "pnp");
+	Object.defineProperty(process.versions, "pnp", { configurable: true, value: "3" });
+	try {
+		expect(resolveFrom(pkg, root)).toBe(path.join(pkgDir, "index.js"));
+	} finally {
+		if (descriptor) {
+			Object.defineProperty(process.versions, "pnp", descriptor);
+		} else {
+			Reflect.deleteProperty(process.versions, "pnp");
+		}
+	}
 });
 
 test("resolveFrom resolves a subpath of a pure-ESM package", () => {

--- a/@commitlint/resolve-extends/src/index.test.ts
+++ b/@commitlint/resolve-extends/src/index.test.ts
@@ -716,7 +716,15 @@ test("resolveFrom does not load pnpapi outside Plug'n'Play", () => {
 		{ "index.js": "export default {};" },
 	);
 
-	expect(() => resolveFrom(pkg, root)).toThrow(/Cannot find module/);
+	const descriptor = Object.getOwnPropertyDescriptor(process.versions, "pnp");
+	Reflect.deleteProperty(process.versions, "pnp");
+	try {
+		expect(() => resolveFrom(pkg, root)).toThrow(/Cannot find module/);
+	} finally {
+		if (descriptor) {
+			Object.defineProperty(process.versions, "pnp", descriptor);
+		}
+	}
 });
 
 test("resolveFrom resolves a pure-ESM package through Yarn Plug'n'Play", () => {

--- a/@commitlint/resolve-extends/src/index.test.ts
+++ b/@commitlint/resolve-extends/src/index.test.ts
@@ -659,6 +659,32 @@ const scaffoldModule = (
 	return root;
 };
 
+const scaffoldPnpModule = (
+	pkg: string,
+	manifest: Record<string, unknown>,
+	files: Record<string, string>,
+): { root: string; pkgDir: string } => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "resolve-from-pnp-"));
+	scaffoldedRoots.push(root);
+	const pkgDir = path.join(root, ".yarn", "cache", pkg, "node_modules", pkg);
+	fs.mkdirSync(pkgDir, { recursive: true });
+	fs.writeFileSync(path.join(pkgDir, "package.json"), JSON.stringify(manifest));
+	for (const [relative, content] of Object.entries(files)) {
+		const file = path.join(pkgDir, relative);
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		fs.writeFileSync(file, content);
+	}
+
+	const pnpApiDir = path.join(root, "node_modules", "pnpapi");
+	fs.mkdirSync(pnpApiDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(pnpApiDir, "index.js"),
+		`module.exports.resolveToUnqualified = (request, issuer, options) => request === ${JSON.stringify(pkg)} && issuer === ${JSON.stringify(path.join(root, "noop.js"))} && options.considerBuiltins === false ? ${JSON.stringify(pkgDir)} : undefined;`,
+	);
+
+	return { root, pkgDir };
+};
+
 // CommonJS resolvers cannot read an `exports` map that only declares the `import`
 // condition (no require/default/main), so resolveFrom must fall back to reading the
 // manifest itself. See conventional-changelog-angular@>=9 / conventionalcommits@>=10.
@@ -676,6 +702,21 @@ test("resolveFrom resolves a pure-ESM package exposing only the import condition
 	expect(resolveFrom("esm-only-preset", root)).toBe(
 		path.join(root, "node_modules", "esm-only-preset", "index.js"),
 	);
+});
+
+test("resolveFrom resolves a pure-ESM package through Yarn Plug'n'Play", () => {
+	const pkg = "pnp-esm-only-preset";
+	const { root, pkgDir } = scaffoldPnpModule(
+		pkg,
+		{
+			name: pkg,
+			type: "module",
+			exports: { types: "./index.d.ts", import: "./index.js" },
+		},
+		{ "index.js": "export default {};" },
+	);
+
+	expect(resolveFrom(pkg, root)).toBe(path.join(pkgDir, "index.js"));
 });
 
 test("resolveFrom resolves a subpath of a pure-ESM package", () => {

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -61,6 +61,28 @@ const resolveExportsEntry = (manifest: Record<string, unknown>): string => {
 	);
 };
 
+const resolveEsmPackage = (pkgDir: string, subpath: string): string | undefined => {
+	const manifestPath = path.join(pkgDir, "package.json");
+
+	if (!fs.existsSync(manifestPath)) {
+		return undefined;
+	}
+
+	if (subpath) {
+		for (const suffix of pathSuffixes) {
+			const filename = path.join(pkgDir, subpath) + suffix;
+			if (fs.existsSync(filename)) {
+				return filename;
+			}
+		}
+		return undefined;
+	}
+
+	const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+	const resolved = path.join(pkgDir, resolveExportsEntry(manifest));
+	return fs.existsSync(resolved) ? resolved : undefined;
+};
+
 /**
  * Pure-ESM presets such as conventional-changelog-angular@>=9 and
  * conventional-changelog-conventionalcommits@>=10 declare only the `import`
@@ -68,7 +90,11 @@ const resolveExportsEntry = (manifest: Record<string, unknown>): string => {
  * CommonJS resolvers above fail with ERR_PACKAGE_PATH_NOT_EXPORTED. Walk
  * node_modules from the requesting location and read the manifest ourselves.
  */
-const resolveEsmOnly = (lookup: string, fromDir: string): string | undefined => {
+const resolveEsmOnly = (
+	lookup: string,
+	parentPath: string,
+	localRequire: ReturnType<typeof createRequire>,
+): string | undefined => {
 	if (path.isAbsolute(lookup) || lookup.startsWith(".")) {
 		return undefined;
 	}
@@ -77,28 +103,32 @@ const resolveEsmOnly = (lookup: string, fromDir: string): string | undefined => 
 	const pkgName = lookup.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
 	const subpath = lookup.slice(pkgName.length).replace(/^\//, "");
 
-	let dir = fromDir;
+	try {
+		const pnpApi = localRequire("pnpapi") as {
+			resolveToUnqualified(
+				request: string,
+				issuer: string | null,
+				options: { considerBuiltins: boolean },
+			): string | null;
+		};
+		const pkgDir = pnpApi.resolveToUnqualified(pkgName, parentPath, {
+			considerBuiltins: false,
+		});
+		if (pkgDir) {
+			const resolved = resolveEsmPackage(pkgDir, subpath);
+			if (resolved) {
+				return resolved;
+			}
+		}
+	} catch {}
+
+	let dir = path.dirname(parentPath);
 	for (;;) {
 		const pkgDir = path.join(dir, "node_modules", pkgName);
 		const manifestPath = path.join(pkgDir, "package.json");
 
 		if (fs.existsSync(manifestPath)) {
-			if (subpath) {
-				for (const suffix of pathSuffixes) {
-					const filename = path.join(pkgDir, subpath) + suffix;
-					if (fs.existsSync(filename)) {
-						return filename;
-					}
-				}
-				return undefined;
-			}
-
-			const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
-			const resolved = path.join(pkgDir, resolveExportsEntry(manifest));
-			if (fs.existsSync(resolved)) {
-				return resolved;
-			}
-			return undefined;
+			return resolveEsmPackage(pkgDir, subpath);
 		}
 
 		const parentDir = path.dirname(dir);
@@ -146,7 +176,7 @@ export const resolveFrom = (lookup: string, parent?: string): string => {
 		 */
 		return resolveFrom_(path.dirname(parentPath), lookup);
 	} catch {
-		const esmResolved = resolveEsmOnly(lookup, path.dirname(parentPath));
+		const esmResolved = resolveEsmOnly(lookup, parentPath, localRequire);
 		if (esmResolved) {
 			return esmResolved;
 		}

--- a/@commitlint/resolve-extends/src/index.ts
+++ b/@commitlint/resolve-extends/src/index.ts
@@ -103,24 +103,30 @@ const resolveEsmOnly = (
 	const pkgName = lookup.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
 	const subpath = lookup.slice(pkgName.length).replace(/^\//, "");
 
-	try {
-		const pnpApi = localRequire("pnpapi") as {
-			resolveToUnqualified(
-				request: string,
-				issuer: string | null,
-				options: { considerBuiltins: boolean },
-			): string | null;
-		};
-		const pkgDir = pnpApi.resolveToUnqualified(pkgName, parentPath, {
-			considerBuiltins: false,
-		});
-		if (pkgDir) {
-			const resolved = resolveEsmPackage(pkgDir, subpath);
-			if (resolved) {
-				return resolved;
+	if ("pnp" in process.versions) {
+		try {
+			const pnpApi = localRequire("pnpapi") as {
+				resolveToUnqualified(
+					request: string,
+					issuer: string | null,
+					options: { considerBuiltins: boolean },
+				): string | null;
+			};
+			const pkgDir = pnpApi.resolveToUnqualified(pkgName, parentPath, {
+				considerBuiltins: false,
+			});
+			if (pkgDir) {
+				const resolved = resolveEsmPackage(pkgDir, subpath);
+				if (resolved) {
+					return resolved;
+				}
+			}
+		} catch (err) {
+			if (process.env.DEBUG === "true") {
+				console.debug(`Failed to resolve ${lookup} through Yarn PnP: ${(err as Error).message}`);
 			}
 		}
-	} catch {}
+	}
 
 	let dir = path.dirname(parentPath);
 	for (;;) {


### PR DESCRIPTION
## Description

Adds Yarn Plug'n'Play resolution to the pure ESM preset fallback while preserving the existing node_modules lookup.

## Motivation and Context

Yarn PnP projects do not have a node_modules tree, so import-only ESM presets cannot be found by the existing fallback. The resolver now asks the PnP API for the package location first.

Closes #2637.

## Usage examples

Existing Yarn PnP configurations work without changes.

## How Has This Been Tested?

- pnpm exec vitest run @commitlint/resolve-extends/src/index.test.ts (30 tests)
- pnpm build
- pnpm lint
- pnpm check-no-focused-tests
- Yarn 4.17 PnP smoke test with conventional-changelog-conventionalcommits@10.2.0
- pnpm test (1199 passed; 10 unrelated Windows environment failures from symlink permissions and the workspace Git root)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified that any documentation examples I added/changed actually work.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] For a feature/bug fix, my commits follow the test-driven flow: a failing-test commit, then the implementation.