### PR TITLE
chore: repair broken lockfile from #4939 and add merge queue CI support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,8 +4,16 @@ on:
   push:
     branches:
       - "**"
+      # Merge-queue commits are validated via the merge_group event below;
+      # without this exclusion every queue build would run twice.
+      - "!gh-readonly-queue/**"
   pull_request:
     types: [opened, synchronize]
+
+  # Runs the required checks on the exact merge result the merge queue is
+  # about to land on master, so a PR whose checks passed against an older
+  # base (e.g. a stale renovate lockfile branch) cannot break master.
+  merge_group:
 
   workflow_dispatch:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,18 +941,6 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  '@conventional-changelog/git-client@3.1.1':
-    resolution: {integrity: sha512-w/q+UIVdWQMgXlziPIYfPlyDud+H8kcvSCzDQQoc/gid7yZzb6eNfAkNN4UlEcS2cVVh924jevsOIb36d0In2g==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      conventional-commits-filter: ^6.0.1
-      conventional-commits-parser: ^7.1.2
-    peerDependenciesMeta:
-      conventional-commits-filter:
-        optional: true
-      conventional-commits-parser:
-        optional: true
-
   '@conventional-changelog/template@1.2.1':
     resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
     engines: {node: '>=22'}


### PR DESCRIPTION
## Problem

The #4939 squash merge combined a stale renovate lock-file-maintenance branch with current master. The resulting `pnpm-lock.yaml` contains two identical copies of the `'@conventional-changelog/git-client@3.1.1'` entry in the `packages:` section — invalid YAML:

- CI installs fail: `ERR_PNPM_BROKEN_LOCKFILE ... duplicated mapping key (944:3)` — all master workflows are red since that merge.
- Local non-frozen `pnpm install` does not error: it silently discards the broken lockfile and regenerates it from scratch, rolling back the recent in-range bumps (vite 8.2.1→8.2.0, vue 3.5.41→3.5.40, oxlint 1.77.0→1.76.0, git-client 3.1.1→3.1.0). Do not commit such a regeneration.

Same failure mode as the es-toolkit incident of 2026-06-15: two lockfile-touching branches merge cleanly *textually* while corrupt *semantically*, and the PR's green checks predate the merge, so nothing ever validated the bytes that actually landed.

## Fix

1. **`pnpm-lock.yaml`** — delete the duplicated 12-line block, nothing else. Zero version churn; every resolved version stays exactly as on master. Verified: `pnpm install --frozen-lockfile` passes (pnpm 11.20.0).
2. **`CI.yml`** — add the `merge_group` trigger so a merge queue can run the required build checks on the exact merge result before it lands on master, which prevents this whole class of stale-merge corruption. `gh-readonly-queue/**` is excluded from the `push` trigger so each queue build runs only once. The existing fork-only/schedule `if:` conditions on the jobs already pass for `merge_group` events — no job changes needed.

## After merging (repo settings, admin-only)

The `merge_group` trigger is inert until the queue is switched on: **Settings → Branches → master rule → Require merge queue**. The two required checks (`build (ubuntu-22.04, 22)`, `build (windows-2025, 22)`) will then gate each queue entry. Until that's flipped, everything behaves exactly as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
