### PR TITLE
build: install pnpm via npm instead of corepack

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,7 +83,6 @@ The required version is pinned in `package.json` (`packageManager` field); the
 easiest ways to install it are:
 
 - [mise](https://mise.jdx.dev/): `mise install` (uses `.mise.toml`)
-- [corepack](https://nodejs.org/api/corepack.html): `corepack enable` (ships with Node)
 - [direct install](https://pnpm.io/installation)
 
 After cloning the repo run

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,8 +3,9 @@ FROM docker.io/library/node:22-alpine AS builder
 WORKDIR /src
 COPY . ./
 RUN apk add --no-cache python3 py3-setuptools make g++ git
-# corepack reads the pnpm version from package.json `packageManager` field.
-RUN corepack enable && \
+# Install the pnpm version pinned in package.json `packageManager` via npm;
+# corepack was removed from Node 25+ and cannot install pnpm >= 12.
+RUN npm install --global pnpm@$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]") && \
     pnpm install --frozen-lockfile && \
     pnpm run build && \
     # Commit lint CLI packages

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,5 +4,8 @@ FROM brainpower/node-cubicle
 WORKDIR /root/repo
 
 ADD . ./
-RUN corepack enable && pnpm install --frozen-lockfile
+# Install the pnpm version pinned in package.json `packageManager` via npm;
+# corepack was removed from Node 25+ and cannot install pnpm >= 12.
+RUN npm install --global pnpm@$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]") && \
+    pnpm install --frozen-lockfile
 RUN pnpm build


### PR DESCRIPTION
## Description

Replace `corepack enable` with an explicit npm install of the pnpm version pinned in the `packageManager` field, in both Dockerfiles, and drop the corepack suggestion from CONTRIBUTING.md (mise and direct install remain).

## Motivation and Context

pnpm now explicitly discourages installing via corepack — the "Using Corepack" section was removed from [pnpm.io/installation](https://pnpm.io/installation) (pnpm/pnpm.io#862):

- Corepack is no longer distributed with Node.js 25+ (nodejs/TSC#1697); Node 24 LTS is the last release line that bundles it.
- Corepack cannot install pnpm >= 12 at all — pnpm 12 ships a native binary without the JS entry point corepack expects (pnpm/pnpm#13018, closed "not planned"). Without this change the container builds would break on the next pnpm major bump.
- GitHub Actions CI already avoids corepack (`pnpm/action-setup`, plus the explicit npm install in the stock-Ubuntu job); this brings the Dockerfiles and contributor docs in line.

## Usage examples

Not applicable — no runtime behavior changes; the published image contents are identical.

## How Has This Been Tested?

Built `Dockerfile.ci` from a pristine clone of this branch (the same conditions `container-build.yml` runs under): image builds green end-to-end, including the final-stage self-test (TypeScript config loads, over-length header correctly rejected).

Note: `Dockerfile.dev` is unbuildable before and after this change — its `brainpower/node-cubicle` base image predates corepack entirely (exit 127 on master). A follow-up PR retires it.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have verified that any documentation examples I added/changed actually work.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] For a feature/bug fix, my commits follow the [test-driven flow](https://github.com/conventional-changelog/commitlint/blob/master/.github/CONTRIBUTING.md#test-driven-development): a failing-test commit, then the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)