### PR TITLE
build: verify pnpm tarball against the packageManager sha512 pin

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,9 +3,15 @@ FROM docker.io/library/node:22-alpine AS builder
 WORKDIR /src
 COPY . ./
 RUN apk add --no-cache python3 py3-setuptools make g++ git
-# Install the pnpm version pinned in package.json `packageManager` via npm;
-# corepack was removed from Node 25+ and cannot install pnpm >= 12.
-RUN npm install --global pnpm@$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]") && \
+# Install the pnpm version pinned in package.json `packageManager`, verifying
+# the tarball against the pin's sha512 digest as corepack did (corepack was
+# removed from Node 25+ and cannot install pnpm >= 12).
+RUN pnpm_version=$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]") && \
+    pnpm_sha=$(node -p "require('./package.json').packageManager.split('+sha512.')[1]") && \
+    npm pack pnpm@$pnpm_version && \
+    echo "$pnpm_sha  pnpm-$pnpm_version.tgz" | sha512sum -c - && \
+    npm install --global ./pnpm-$pnpm_version.tgz && \
+    rm ./pnpm-$pnpm_version.tgz && \
     pnpm install --frozen-lockfile && \
     pnpm run build && \
     # Commit lint CLI packages


### PR DESCRIPTION
## Description

Follow-up to #4948: the container build now verifies the pnpm tarball against the `+sha512` suffix of the `packageManager` field before installing it — `npm pack` the pinned version, `sha512sum -c` against the pin, install from the verified file, remove the tarball so the final stage's `*.tgz` glob keeps matching only the packed commitlint packages.

## Motivation and Context

Addresses the [review comment on #4948](https://github.com/conventional-changelog/commitlint/pull/4948#pullrequestreview-4943749387): the corepack replacement installed pnpm by version only, dropping the artifact-integrity check corepack performed against the `packageManager` pin. The pin is the sha512 hex digest of the npm tarball, so the same guarantee is restored with stock tooling.

Deliberately unchanged: the stock-Ubuntu CI job (`CI.yml`) keeps its version-only `npm install -g pnpm` — that job is an intentional "stock environment" smoke test; it can get the same treatment separately if wanted.

## Usage examples

Not applicable — no runtime behavior changes; published image contents are identical.

## How Has This Been Tested?

- Verified the premise: the `+sha512` value in `package.json` is byte-identical to the sha512 of `pnpm-11.21.0.tgz` from the registry.
- Minimal-image tests on `node:22-alpine`: correct pin → `pnpm-11.21.0.tgz: OK`, install proceeds; tampered pin → `sha512sum` FAILED and the build aborts before installing anything.
- Full `Dockerfile.ci` build from a pristine clone of this branch: green end-to-end, checksum `OK` in the build log. The final-stage layers (including `COPY --from=builder /src/*.tgz`) cache-hit against the previous green build, confirming the produced tarball set — and therefore the published image — is unchanged.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified that any documentation examples I added/changed actually work.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] For a feature/bug fix, my commits follow the [test-driven flow](https://github.com/conventional-changelog/commitlint/blob/master/.github/CONTRIBUTING.md#test-driven-development): a failing-test commit, then the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)