### PR TITLE
fix(types): correct breaking-change-exclamation-mark rule config type

### DIFF
--- a/@commitlint/types/src/rules.test-d.ts
+++ b/@commitlint/types/src/rules.test-d.ts
@@ -41,6 +41,14 @@ const _scopeCaseSimpleCheck: Partial<RulesConfig> = {
 };
 void _scopeCaseSimpleCheck;
 
+// Regression check: breaking-change-exclamation-mark has no target case, so it
+// must accept a plain two-element tuple.
+const _breakingChangeExclamationMark = [ERROR, "always"] as const;
+const _breakingChangeExclamationMarkCheck: Partial<RulesConfig> = {
+	"breaking-change-exclamation-mark": _breakingChangeExclamationMark,
+};
+void _breakingChangeExclamationMarkCheck;
+
 // Tests for context parameter support:
 // https://github.com/conventional-changelog/commitlint/issues/4357
 // Rule functions should accept an optional context parameter with cwd.

--- a/@commitlint/types/src/rules.ts
+++ b/@commitlint/types/src/rules.ts
@@ -95,7 +95,7 @@ export type RulesConfig<V = RuleConfigQuality.User> = {
 	"body-max-length": LengthRuleConfig<V>;
 	"body-max-line-length": LengthRuleConfig<V>;
 	"body-min-length": LengthRuleConfig<V>;
-	"breaking-change-exclamation-mark": CaseRuleConfig<V>;
+	"breaking-change-exclamation-mark": RuleConfig<V>;
 	"footer-empty": RuleConfig<V>;
 	"footer-leading-blank": RuleConfig<V>;
 	"footer-max-length": LengthRuleConfig<V>;


### PR DESCRIPTION
## Description

Types `breaking-change-exclamation-mark` as `RuleConfig<V>` instead of `CaseRuleConfig<V>`.

## Motivation and Context

The rule only takes a severity and a condition, no target case, but its type required a third tuple element for a case type. That made a valid config like `[RuleConfigSeverity.Error, "always"]` fail a `satisfies UserConfig` check.

Fixes #4953.

## Usage examples

```ts
import type { UserConfig } from "@commitlint/types";
import { RuleConfigSeverity } from "@commitlint/types";

export default {
  rules: {
    "breaking-change-exclamation-mark": [RuleConfigSeverity.Error, "always"],
  },
} satisfies UserConfig;
```

## How Has This Been Tested?

- Reproduced the `satisfies UserConfig` type error against the config above before the fix
- Added a type-check regression test in `@commitlint/types/src/rules.test-d.ts`, confirmed it fails without the fix and passes with it
- `pnpm build`
- `pnpm exec vitest run --typecheck @commitlint/types`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified that any documentation examples I added/changed actually work.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] For a feature/bug fix, my commits follow the test-driven flow: a failing-test commit, then the implementation.