### PR TITLE
fix(lint): trim trailing whitespace off the message handed to ignore matchers

### DIFF
--- a/@commitlint/cli/fixtures/ignores-exact/commitlint.config.js
+++ b/@commitlint/cli/fixtures/ignores-exact/commitlint.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	rules: {
+		'type-empty': [2, 'never'],
+		'subject-empty': [2, 'never']
+	},
+	ignores: [commit => commit === 'Initialize project using Create React App']
+};

--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -586,6 +586,34 @@ test("should not skip linting if message does not match ignores config", async (
 	expect(result.exitCode).toBe(ExitCode.CommitlintErrorDefault);
 });
 
+test("should skip linting if an edit mode message matches an exact ignores config", async () => {
+	const cwd = await gitBootstrap("fixtures/ignores-exact");
+	await fs.writeFile(
+		path.join(cwd, ".git", "COMMIT_EDITMSG"),
+		"Initialize project using Create React App\n",
+	);
+
+	const result = cli(["--edit", ".git/COMMIT_EDITMSG"], { cwd })();
+	await result;
+	expect(result.exitCode).toBe(ExitCode.CommitlintDefault);
+});
+
+test("should skip linting if a stdin message matches an exact ignores config", async () => {
+	const cwd = await gitBootstrap("fixtures/ignores-exact");
+	const result = cli([], { cwd })("Initialize project using Create React App\n");
+	await result;
+	expect(result.exitCode).toBe(ExitCode.CommitlintDefault);
+});
+
+test("should not skip linting if an edit mode message does not match an exact ignores config", async () => {
+	const cwd = await gitBootstrap("fixtures/ignores-exact");
+	await fs.writeFile(path.join(cwd, ".git", "COMMIT_EDITMSG"), "Some other message\n");
+
+	const result = cli(["--edit", ".git/COMMIT_EDITMSG"], { cwd })();
+	await result;
+	expect(result.exitCode).toBe(ExitCode.CommitlintErrorDefault);
+});
+
 test("should not skip linting if defaultIgnores is false", async () => {
 	const cwd = await gitBootstrap("fixtures/default-ignores-false");
 	const result = cli([], { cwd })("fixup! foo: bar");

--- a/@commitlint/lint/src/lint.test.ts
+++ b/@commitlint/lint/src/lint.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "vitest";
+import { test, expect, vi } from "vitest";
 import type { Parser } from "@commitlint/types";
 import { RuleConfigSeverity } from "@commitlint/types";
 
@@ -70,6 +70,93 @@ test("positive on custom ignored message and broken rule", async () => {
 	);
 	expect(actual.valid).toBe(true);
 	expect(actual.input).toBe(ignoredMessage);
+});
+
+test("positive on custom ignored message with trailing newlines", async () => {
+	const ignoredMessage = "Initialize project using Create React App";
+	const actual = await lint(
+		`${ignoredMessage}\n\n`,
+		{
+			"type-empty": [RuleConfigSeverity.Error, "never"],
+			"subject-empty": [RuleConfigSeverity.Error, "never"],
+		},
+		{
+			ignores: [(c) => c === ignoredMessage],
+		},
+	);
+	expect(actual.valid).toBe(true);
+	expect(actual.errors).toEqual([]);
+});
+
+test("passes the message without trailing whitespace to ignore matchers", async () => {
+	const matcher = vi.fn(() => false);
+	await lint("feat: thing\n\nbody\n\n", {}, { ignores: [matcher] });
+	expect(matcher).toHaveBeenCalledWith("feat: thing\n\nbody");
+});
+
+test("keeps leading whitespace in the message passed to ignore matchers", async () => {
+	// The default matchers are anchored to the start of the message, so trimming
+	// the start would start ignoring messages that are linted today.
+	const matcher = vi.fn(() => false);
+	await lint("\nfeat: thing\n\n", {}, { ignores: [matcher] });
+	expect(matcher).toHaveBeenCalledWith("\nfeat: thing");
+});
+
+test("negative on a semver message behind a leading blank line", async () => {
+	const actual = await lint("\nv1.2.3\n\n", {
+		"type-empty": [RuleConfigSeverity.Error, "never"],
+	});
+	expect(actual.valid).toBe(false);
+});
+
+test("positive on whitespace only message and the documented empty ignore matcher", async () => {
+	const matcher = vi.fn((commit: string) => commit === "");
+	await expect(
+		lint(
+			"\n\n",
+			{
+				"type-empty": [RuleConfigSeverity.Error, "never"],
+			},
+			{ ignores: [matcher] },
+		),
+	).resolves.toMatchObject({ valid: true });
+	expect(matcher).toHaveBeenCalledWith("");
+});
+
+test("reports the message as given for ignored messages", async () => {
+	const message = "Initialize project using Create React App\n\n";
+	const actual = await lint(
+		message,
+		{},
+		{ ignores: [(c) => c === "Initialize project using Create React App"] },
+	);
+	expect(actual.input).toBe(message);
+});
+
+test("keeps the message as it was read when evaluating rules", async () => {
+	// `parsed.raw` is line-indexed by body-leading-blank and footer-leading-blank,
+	// so rules must keep seeing the message exactly as it was read.
+	const actual = await lint("\nfeat: thing\n\nbody\n\n", {
+		"body-leading-blank": [RuleConfigSeverity.Error, "always"],
+	});
+	expect(actual.valid).toBe(false);
+	expect(actual.errors.map((error) => error.name)).toEqual(["body-leading-blank"]);
+});
+
+test("parses a multi line message the same way with or without a trailing newline", async () => {
+	const message = "feat: thing\n\nbody line one\n\nbody line two\n\nBREAKING CHANGE: nope";
+	const rules = {
+		"body-leading-blank": [RuleConfigSeverity.Error, "always"],
+		"footer-leading-blank": [RuleConfigSeverity.Error, "always"],
+		"body-max-line-length": [RuleConfigSeverity.Error, "always", 10],
+	} as const;
+
+	const withTrailingNewlines = await lint(`${message}\n\n`, rules);
+	const withoutTrailingNewlines = await lint(message, rules);
+
+	expect(withTrailingNewlines.valid).toBe(withoutTrailingNewlines.valid);
+	expect(withTrailingNewlines.errors).toEqual(withoutTrailingNewlines.errors);
+	expect(withTrailingNewlines.warnings).toEqual(withoutTrailingNewlines.warnings);
 });
 
 test("positive on stub message and opts", async () => {

--- a/@commitlint/lint/src/lint.ts
+++ b/@commitlint/lint/src/lint.ts
@@ -23,8 +23,11 @@ export default async function lint(
 	const opts = rawOpts ? rawOpts : { defaultIgnores: undefined, ignores: undefined };
 	const rulesConfig = rawRulesConfig || {};
 
-	// Found a wildcard match, skip
-	if (isIgnored(message, { defaults: opts.defaultIgnores, ignores: opts.ignores })) {
+	// Found a wildcard match, skip. Matchers see the message without the trailing
+	// newlines git leaves behind. Only the end is trimmed, since the default matchers
+	// are anchored to the start, and `message` itself is left alone because rules such
+	// as body-leading-blank read its blank lines back off `parsed.raw`.
+	if (isIgnored(message?.trimEnd(), { defaults: opts.defaultIgnores, ignores: opts.ignores })) {
 		return {
 			valid: true,
 			errors: [],


### PR DESCRIPTION
## Description

`@commitlint/lint` hands the raw message to the ignore matchers, and a message read from a file or
from git history still carries its trailing newlines. An `ignores` matcher that compares the message
by value therefore never matches, and the commit gets linted anyway.

`@commitlint/read` appends a newline to the contents of the commit message file in
`get-edit-commit.ts`, and git has already put one there, so a commit-msg hook hands
`"Initialize project using Create React App\n\n"` to the matcher. Commits read from history arrive
the same way, and a piped message keeps the newline the shell adds. This is the case @escapedcat
reproduced in the issue thread, where the matcher printed `STARThello\n\nEND` and returned false.

### Where the fix goes

The trim happens in `@commitlint/lint`, on the value passed to `isIgnored`, and nowhere else.

Trimming in `@commitlint/read/src/get-edit-commit.ts` looked like the smaller change but it is the
wrong place. It changes the string every consumer of that package sees, and a commit message is
newline significant. `parsed.raw` carries the message through to the rules, and `body-leading-blank`
and `footer-leading-blank` index into its lines while `signed-off-by` and `trailer-exists` read it
too. Linting `"\nfeat: thing\n\nbody\n\n"` under `body-leading-blank` fails today and starts passing
if the read layer trims, which is a rule quietly changing its answer. Trimming before the ignore
check leaves the message that reaches the parser byte for byte identical, so no rule can move. It
also covers every input source at once, because they all reach this same call.

Only the end of the message is trimmed. The default matchers in `@commitlint/is-ignored` are
anchored to the start of the message, so trimming the start would make them match messages they do
not match today, and a linter that begins skipping commits it used to check is the worse failure.
Running the last 600 commit messages of this repository through `isIgnored` with a blank first line
added shows the size of that: trimming the end changes 0 of the 600 ignore decisions, trimming both
ends changes 28 of them. Those 28 are release commits and reverts that would silently stop being
linted. `@commitlint/is-ignored` itself is untouched, so anyone calling it directly keeps the
behavior they have.

## Motivation and Context

Fixes #3162

The repository's own documentation contradicts the current behavior. `docs/reference/configuration.md`
presents `ignores: [(commit) => commit === ""]` as the worked example of the option, and no message
read through `--edit` or through `--from`/`--to` can ever equal `""`. The existing test in
`@commitlint/cli/src/cli.test.ts` passes only because its fixture uses `commit.includes("WIP")`
rather than a comparison by value, which is what hid this.

One clarification on the example in the issue title. A truly empty `--edit` message never reaches
`lint()` at all, because `cli.ts` drops messages that are blank after trimming before it lints. The
reachable form of the bug is the one above, where a matcher compares against real message text.

## Usage examples

```js
// commitlint.config.js
export default {
  rules: { "type-empty": [2, "never"], "subject-empty": [2, "never"] },
  ignores: [(commit) => commit === "Initialize project using Create React App"],
};
```

```sh
printf 'Initialize project using Create React App\n' > .git/COMMIT_EDITMSG
npx commitlint --edit .git/COMMIT_EDITMSG

# before: the matcher receives "Initialize project using Create React App\n\n",
#         the commit is linted, and the run exits 1 on type-empty and subject-empty
# after:  the matcher receives "Initialize project using Create React App",
#         the commit is skipped, and the run exits 0
```

## How Has This Been Tested?

Unit tests in `@commitlint/lint/src/lint.test.ts` cover a matcher comparing by value against a
message with trailing newlines, the exact value a matcher receives, the documented empty-message
matcher firing on a whitespace-only message, leading whitespace being preserved, a semver message
behind a blank first line still being linted, and a multi-line message with a body and a footer
producing the same result with and without trailing newlines.

End-to-end tests in `@commitlint/cli/src/cli.test.ts` cover the `--edit` path and the stdin path
against a new `fixtures/ignores-exact` fixture whose matcher compares by value, plus the negative
case where the message does not match.

On the test commit alone, five of the new lint tests and two of the new cli tests fail on assertions
rather than on build or import errors, so the coverage is not vacuous.

Regression check against real messages: the last 600 commit messages of this repository were shaped
the way `@commitlint/read` hands them over, then linted against `@commitlint/config-conventional` on
master and on this branch. All 600 produce identical outcomes, with the same 6 invalid messages and
the same reported output on both sides.

What I ran locally on Node 22 and pnpm 11:

- `pnpm build`
- `pnpm test`, the full suite, 91 files and 1227 tests, no type errors
- `npx oxlint` and `npx oxfmt --check` over the changed files, both clean
- `npx commitlint --from 013c3582 --to HEAD --verbose`, 0 problems on both commits

One note on the last two. `pnpm lint` and `pnpm format` at the repository root also walk an
untracked `.cache/` directory that corepack drops in the checkout, and they fail on master for the
same reason, so I ran oxlint and oxfmt against the changed files instead.

### One thing left alone

`lint("\n\n")` still rejects with `Expected a raw commit` from the parser, because the guard above
`parse` checks `message === ""` and a whitespace-only message does not hit it. The CLI never reaches
that path since it drops blank messages before linting, and tightening the guard would change the
error that `lint()` throws when it is called with no arguments. That looked like its own change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have verified that any documentation examples I added/changed actually work.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] For a feature/bug fix, my commits follow the test-driven flow: a failing-test commit, then the
      implementation.

No documentation change is needed here. The `ignores` example in `docs/reference/configuration.md`
already describes what the option is meant to do, and this change makes that description true, so I
verified the example works rather than editing it.
