### PR TITLE
fix(load): detect dynamic await support on node majors above 20

### DIFF
--- a/@commitlint/load/src/utils/load-config.test.ts
+++ b/@commitlint/load/src/utils/load-config.test.ts
@@ -1,0 +1,34 @@
+import { test, expect, afterEach } from "vitest";
+
+import { isDynamicAwaitSupported } from "./load-config.js";
+
+const actualVersion = Object.getOwnPropertyDescriptor(process, "version")!;
+
+const withNodeVersion = (version: string) => {
+	Object.defineProperty(process, "version", { ...actualVersion, value: version });
+	return isDynamicAwaitSupported();
+};
+
+afterEach(() => {
+	Object.defineProperty(process, "version", actualVersion);
+});
+
+// Dynamic await landed in Node v20.8.0, so every release from there on supports it.
+test.each([
+	["v18.20.8", false],
+	["v20.0.0", false],
+	["v20.7.1", false],
+	["v20.8.0", true],
+	["v20.19.5", true],
+	["v22.12.0", true],
+	["v24.0.0", true],
+	["v24.3.0", true],
+	["v24.7.0", true],
+	["v24.8.0", true],
+	["v25.0.0", true],
+	["v26.0.0", true],
+	["v26.7.0", true],
+	["v30.1.0", true],
+])("reports dynamic await support on %s as %s", (version, supported) => {
+	expect(withNodeVersion(version)).toBe(supported);
+});

--- a/@commitlint/load/src/utils/load-config.ts
+++ b/@commitlint/load/src/utils/load-config.ts
@@ -86,7 +86,7 @@ export const isDynamicAwaitSupported = () => {
 		.split(".")
 		.map((val) => parseInt(val));
 
-	return major >= 20 && minor >= 8;
+	return major > 20 || (major === 20 && minor >= 8);
 };
 
 // Is the given directory set up to use ESM (ECMAScript Modules)?


### PR DESCRIPTION
## Description

`isDynamicAwaitSupported()` compares major and minor independently:

```ts
return major >= 20 && minor >= 8;
```

The `minor >= 8` term applies at every major, so the check returns `false` on the first eight minors of every major above 20. This changes it to `major > 20 || (major === 20 && minor >= 8)`.

| Node     | before    | after |
| -------- | --------- | ----- |
| v20.7.1  | false     | false |
| v20.8.0  | true      | true  |
| v22.12.0 | true      | true  |
| v24.0.0  | **false** | true  |
| v24.7.0  | **false** | true  |
| v24.8.0  | true      | true  |
| v25.0.0  | **false** | true  |
| v26.0.0  | **false** | true  |

Only the misfiring versions change.

## Motivation and Context

Fixes #4399.

When it returns `false` and the directory has no `package.json`, `loadConfig` falls back to `defaultLoadersSync`, whose `.js` loader is a bare `require`. An ESM `commitlint.config.js` loads as empty and surfaces as `empty-rules`, the reporter's repro.

Within `engines.node` (`>=22.12.0`) that hits v23.0-v23.7, v24.0-v24.7, v25.0-v25.7, v26.0-v26.7. CI runs `node: [22, 24]`, which resolve to each line's latest minor, so the matrix sits on the passing side.

The README's Node 24+ note is left untouched.

Alternative: drop the guard entirely, since every Node inside `engines` supports dynamic await. I kept it because `engines` is advisory and a git hook can run any Node.

## Usage examples

```sh
# commitlint.config.js uses `export default`; project has no package.json
$ node -v
v24.7.0
$ echo "fix: message" | commitlint
# before: ✖ Please add rules to your `commitlint.config.js`
# after:  passes
```

## How Has This Been Tested?

New table-driven test stubs `process.version` across fourteen versions, v18.20.8 to v30.1.0.

Seven of the fourteen fail on master and pass with the fix; the rest pin unchanged behavior. Reverting the source change puts those seven red on an assertion, not a build error.

Full suite (1241 tests) and `pnpm build` pass locally on v24.14.1.

Note: `load.test.ts:296` filters its ESM fixtures through `isDynamicAwaitSupported()` itself, so on an affected Node those cases were dropped instead of failing. That is why this survived. The new test asserts on the predicate directly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified that any documentation examples I added/changed actually work.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] For a feature/bug fix, my commits follow the [test-driven flow](https://github.com/conventional-changelog/commitlint/blob/master/.github/CONTRIBUTING.md#test-driven-development): a failing-test commit, then the implementation.
