### PR TITLE
fix(rules): report the case that matched in case rule failure messages

### DIFF
--- a/@commitlint/config-conventional/src/index.test.ts
+++ b/@commitlint/config-conventional/src/index.test.ts
@@ -70,12 +70,12 @@ const errors = {
 		name: "type-empty",
 		valid: false,
 	},
-	subjectCase: {
+	subjectCase: (matched: string) => ({
 		level: 2,
-		message: "subject must not be sentence-case, start-case, pascal-case, upper-case",
+		message: `subject must not be ${matched}`,
 		name: "subject-case",
 		valid: false,
-	},
+	}),
 	subjectEmpty: {
 		level: 2,
 		message: "subject may not be empty",
@@ -145,13 +145,22 @@ test("type-empty", async () => {
 });
 
 test("subject-case", async () => {
+	// One entry per `messages.invalidSubjectCases` input: the configured cases
+	// that the subject matches, which is what the failure message reports.
+	const matched = [
+		"sentence-case",
+		"sentence-case, start-case",
+		"sentence-case, pascal-case",
+		"sentence-case, start-case, upper-case",
+	];
+
 	const invalidInputs = await Promise.all(
 		messages.invalidSubjectCases.map((invalidInput) => commitLint(invalidInput)),
 	);
 
-	invalidInputs.forEach((result) => {
+	invalidInputs.forEach((result, index) => {
 		expect(result.valid).toBe(false);
-		expect(result.errors).toEqual([errors.subjectCase]);
+		expect(result.errors).toEqual([errors.subjectCase(matched[index])]);
 	});
 });
 

--- a/@commitlint/rules/src/body-case.test.ts
+++ b/@commitlint/rules/src/body-case.test.ts
@@ -87,3 +87,40 @@ test('with lowercase body should succeed for "always uppercase"', async () => {
 	const expected = true;
 	expect(actual).toEqual(expected);
 });
+
+test('with "never" should report only the case that matched', async () => {
+	const [actual, message] = bodyCase(await parsed.uppercase, "never", [
+		"sentence-case",
+		"pascal-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("body must not be sentence-case");
+});
+
+test('with "never" should report every case that matched', async () => {
+	const [actual, message] = bodyCase(await parsed.uppercase, "never", [
+		"sentence-case",
+		"start-case",
+		"pascal-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("body must not be sentence-case, start-case");
+});
+
+test('with "always" should report every configured case when none matched', async () => {
+	const [actual, message] = bodyCase(await parsed.uppercase, "always", [
+		"pascal-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("body must be pascal-case, kebab-case");
+});
+
+test('with "never" should report every configured case when none matched', async () => {
+	const [actual, message] = bodyCase(await parsed.uppercase, "never", [
+		"pascal-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(true);
+	expect(message).toEqual("body must not be pascal-case, kebab-case");
+});

--- a/@commitlint/rules/src/body-case.ts
+++ b/@commitlint/rules/src/body-case.ts
@@ -25,12 +25,18 @@ export const bodyCase: SyncRule<TargetCaseType | TargetCaseType[]> = (
 		return check;
 	});
 
-	const result = checks.some((check) => {
+	const matches = checks.filter((check) => {
 		const r = ensureCase(body, check.case);
 		return negated(check.when) ? !r : r;
 	});
 
-	const list = checks.map((c) => c.case).join(", ");
+	const result = matches.length > 0;
+
+	// A `never` rule fails because a case matched, so report the case(s) that
+	// did. An `always` rule fails because none matched, so it keeps reporting
+	// every configured case.
+	const reported = negated(when) && result ? matches : checks;
+	const list = reported.map((c) => c.case).join(", ");
 
 	return [
 		negated(when) ? !result : result,

--- a/@commitlint/rules/src/header-case.test.ts
+++ b/@commitlint/rules/src/header-case.test.ts
@@ -297,3 +297,40 @@ test('with numeric header should succeed for "always uppercase"', async () => {
 	const expected = true;
 	expect(actual).toEqual(expected);
 });
+
+test('with "never" should report only the case that matched', async () => {
+	const [actual, message] = headerCase(await parsed.pascalcase, "never", [
+		"sentence-case",
+		"start-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("header must not be sentence-case");
+});
+
+test('with "never" should report every case that matched', async () => {
+	const [actual, message] = headerCase(await parsed.pascalcase, "never", [
+		"sentence-case",
+		"pascal-case",
+		"start-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("header must not be sentence-case, pascal-case");
+});
+
+test('with "always" should report every configured case when none matched', async () => {
+	const [actual, message] = headerCase(await parsed.pascalcase, "always", [
+		"upper-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("header must be upper-case, kebab-case");
+});
+
+test('with "never" should report every configured case when none matched', async () => {
+	const [actual, message] = headerCase(await parsed.pascalcase, "never", [
+		"upper-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(true);
+	expect(message).toEqual("header must not be upper-case, kebab-case");
+});

--- a/@commitlint/rules/src/header-case.ts
+++ b/@commitlint/rules/src/header-case.ts
@@ -25,12 +25,18 @@ export const headerCase: SyncRule<TargetCaseType | TargetCaseType[]> = (
 		return check;
 	});
 
-	const result = checks.some((check) => {
+	const matches = checks.filter((check) => {
 		const r = ensureCase(header, check.case);
 		return negated(check.when) ? !r : r;
 	});
 
-	const list = checks.map((c) => c.case).join(", ");
+	const result = matches.length > 0;
+
+	// A `never` rule fails because a case matched, so report the case(s) that
+	// did. An `always` rule fails because none matched, so it keeps reporting
+	// every configured case.
+	const reported = negated(when) && result ? matches : checks;
+	const list = reported.map((c) => c.case).join(", ");
 
 	return [
 		negated(when) ? !result : result,

--- a/@commitlint/rules/src/scope-case.test.ts
+++ b/@commitlint/rules/src/scope-case.test.ts
@@ -366,3 +366,40 @@ test('with object-based configuration should respect "never" when custom delimit
 	const expected = false;
 	expect(actual).toEqual(expected);
 });
+
+test('with "never" should report only the case that matched', async () => {
+	const [actual, message] = scopeCase(await parsed.pascalcase, "never", [
+		"sentence-case",
+		"start-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("scope must not be sentence-case");
+});
+
+test('with "never" should report every case that matched', async () => {
+	const [actual, message] = scopeCase(await parsed.pascalcase, "never", [
+		"sentence-case",
+		"pascal-case",
+		"start-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("scope must not be sentence-case, pascal-case");
+});
+
+test('with "always" should report every configured case when none matched', async () => {
+	const [actual, message] = scopeCase(await parsed.pascalcase, "always", [
+		"upper-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("scope must be upper-case, kebab-case");
+});
+
+test('with "never" should report every configured case when none matched', async () => {
+	const [actual, message] = scopeCase(await parsed.pascalcase, "never", [
+		"upper-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(true);
+	expect(message).toEqual("scope must not be upper-case, kebab-case");
+});

--- a/@commitlint/rules/src/scope-case.ts
+++ b/@commitlint/rules/src/scope-case.ts
@@ -39,7 +39,7 @@ export const scopeCase: SyncRule<
 	const delimiterRegex = new RegExp(delimiterPatterns.join("|"));
 	const scopeSegments = scope.split(delimiterRegex);
 
-	const result = checks.some((check) => {
+	const matches = checks.filter((check) => {
 		const r = scopeSegments.every(
 			(segment) => delimiterRegex.test(segment) || ensureCase(segment, check.case),
 		);
@@ -47,7 +47,13 @@ export const scopeCase: SyncRule<
 		return negated(check.when) ? !r : r;
 	});
 
-	const list = checks.map((c) => c.case).join(", ");
+	const result = matches.length > 0;
+
+	// A `never` rule fails because a case matched, so report the case(s) that
+	// did. An `always` rule fails because none matched, so it keeps reporting
+	// every configured case.
+	const reported = negated(when) && result ? matches : checks;
+	const list = reported.map((c) => c.case).join(", ");
 
 	return [
 		negated(when) ? !result : result,

--- a/@commitlint/rules/src/subject-case.test.ts
+++ b/@commitlint/rules/src/subject-case.test.ts
@@ -511,3 +511,40 @@ test("accepts mixed Latin and Cyrillic lowercase subjects", async () => {
 
 	expect(actual).toBe(true);
 });
+
+test('with "never" should report only the case that matched', async () => {
+	const [actual, message] = subjectCase(await parsed.pascalcase, "never", [
+		"sentence-case",
+		"start-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("subject must not be sentence-case");
+});
+
+test('with "never" should report every case that matched', async () => {
+	const [actual, message] = subjectCase(await parsed.pascalcase, "never", [
+		"sentence-case",
+		"pascal-case",
+		"start-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("subject must not be sentence-case, pascal-case");
+});
+
+test('with "always" should report every configured case when none matched', async () => {
+	const [actual, message] = subjectCase(await parsed.pascalcase, "always", [
+		"upper-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("subject must be upper-case, kebab-case");
+});
+
+test('with "never" should report every configured case when none matched', async () => {
+	const [actual, message] = subjectCase(await parsed.pascalcase, "never", [
+		"upper-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(true);
+	expect(message).toEqual("subject must not be upper-case, kebab-case");
+});

--- a/@commitlint/rules/src/subject-case.ts
+++ b/@commitlint/rules/src/subject-case.ts
@@ -42,12 +42,18 @@ export const subjectCase: SyncRule<TargetCaseType | TargetCaseType[]> = (
 		return check;
 	});
 
-	const result = checks.some((check) => {
+	const matches = checks.filter((check) => {
 		const r = ensureCase(subject, check.case);
 		return negated(check.when) ? !r : r;
 	});
 
-	const list = checks.map((c) => c.case).join(", ");
+	const result = matches.length > 0;
+
+	// A `never` rule fails because a case matched, so report the case(s) that
+	// did. An `always` rule fails because none matched, so it keeps reporting
+	// every configured case.
+	const reported = negated(when) && result ? matches : checks;
+	const list = reported.map((c) => c.case).join(", ");
 
 	return [
 		negated(when) ? !result : result,

--- a/@commitlint/rules/src/type-case.test.ts
+++ b/@commitlint/rules/src/type-case.test.ts
@@ -308,3 +308,40 @@ test('with uppercase scope should fail for "never [uppercase, lowercase]"', asyn
 	const expected = false;
 	expect(actual).toEqual(expected);
 });
+
+test('with "never" should report only the case that matched', async () => {
+	const [actual, message] = typeCase(await parsed.pascalcase, "never", [
+		"sentence-case",
+		"start-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("type must not be sentence-case");
+});
+
+test('with "never" should report every case that matched', async () => {
+	const [actual, message] = typeCase(await parsed.pascalcase, "never", [
+		"sentence-case",
+		"pascal-case",
+		"start-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("type must not be sentence-case, pascal-case");
+});
+
+test('with "always" should report every configured case when none matched', async () => {
+	const [actual, message] = typeCase(await parsed.pascalcase, "always", [
+		"upper-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(false);
+	expect(message).toEqual("type must be upper-case, kebab-case");
+});
+
+test('with "never" should report every configured case when none matched', async () => {
+	const [actual, message] = typeCase(await parsed.pascalcase, "never", [
+		"upper-case",
+		"kebab-case",
+	]);
+	expect(actual).toEqual(true);
+	expect(message).toEqual("type must not be upper-case, kebab-case");
+});

--- a/@commitlint/rules/src/type-case.ts
+++ b/@commitlint/rules/src/type-case.ts
@@ -25,12 +25,18 @@ export const typeCase: SyncRule<TargetCaseType | TargetCaseType[]> = (
 		return check;
 	});
 
-	const result = checks.some((check) => {
+	const matches = checks.filter((check) => {
 		const r = ensureCase(type, check.case);
 		return negated(check.when) ? !r : r;
 	});
 
-	const list = checks.map((c) => c.case).join(", ");
+	const result = matches.length > 0;
+
+	// A `never` rule fails because a case matched, so report the case(s) that
+	// did. An `always` rule fails because none matched, so it keeps reporting
+	// every configured case.
+	const reported = negated(when) && result ? matches : checks;
+	const list = reported.map((c) => c.case).join(", ");
 
 	return [
 		negated(when) ? !result : result,


### PR DESCRIPTION
## Description

All five case rules listed every configured case in the failure message, matched or not. Under `never` they now name only the case(s) the input matched.

For the `scope-case: [2, "never", ["sentence-case", "start-case"]]` example in #3501:

```diff
-✖   scope must not be sentence-case, start-case [scope-case]
+✖   scope must not be sentence-case [scope-case]
```

`start-case` never matched `ClearlyDefined`, because `startCase()` returns `Clearly Defined`. It appeared in the message only because it was configured.

Under `always` a failure means nothing matched, so those messages keep listing every configured case.

## Motivation and Context

#3501 reads as if `start-case` fired on a camel-cased scope. #3312 has the same shape: `JTD types -> JSON schema types` is reported as `upper-case` when only `sentence-case` matches. Case semantics are untouched, per the conclusion in #3501.

## Usage examples

```js
// commitlint.config.js
export default {
	rules: { "scope-case": [2, "never", ["sentence-case", "start-case"]] },
};
```

```sh
echo 'fix(ClearlyDefined): Make `Described` use `CurationFacets`' | commitlint
# before: ✖   scope must not be sentence-case, start-case [scope-case]
# after:  ✖   scope must not be sentence-case [scope-case]
```

Under `config-conventional`, each rejected subject now names its own reason:

```
fix(scope): Some message  ->  subject must not be sentence-case
fix(scope): Some Message  ->  subject must not be sentence-case, start-case
fix(scope): SomeMessage   ->  subject must not be sentence-case, pascal-case
fix(scope): SOMEMESSAGE   ->  subject must not be sentence-case, start-case, upper-case
```

## How Has This Been Tested?

`pnpm build` and `pnpm test` pass. 20 new unit tests, four per rule: `never` matching one case, `never` matching a subset, `always` matching none, `never` matching none. Reverting the source change fails 10 of them plus the `config-conventional` message test.

Verdict neutrality was measured. 56,909 unique conventional commit messages from 16 public repos went through the five rules under 14 configs spanning `always`, `never`, and per-check `when` objects. Of 796,726 pass/fail verdicts, 0 changed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have verified that any documentation examples I added/changed actually work.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] For a feature/bug fix, my commits follow the [test-driven flow](https://github.com/conventional-changelog/commitlint/blob/master/.github/CONTRIBUTING.md#test-driven-development): a failing-test commit, then the implementation.
