### PR TITLE
fix(load): run the parser factory of scoped conventional-changelog presets

### DIFF
--- a/@commitlint/load/src/utils/load-parser-opts.test.ts
+++ b/@commitlint/load/src/utils/load-parser-opts.test.ts
@@ -54,3 +54,16 @@ test("runs an async function which returns the preset", async () => {
 
 	expect(opts).toEqual(preset);
 });
+
+// https://github.com/conventional-changelog/commitlint/issues/2488
+test("runs the factory of a scoped conventional-changelog preset", async () => {
+	const parserOpts = { headerPattern: /^(\w*)(?:\((.*)\))?-(.*)$/ };
+	const preset = {
+		name: "@scope/conventional-changelog-custom",
+		parserOpts: (cb: (_: never, opts: { parserOpts: unknown }) => void) => {
+			cb(undefined as never, { parserOpts });
+		},
+	};
+
+	expect(await loadParserOpts(preset)).toHaveProperty("parserOpts", parserOpts);
+});

--- a/@commitlint/load/src/utils/load-parser-opts.ts
+++ b/@commitlint/load/src/utils/load-parser-opts.ts
@@ -6,6 +6,20 @@ function isObjectLike(obj: unknown): obj is Record<string, unknown> {
 	return Boolean(obj) && typeof obj === "object"; // typeof null === 'object'
 }
 
+/**
+ * Presets published under a scope keep the conventional prefix after the
+ * scope, e.g. `@scope/conventional-changelog-preset` (#2488).
+ */
+function isConventionalChangelogPreset(name: unknown): boolean {
+	if (typeof name !== "string") {
+		return false;
+	}
+
+	const unscoped = name.startsWith("@") ? name.slice(name.indexOf("/") + 1) : name;
+
+	return unscoped.startsWith("conventional-changelog-");
+}
+
 function isParserOptsFunction<T extends ParserPreset>(
 	obj: T,
 ): obj is T & {
@@ -51,11 +65,7 @@ export async function loadParserOpts(
 	}
 
 	// Create parser opts from factory
-	if (
-		isParserOptsFunction(parser) &&
-		typeof parser.name === "string" &&
-		parser.name.startsWith("conventional-changelog-")
-	) {
+	if (isParserOptsFunction(parser) && isConventionalChangelogPreset(parser.name)) {
 		return new Promise((resolve) => {
 			const result = parser.parserOpts((_: never, opts) => {
 				resolve({


### PR DESCRIPTION
## Description

fixes #2488

`@commitlint/load` only invoked a preset's `parserOpts` factory when the preset name started with `conventional-changelog-`. A preset published under a scope, for example `@scope/conventional-changelog-preset`, never matched that check, so the factory was passed through untouched and the preset's parser options were silently dropped. commitlint then parsed commits with default options and gave no error.

Root cause: the `parser.name.startsWith("conventional-changelog-")` guard on the factory branch in `@commitlint/load/src/utils/load-parser-opts.ts`.

Reproduced on the published `@commitlint/load@21.2.2`: with two identical factory presets in `node_modules`, `conventional-changelog-myorg` resolves `parserOpts` to an object while `@scope/conventional-changelog-myorg` leaves it as a function.

## Fix

Strip a leading `@scope/` before the prefix check, so a scoped preset is recognized the same way an unscoped one already is. Behavior for every other preset shape is unchanged.

## Test

`load-parser-opts.test.ts` gains a case for a scoped preset exposing a `parserOpts` factory. It fails without the fix (parserOpts stays a function) and passes with it. Full suite stays green.
