### PR TITLE
docs: drop the Node 24 config-loading workaround note

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,6 @@ These can be modified by [your own configuration](#config).
 - See [Rules](./docs/reference/rules.md) for a complete list of possible rules
 - An example configuration can be found at [@commitlint/config-conventional](./@commitlint/config-conventional/src/index.ts)
 
-### Important note about Node 24+
-
-Node v24 changes the way that modules are loaded, and this includes the commitlint config file. If your project does not contain a `package.json`, commitlint may fail to load the config, resulting in a `Please add rules to your commitlint.config.js` error message. This can be fixed by doing either of the following:
-
-- Add a `package.json` file, declaring your project as an ES6 module. This can be done easily by running `npm init es6`.
-- Rename the config file from `commitlint.config.js` to `commitlint.config.mjs`.
-
 ## Shared configuration
 
 A number of shared configurations are available to install and use with `commitlint`:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -47,10 +47,4 @@ node -e "fs.writeFileSync('commitlint.config.js', process.argv[1])" "export defa
 
 :::
 
-> [!WARNING]
-> Node v24 changes the way that modules are loaded, and this includes the commitlint config file. If your project does not contain a `package.json`, commitlint may fail to load the config, resulting in a `Please add rules to your commitlint.config.js` error message. This can be fixed by doing either of the following:
->
-> - Add a `package.json` file, declaring your project as an ES6 module. This can be done easily by running `npm init es6`.
-> - Rename the config file from `commitlint.config.js` to `commitlint.config.mjs`.
-
 Refer to [configuration documentation](/reference/configuration) for more information.


### PR DESCRIPTION
## Description

Removes the Node 24 note from **both** places it lives:

- `README.md` — the `### Important note about Node 24+` section added in #4406
- `docs/guides/getting-started.md` — the `[!WARNING]` block copied there the next day in a4323646

Reverting #4406 alone would only remove the first. The second is the copy on commitlint.js.org, i.e. the one users actually read.

## Motivation and Context

Raised by @knocte in https://github.com/conventional-changelog/commitlint/issues/4399#issuecomment-5435442650: the bug now has a real fix, so the workaround note should go.

The note is not just obsolete — it named the wrong cause. Node never changed anything here. `isDynamicAwaitSupported()` compared major and minor independently:

```ts
return major >= 20 && minor >= 8;
```

The `minor >= 8` term applied at every major, so the predicate returned `false` on the first eight minors of *every* major above 20 — v24.0–24.7, v25.0–25.7, v26.0–26.7. When it returned `false` and the directory had no `package.json`, `loadConfig` fell back to `defaultLoadersSync`, whose `.js` loader is a bare `require`. An ESM `commitlint.config.js` loaded as empty and surfaced as `empty-rules` — the reporter's symptom.

- #4961 fixed the comparison.
- #4972 removed the predicate outright; `defaultLoaders` is now passed unconditionally.

Nothing in `@commitlint/load/src` reads `process.version` any more, so there is no Node version on which the sync loaders get selected. Every current release line (v24.20.0, v25.9.0, v26.8.1) is also past the affected `.0`–`.7` minor window.

Follow-up to #4961 and #4972. Refs #4399.

## Usage examples

The reporter's original repro — directory with no `package.json`, ESM config — against a `tsc -b --force` build of master:

```js
// commitlint.config.js
export default { rules: { "type-enum": [2, "always", ["feat", "fix"]] } };
```

```sh
$ ls -a
.  ..  commitlint.config.js          # no package.json

$ echo "feat: example commit" | commitlint    # passes (exit 0)
$ echo "nope: example commit" | commitlint    # fails on type-enum (exit 1)
```

The config loads and its rules are enforced, so the workaround the note described is no longer needed.

## How Has This Been Tested?

Docs-only, no source change, so no tests added.

- `pnpm build` (`tsc -b --force`) clean
- `pnpm format` (`oxfmt --check`) clean
- `pnpm docs-build` (`vitepress build docs`) succeeds — both edited pages render, no dangling headings or blank-line artifacts
- Ran the repro above against the fresh build, including a negative control to confirm rules actually apply rather than the config silently loading empty

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have verified that any documentation examples I added/changed actually work.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] For a feature/bug fix, my commits follow the [test-driven flow](https://github.com/conventional-changelog/commitlint/blob/master/.github/CONTRIBUTING.md#test-driven-development): a failing-test commit, then the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164XzGFx5J2cP3NFuEUJrbJ