### PR TITLE
chore: swap pnpm resolutionMode time-based for minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,12 +13,23 @@ allowBuilds:
 # Supply-chain hardening; pnpm ignores these in .npmrc, silently, so they live here.
 # - strictDepBuilds: an unlisted build script fails the install instead of warning
 # - verifyDepsBeforeRun: refuse to run scripts against a lockfile-stale node_modules
-# - resolutionMode: prefer versions current at the last direct-dep publish, limiting
-#   exposure to a freshly compromised transitive release
+# - minimumReleaseAge: never resolve a version published less than two days ago, so a
+#   freshly compromised release cannot reach the lockfile. The unit is minutes. Keep it
+#   below renovate.minimumReleaseAge in package.json (3 days), otherwise pnpm refuses
+#   the very versions Renovate proposes. Setting it also enables
+#   minimumReleaseAgeStrict, so the existing lockfile is verified against the policy on
+#   every install; a genuinely urgent bump needs
+#   `pnpm install --config.minimumReleaseAge=0`.
+#
+# resolutionMode stays at the default (highest). time-based looks like the same
+# hardening, but it also resolves every direct dependency to the floor of its range, so
+# the first full re-resolution after it went live turned lock file maintenance into a
+# mass downgrade -- nx 14.0.0 (2022) via the config-nx-scopes peer range, vitepress
+# 1.3.4, @types/node 22.0.0 -- see #4983.
 #
 # engineStrict is off on purpose: it enforces every dependency's engines, which
 # currently resolves above engines.node here. Revisit with the node floor bump;
 # do not raise engines.node to satisfy it.
 strictDepBuilds: true
 verifyDepsBeforeRun: error
-resolutionMode: time-based
+minimumReleaseAge: 2880


### PR DESCRIPTION
## What

Replaces `resolutionMode: time-based` with `minimumReleaseAge: 2880` in `pnpm-workspace.yaml`, and documents why `resolutionMode` stays at the default.

## Why

`time-based` does more than its comment in #4977 claimed. It does not only prefer publish-time-current subdependencies — it also resolves **every direct dependency to the floor of its range**.

The setting was inert while it lived in `.npmrc` (pnpm 11 ignores pnpm settings there, silently), so this only became visible once #4977 moved it into `pnpm-workspace.yaml`. The first full re-resolution after that — lock file maintenance #4983 — came back as a mass downgrade, +2971/−923:

| package | master | #4983 |
| --- | --- | --- |
| nx (peer of `config-nx-scopes`, `>=14.0.0`) | 23.1.1 | **14.0.0** (published 2022-04-21) |
| vitepress | 1.6.4 | 1.3.4 |
| @types/node | 22.20.1 | 22.0.0 |
| lerna | 10.0.1 | 10.0.0 |
| vite | 8.2.2 | 8.0.0 |

Those downgrades pulled in two packages master does not have at all — `@parcel/watcher@2.0.4` (via nx 14) and `vue-demi@0.14.10` (via `@vueuse/core` 11, from vitepress 1.3.4). Both run install scripts, neither is listed in `allowBuilds`, so `strictDepBuilds` failed CI with `ERR_PNPM_IGNORED_BUILDS`. The build error was the symptom; the downgrade was the event.

## Why `minimumReleaseAge`

It delivers the stated intent of the original setting — never install a release that is only hours old, limiting exposure to a freshly compromised version — without touching version selection at all.

- The unit is **minutes**; 2880 = 2 days.
- It deliberately sits **below** `renovate.minimumReleaseAge` (`"3 days"` in `package.json`), so pnpm can never reject a version Renovate has proposed. Lock file maintenance is exempt from Renovate's gate, and that is exactly where pnpm's own gate now does the work.
- Setting it explicitly also enables `minimumReleaseAgeStrict`, so the **existing** lockfile is verified against the policy on every install, not just new resolutions. A hand-edited lockfile can no longer smuggle in a fresh release. A genuinely urgent same-day bump needs `pnpm install --config.minimumReleaseAge=0`.

## Verification

Local, pnpm 11.24.0:

- `pnpm install --frozen-lockfile` → `✓ Lockfile passes supply-chain policies (954 entries in 3.5s)`, lockfile unchanged, no ignored-builds failure.
- `pnpm install --frozen-lockfile --config.minimumReleaseAge=5256000` → fails with per-package rejections, which proves the key is genuinely enforced rather than silently ignored — the trap `.npmrc` fell into.

## Notes

- `pnpm-lock.yaml` is intentionally untouched. It still carries the stale `time:` block that `time-based` wrote; pnpm only emits that block in that mode, so the next full re-resolution drops it.
- #4983 should be closed rather than merged. Renovate reopens lock file maintenance Monday before 5am, and that run will be a genuine refresh once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hoRjc4XLWFeN3yJbjUxe4